### PR TITLE
python

### DIFF
--- a/src/core/data/ions/particle_initializers/particle_initializer_factory.h
+++ b/src/core/data/ions/particle_initializers/particle_initializer_factory.h
@@ -7,6 +7,8 @@
 #include "particle_initializer.h"
 #include "utilities/types.h"
 
+#include <memory>
+
 namespace PHARE
 {
 namespace core
@@ -27,11 +29,24 @@ namespace core
             if (initializerName == "MaxwellianParticleInitializer")
             {
                 auto& density = dict["density"].to<PHARE::initializer::ScalarFunction<dimension>>();
-                auto& bulkVel
-                    = dict["bulkVelocity"].to<PHARE::initializer::VectorFunction<dimension>>();
 
-                auto& thermalVel
-                    = dict["thermalVelocity"].to<PHARE::initializer::VectorFunction<dimension>>();
+                auto& bulkVelx
+                    = dict["bulk_velocity_x"].to<PHARE::initializer::ScalarFunction<dimension>>();
+
+                auto& bulkVely
+                    = dict["bulk_velocity_y"].to<PHARE::initializer::ScalarFunction<dimension>>();
+
+                auto& bulkVelz
+                    = dict["bulk_velocity_z"].to<PHARE::initializer::ScalarFunction<dimension>>();
+
+                auto& vthx = dict["thermal_velocity_x"]
+                                 .to<PHARE::initializer::ScalarFunction<dimension>>();
+
+                auto& vthy = dict["thermal_velocity_y"]
+                                 .to<PHARE::initializer::ScalarFunction<dimension>>();
+
+                auto& vthz = dict["thermal_velocity_z"]
+                                 .to<PHARE::initializer::ScalarFunction<dimension>>();
 
                 auto charge = dict["charge"].to<double>();
 
@@ -39,22 +54,31 @@ namespace core
 
                 auto basisName = dict["basis"].to<std::string>();
 
+                std::array<PHARE::initializer::ScalarFunction<dimension>, 3> v
+                    = {bulkVelx, bulkVely, bulkVelz};
+
+                std::array<PHARE::initializer::ScalarFunction<dimension>, 3> vth
+                    = {vthx, vthy, vthz};
 
                 if (basisName == "Cartesian")
                 {
-                    [[maybe_unused]] Basis basis = Basis::Cartesian;
                     return std::make_unique<
                         MaxwellianParticleInitializer<ParticleArray, GridLayout>>(
-                        density, bulkVel, thermalVel, charge, nbrPartPerCell);
+                        density, v, vth, charge, nbrPartPerCell);
                 }
                 else if (basisName == "Magnetic")
                 {
                     [[maybe_unused]] Basis basis = Basis::Magnetic;
-                    [[maybe_unused]] auto& magnetic
-                        = dict["magnetic"].to<PHARE::initializer::VectorFunction<dimension>>();
+                    [[maybe_unused]] auto& bx
+                        = dict["magnetic_x"].to<PHARE::initializer::ScalarFunction<dimension>>();
+                    [[maybe_unused]] auto& by
+                        = dict["magnetic_x"].to<PHARE::initializer::ScalarFunction<dimension>>();
+                    [[maybe_unused]] auto& bz
+                        = dict["magnetic_x"].to<PHARE::initializer::ScalarFunction<dimension>>();
+
                     return std::make_unique<
                         MaxwellianParticleInitializer<ParticleArray, GridLayout>>(
-                        density, bulkVel, thermalVel, charge, nbrPartPerCell);
+                        density, v, vth, charge, nbrPartPerCell);
                 }
             }
             // TODO throw?

--- a/src/initializer/data_provider.cpp
+++ b/src/initializer/data_provider.cpp
@@ -1,2 +1,16 @@
 
 #include "data_provider.h"
+
+
+namespace PHARE
+{
+namespace initializer
+{
+    PHAREDictHandler& PHAREDictHandler::INSTANCE()
+    {
+        static PHAREDictHandler handler;
+        return handler;
+    }
+} // namespace initializer
+
+} // namespace PHARE

--- a/src/initializer/data_provider.cpp
+++ b/src/initializer/data_provider.cpp
@@ -1,12 +1,2 @@
 
 #include "data_provider.h"
-
-namespace PHARE
-{
-namespace initializer
-{
-    PHAREDict<1> phareDict1D;
-    PHAREDict<2> phareDict2D;
-    PHAREDict<3> phareDict3D;
-} // namespace initializer
-} // namespace PHARE

--- a/src/initializer/data_provider.h
+++ b/src/initializer/data_provider.h
@@ -52,6 +52,8 @@ namespace initializer
         std::unique_ptr<PHAREDict<2>> phareDict2D;
         std::unique_ptr<PHAREDict<3>> phareDict3D;
 
+    private:
+        PHAREDictHandler() = default;
 
 
 
@@ -77,13 +79,13 @@ namespace initializer
         void stop()
         {
             if constexpr (dim == 1)
-                PHAREDictHandler::INSTANCE().phareDict1D.release();
+                phareDict1D.release();
 
             else if constexpr (dim == 2)
-                PHAREDictHandler::INSTANCE().phareDict2D.release();
+                phareDict2D.release();
 
             else if constexpr (dim == 3)
-                PHAREDictHandler::INSTANCE().phareDict3D.release();
+                phareDict3D.release();
         }
 
 

--- a/src/initializer/data_provider.h
+++ b/src/initializer/data_provider.h
@@ -2,7 +2,6 @@
 #define DATA_PROVIDER_H
 
 #include "cppdict/include/dict.hpp"
-//#include "models/physical_state.h"
 
 #include <map>
 #include <string>
@@ -35,40 +34,14 @@ namespace initializer
         using type = std::function<double(double, double, double)>;
     };
 
-    template<typename ReturnType, std::size_t dim>
-    struct VectorFunctionHelper
-    {
-    };
-
-    template<>
-    struct VectorFunctionHelper<std::array<double, 3>, 1>
-    {
-        using type = std::function<std::array<double, 3>(double)>;
-    };
-
-    template<>
-    struct VectorFunctionHelper<std::array<double, 3>, 2>
-    {
-        using type = std::function<std::array<double, 3>(double, double)>;
-    };
-
-    template<>
-    struct VectorFunctionHelper<std::array<double, 3>, 3>
-    {
-        using type = std::function<std::array<double, 3>(double, double, double)>;
-    };
 
     template<std::size_t dim>
     using ScalarFunction = typename ScalarFunctionHelper<double, dim>::type;
 
-    template<std::size_t dim>
-    using VectorFunction = typename VectorFunctionHelper<std::array<double, 3>, dim>::type;
-
 
 
     template<std::size_t dim>
-    using PHAREDict = cppdict::Dict<int, double, std::size_t, std::string, ScalarFunction<dim>,
-                                    VectorFunction<dim>>;
+    using PHAREDict = cppdict::Dict<int, double, std::size_t, std::string, ScalarFunction<dim>>;
 
 
 

--- a/src/initializer/data_provider.h
+++ b/src/initializer/data_provider.h
@@ -70,30 +70,6 @@ namespace initializer
     using PHAREDict = cppdict::Dict<int, double, std::size_t, std::string, ScalarFunction<dim>,
                                     VectorFunction<dim>>;
 
-
-
-    extern PHAREDict<1> phareDict1D;
-    extern PHAREDict<2> phareDict2D;
-    extern PHAREDict<3> phareDict3D;
-
-    template<std::size_t dim>
-    auto& dict()
-    {
-        static_assert(dim >= 1 and dim <= 3, "error, invalid dimension in dict<dim>()");
-        if constexpr (dim == 1)
-        {
-            return phareDict1D;
-        }
-        else if constexpr (dim == 2)
-        {
-            return phareDict2D;
-        }
-        else if constexpr (dim == 3)
-        {
-            return phareDict3D;
-        }
-    }
-
     class DataProvider
     {
     public:

--- a/src/initializer/data_provider.h
+++ b/src/initializer/data_provider.h
@@ -70,6 +70,72 @@ namespace initializer
     using PHAREDict = cppdict::Dict<int, double, std::size_t, std::string, ScalarFunction<dim>,
                                     VectorFunction<dim>>;
 
+
+
+
+    class PHAREDictHandler
+    {
+        std::unique_ptr<PHAREDict<1>> phareDict1D;
+        std::unique_ptr<PHAREDict<2>> phareDict2D;
+        std::unique_ptr<PHAREDict<3>> phareDict3D;
+
+
+
+
+    public:
+        template<std::size_t dim>
+        void init()
+        {
+            if constexpr (dim == 1)
+                phareDict1D = std::make_unique<PHAREDict<1>>();
+
+            else if constexpr (dim == 2)
+            {
+                phareDict2D = std::make_unique<PHAREDict<2>>();
+            }
+
+            else if constexpr (dim == 3)
+            {
+                phareDict3D = std::make_unique<PHAREDict<3>>();
+            }
+        }
+
+        template<std::size_t dim>
+        void stop()
+        {
+            if constexpr (dim == 1)
+                PHAREDictHandler::INSTANCE().phareDict1D.release();
+
+            else if constexpr (dim == 2)
+                PHAREDictHandler::INSTANCE().phareDict2D.release();
+
+            else if constexpr (dim == 3)
+                PHAREDictHandler::INSTANCE().phareDict3D.release();
+        }
+
+
+        static PHAREDictHandler& INSTANCE();
+
+        template<std::size_t dim>
+        auto& dict()
+        {
+            static_assert(dim >= 1 and dim <= 3, "error, invalid dimension in dict<dim>()");
+            if constexpr (dim == 1)
+            {
+                return *phareDict1D;
+            }
+            else if constexpr (dim == 2)
+            {
+                return *phareDict2D;
+            }
+            else if constexpr (dim == 3)
+            {
+                return *phareDict3D;
+            }
+        }
+    };
+
+
     class DataProvider
     {
     public:

--- a/src/initializer/pyphare.cpp
+++ b/src/initializer/pyphare.cpp
@@ -7,12 +7,13 @@
 
 
 using PHARE::initializer::ScalarFunction;
-using PHARE::initializer::VectorFunction;
+// using PHARE::initializer::VectorFunction;
+// using PHARE::initializer::VectorFunction2;
 
 
 template<std::size_t dim, typename T,
-         typename = std::enable_if_t<
-             cppdict::is_in<T, int, double, std::string, ScalarFunction<1>, VectorFunction<1>>>>
+         typename = std::enable_if_t<cppdict::is_in<T, int, double, std::string,
+                                                    ScalarFunction<1> /*, VectorFunction<1>*/>>>
 void add(std::string path, T&& value)
 {
     if constexpr (dim == 1)
@@ -21,7 +22,7 @@ void add(std::string path, T&& value)
         cppdict::add(path, std::forward<T>(value),
                      PHARE::initializer::PHAREDictHandler::INSTANCE().dict<dim>());
     }
-    if constexpr (dim == 2)
+    /*if constexpr (dim == 2)
     {
         std::cout << path + "\n";
         cppdict::add(path, std::forward<T>(value),
@@ -32,7 +33,7 @@ void add(std::string path, T&& value)
         std::cout << path + "\n";
         cppdict::add(path, std::forward<T>(value),
                      PHARE::initializer::PHAREDictHandler::INSTANCE().dict<dim>());
-    }
+    }*/
 }
 
 
@@ -41,23 +42,20 @@ void add(std::string path, T&& value)
 PYBIND11_MODULE(pyphare, m)
 {
     m.def("add", add<1, int, void>, "add");
-    m.def("add", add<2, int, void>, "add");
-    m.def("add", add<3, int, void>, "add");
+    // m.def("add", add<2, int, void>, "add");
+    // m.def("add", add<3, int, void>, "add");
 
     m.def("add", add<1, double, void>, "add");
-    m.def("add", add<2, double, void>, "add");
-    m.def("add", add<3, double, void>, "add");
+    // m.def("add", add<2, double, void>, "add");
+    // m.def("add", add<3, double, void>, "add");
 
 
     m.def("add", add<1, std::string, void>, "add");
-    m.def("add", add<2, std::string, void>, "add");
-    m.def("add", add<3, std::string, void>, "add");
+    // m.def("add", add<2, std::string, void>, "add");
+    // m.def("add", add<3, std::string, void>, "add");
 
-    m.def("add", add<1, ScalarFunction<1>, void>, "add");
-    m.def("add", add<2, ScalarFunction<2>, void>, "add");
-    m.def("add", add<3, ScalarFunction<3>, void>, "add");
-
-    m.def("add", add<1, VectorFunction<1>, void>, "add");
-    m.def("add", add<2, VectorFunction<2>, void>, "add");
-    m.def("add", add<3, VectorFunction<3>, void>, "add");
+    m.def("addScalarFunction1D", add<1, ScalarFunction<1>, void>, "addScalarFunction1D");
+    // m.def("add", add<2, ScalarFunction<2>, void>, "add");
+    // m.def("add", add<3, ScalarFunction<3>, void>, "add");
+    //
 }

--- a/src/initializer/pyphare.cpp
+++ b/src/initializer/pyphare.cpp
@@ -18,17 +18,17 @@ void add(std::string path, T&& value)
     if constexpr (dim == 1)
     {
         std::cout << path + "\n";
-        cppdict::add(path, std::forward<T>(value), PHARE::initializer::dict<dim>());
+        cppdict::add(path, std::forward<T>(value), PHARE::initializer::PythonDictHandler::INSTANCE().dict<dim>());
     }
     if constexpr (dim == 2)
     {
         std::cout << path + "\n";
-        cppdict::add(path, std::forward<T>(value), PHARE::initializer::dict<dim>());
+        cppdict::add(path, std::forward<T>(value), PHARE::initializer::PythonDictHandler::INSTANCE().dict<dim>());
     }
     if constexpr (dim == 3)
     {
         std::cout << path + "\n";
-        cppdict::add(path, std::forward<T>(value), PHARE::initializer::dict<dim>());
+        cppdict::add(path, std::forward<T>(value), PHARE::initializer::PythonDictHandler::INSTANCE().dict<dim>());
     }
 }
 

--- a/src/initializer/pyphare.cpp
+++ b/src/initializer/pyphare.cpp
@@ -7,8 +7,6 @@
 
 
 using PHARE::initializer::ScalarFunction;
-// using PHARE::initializer::VectorFunction;
-// using PHARE::initializer::VectorFunction2;
 
 
 template<std::size_t dim, typename T,

--- a/src/initializer/pyphare.cpp
+++ b/src/initializer/pyphare.cpp
@@ -18,17 +18,20 @@ void add(std::string path, T&& value)
     if constexpr (dim == 1)
     {
         std::cout << path + "\n";
-        cppdict::add(path, std::forward<T>(value), PHARE::initializer::PythonDictHandler::INSTANCE().dict<dim>());
+        cppdict::add(path, std::forward<T>(value),
+                     PHARE::initializer::PHAREDictHandler::INSTANCE().dict<dim>());
     }
     if constexpr (dim == 2)
     {
         std::cout << path + "\n";
-        cppdict::add(path, std::forward<T>(value), PHARE::initializer::PythonDictHandler::INSTANCE().dict<dim>());
+        cppdict::add(path, std::forward<T>(value),
+                     PHARE::initializer::PHAREDictHandler::INSTANCE().dict<dim>());
     }
     if constexpr (dim == 3)
     {
         std::cout << path + "\n";
-        cppdict::add(path, std::forward<T>(value), PHARE::initializer::PythonDictHandler::INSTANCE().dict<dim>());
+        cppdict::add(path, std::forward<T>(value),
+                     PHARE::initializer::PHAREDictHandler::INSTANCE().dict<dim>());
     }
 }
 

--- a/src/initializer/python_data_provider.cpp
+++ b/src/initializer/python_data_provider.cpp
@@ -6,5 +6,11 @@ namespace PHARE
 {
 namespace initializer
 {
-} // namespace initializer
-} // namespace PHARE
+    PythonDictHandler& PythonDictHandler::INSTANCE()
+    {
+        static PythonDictHandler handler;
+        return handler;
+    }
+
+} /*namespace initializer*/
+} /*namespace PHARE*/

--- a/src/initializer/python_data_provider.cpp
+++ b/src/initializer/python_data_provider.cpp
@@ -6,11 +6,5 @@ namespace PHARE
 {
 namespace initializer
 {
-    PythonDictHandler& PythonDictHandler::INSTANCE()
-    {
-        static PythonDictHandler handler;
-        return handler;
-    }
-
 } /*namespace initializer*/
 } /*namespace PHARE*/

--- a/src/initializer/python_data_provider.h
+++ b/src/initializer/python_data_provider.h
@@ -41,20 +41,9 @@ namespace initializer
          * @brief read overrides the abstract DataProvider::read method. This method basically
          * executes the user python script that fills the dictionnary.
          */
-        virtual void read() override
-        {
-            py::eval_file(initModuleName_, scope_);
-            /*auto& d = dict<1>();
-            auto& pop1                   = d["simulation"]["hybridstate"]["ions"]["pop1"];
-            auto popname                 = pop1["name"].to<std::string>();
-            auto particleInitializerName = pop1["particleinitializer"]["name"].to<std::string>();
-            auto& density = pop1["particleinitializer"]["density"].to<ScalarFunction<1>>();
-            std::cout << "pop1 (" + popname + ") has a " + particleInitializerName
-                             + "particle initializer"
-                      << " and density(2) = " << density(2.) << "\n";*/
-        }
+        virtual void read() override { py::eval_file(initModuleName_, scope_); }
 
-        virtual ~PythonDataProvider() { std::cout << "hello\n"; }
+
 
     private:
         void preparePythonPath_() { py::eval_file("setpythonpath.py", scope_); }

--- a/src/initializer/python_data_provider.h
+++ b/src/initializer/python_data_provider.h
@@ -5,10 +5,12 @@
 
 #include "pragma_disable.h"
 
+// clang-format off
 DISABLE_WARNING(shadow, shadow-field-in-constructor-modified, 42)
 #include <pybind11/embed.h> // everything needed for embedding
 #include <pybind11/functional.h>
 ENABLE_WARNING(shadow, shadow-field-in-constructor-modified, 42)
+// clang-format on
 
 namespace py = pybind11;
 
@@ -21,16 +23,49 @@ namespace initializer
 {
     extern py::scoped_interpreter guard;
 
+    class PythonDataProvider;
 
+    class PythonDictHandler
+    {
+        friend class PythonDataProvider;
+        std::unique_ptr<PHAREDict<1>> phareDict1D;
+        std::unique_ptr<PHAREDict<2>> phareDict2D;
+        std::unique_ptr<PHAREDict<3>> phareDict3D;
+        PythonDictHandler()
+            : phareDict1D(std::make_unique<PHAREDict<1>>())
+        {
+        }
 
-    class __attribute__ ((visibility ("hidden")))  PythonDataProvider : public DataProvider
+    public:
+        static PythonDictHandler& INSTANCE();
+
+        template<std::size_t dim>
+        auto& dict()
+        {
+            static_assert(dim >= 1 and dim <= 3, "error, invalid dimension in dict<dim>()");
+            if constexpr (dim == 1)
+            {
+                return *phareDict1D;
+            }
+            else if constexpr (dim == 2)
+            {
+                return *phareDict2D;
+            }
+            else if constexpr (dim == 3)
+            {
+                return *phareDict3D;
+            }
+        }
+    };
+
+    class __attribute__((visibility("hidden"))) PythonDataProvider : public DataProvider
     {
     public:
         PythonDataProvider(int argc, char const* argv)
         {
             if (argc == 2)
             {
-                initModuleName_ = argv[1];
+                initModuleName_ = std::string{argv};
             }
             preparePythonPath_();
         }
@@ -42,20 +77,24 @@ namespace initializer
         virtual void read() override
         {
             py::eval_file(initModuleName_, scope_);
-            auto& d                      = dict<1>();
+            /*auto& d = dict<1>();
             auto& pop1                   = d["simulation"]["hybridstate"]["ions"]["pop1"];
             auto popname                 = pop1["name"].to<std::string>();
             auto particleInitializerName = pop1["particleinitializer"]["name"].to<std::string>();
             auto& density = pop1["particleinitializer"]["density"].to<ScalarFunction<1>>();
             std::cout << "pop1 (" + popname + ") has a " + particleInitializerName
                              + "particle initializer"
-                      << " and density(2) = " << density(2.) << "\n";
+                      << " and density(2) = " << density(2.) << "\n";*/
         }
 
+        virtual ~PythonDataProvider()
+        {
+            PythonDictHandler::INSTANCE().phareDict1D.release();
+            std::cout << "hello\n";
+        }
 
     private:
         void preparePythonPath_() { py::eval_file("setpythonpath.py", scope_); }
-
 
         std::string initModuleName_{"job.py"};
         py::scoped_interpreter guard_{};

--- a/src/initializer/python_data_provider.h
+++ b/src/initializer/python_data_provider.h
@@ -23,40 +23,7 @@ namespace initializer
 {
     extern py::scoped_interpreter guard;
 
-    class PythonDataProvider;
 
-    class PythonDictHandler
-    {
-        friend class PythonDataProvider;
-        std::unique_ptr<PHAREDict<1>> phareDict1D;
-        std::unique_ptr<PHAREDict<2>> phareDict2D;
-        std::unique_ptr<PHAREDict<3>> phareDict3D;
-        PythonDictHandler()
-            : phareDict1D(std::make_unique<PHAREDict<1>>())
-        {
-        }
-
-    public:
-        static PythonDictHandler& INSTANCE();
-
-        template<std::size_t dim>
-        auto& dict()
-        {
-            static_assert(dim >= 1 and dim <= 3, "error, invalid dimension in dict<dim>()");
-            if constexpr (dim == 1)
-            {
-                return *phareDict1D;
-            }
-            else if constexpr (dim == 2)
-            {
-                return *phareDict2D;
-            }
-            else if constexpr (dim == 3)
-            {
-                return *phareDict3D;
-            }
-        }
-    };
 
     class __attribute__((visibility("hidden"))) PythonDataProvider : public DataProvider
     {
@@ -87,11 +54,7 @@ namespace initializer
                       << " and density(2) = " << density(2.) << "\n";*/
         }
 
-        virtual ~PythonDataProvider()
-        {
-            PythonDictHandler::INSTANCE().phareDict1D.release();
-            std::cout << "hello\n";
-        }
+        virtual ~PythonDataProvider() { std::cout << "hello\n"; }
 
     private:
         void preparePythonPath_() { py::eval_file("setpythonpath.py", scope_); }

--- a/tests/amr/messengers/test_messengers.cpp
+++ b/tests/amr/messengers/test_messengers.cpp
@@ -80,58 +80,86 @@ using HybridMessengerT = HybridMessenger<HybridModelT, IPhysicalModel<SAMRAI_Typ
 
 double density(double x)
 {
-    return x * x + 2.;
+    return x * +2.;
 }
 
-std::array<double, 3> bulkVelocity(double x)
+double vx(double x)
 {
     (void)x;
-    return std::array<double, 3>{{1.0, 0.0, 0.0}};
+    return 1.;
 }
 
 
-std::array<double, 3> thermalVelocity(double x)
+double vy(double x)
 {
     (void)x;
-    return std::array<double, 3>{{0.5, 0.0, 0.0}};
+    return 1.;
+}
+
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+
+double vthz(double x)
+{
+    (void)x;
+    return 1.;
 }
 
 
 
 double bx(double x)
 {
-    return 4. * x;
+    return x + 2.;
 }
 
 double by(double x)
 {
-    return 5. * x;
+    return x + 3.;
 }
 
 double bz(double x)
 {
-    return 6. * x;
+    return x + 4.;
 }
 
 double ex(double x)
 {
-    return x;
+    return x + 5.;
 }
 
 double ey(double x)
 {
-    return 2. * x;
+    return x + 6.;
 }
 
 double ez(double x)
 {
-    return 3. * x;
+    return x + 7.;
 }
 
 
 
 using ScalarFunctionT = PHARE::initializer::ScalarFunction<1>;
-using VectorFunctionT = PHARE::initializer::VectorFunction<1>;
 
 PHARE::initializer::PHAREDict<1> createIonsDict()
 {
@@ -144,17 +172,29 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop0"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
     dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
-
-
 
     dict["ions"]["pop1"]["name"] = std::string{"alpha"};
     dict["ions"]["pop1"]["mass"] = 1.;
@@ -162,11 +202,25 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop1"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;
@@ -183,7 +237,6 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
     dict["electromag"]["magnetic"]["initializer"]["x_component"] = static_cast<ScalarFunctionT>(bx);
     dict["electromag"]["magnetic"]["initializer"]["y_component"] = static_cast<ScalarFunctionT>(by);
     dict["electromag"]["magnetic"]["initializer"]["z_component"] = static_cast<ScalarFunctionT>(bz);
-
 
     return dict;
 }

--- a/tests/amr/models/test_main.cpp
+++ b/tests/amr/models/test_main.cpp
@@ -48,57 +48,84 @@ double density(double x)
     return x * x + 2.;
 }
 
-std::array<double, 3> bulkVelocity(double x)
+double vx(double x)
 {
     (void)x;
-    return std::array<double, 3>{{1.0, 0.0, 0.0}};
+    return 1.;
 }
 
 
-std::array<double, 3> thermalVelocity(double x)
+double vy(double x)
 {
     (void)x;
-    return std::array<double, 3>{{0.5, 0.0, 0.0}};
+    return 1.;
 }
 
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+
+double vthz(double x)
+{
+    (void)x;
+    return 1.;
+}
 
 
 
 double bx(double x)
 {
-    return 4. * x;
+    return x * x + 2.;
 }
 
 double by(double x)
 {
-    return 5. * x;
+    return x * x + 2.;
 }
 
 double bz(double x)
 {
-    return 6. * x;
+    return x * x + 2.;
 }
 
 double ex(double x)
 {
-    return x;
+    return x * x + 2.;
 }
 
 double ey(double x)
 {
-    return 2. * x;
+    return x * x + 2.;
 }
 
 double ez(double x)
 {
-    return 3. * x;
+    return x * x + 2.;
 }
 
 
 
 
 using ScalarFunctionT = PHARE::initializer::ScalarFunction<1>;
-using VectorFunctionT = PHARE::initializer::VectorFunction<1>;
 
 PHARE::initializer::PHAREDict<1> createIonsDict()
 {
@@ -111,17 +138,29 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop0"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
     dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
-
-
 
     dict["ions"]["pop1"]["name"] = std::string{"alpha"};
     dict["ions"]["pop1"]["mass"] = 1.;
@@ -129,11 +168,25 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop1"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;
@@ -150,7 +203,6 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
     dict["electromag"]["magnetic"]["initializer"]["x_component"] = static_cast<ScalarFunctionT>(bx);
     dict["electromag"]["magnetic"]["initializer"]["y_component"] = static_cast<ScalarFunctionT>(by);
     dict["electromag"]["magnetic"]["initializer"]["z_component"] = static_cast<ScalarFunctionT>(bz);
-
 
     return dict;
 }

--- a/tests/amr/multiphysics_integrator/test_main.cpp
+++ b/tests/amr/multiphysics_integrator/test_main.cpp
@@ -152,53 +152,84 @@ using Ions1D    = Ions<IonsPop1D, GridYee1D>;
 
 
 
+
 double density(double x)
 {
     return x * x + 2.;
 }
 
-std::array<double, 3> bulkVelocity(double x)
+double vx(double x)
 {
-    return std::array<double, 3>{{1.0, 0.0, 0.0}};
+    (void)x;
+    return 1.;
 }
 
 
-std::array<double, 3> thermalVelocity(double x)
+double vy(double x)
 {
-    return std::array<double, 3>{{0.5, 0.0, 0.0}};
+    (void)x;
+    return 1.;
 }
 
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+
+double vthz(double x)
+{
+    (void)x;
+    return 1.;
+}
 
 
 
 double bx(double x)
 {
-    return 4. * x;
+    return x * x + 2.;
 }
 
 double by(double x)
 {
-    return 5. * x;
+    return x * x + 2.;
 }
 
 double bz(double x)
 {
-    return 6. * x;
+    return x * x + 2.;
 }
 
 double ex(double x)
 {
-    return x;
+    return x * x + 2.;
 }
 
 double ey(double x)
 {
-    return 2. * x;
+    return x * x + 2.;
 }
 
 double ez(double x)
 {
-    return 3. * x;
+    return x * x + 2.;
 }
 
 
@@ -210,7 +241,6 @@ double ez(double x)
 
 
 using ScalarFunctionT = PHARE::initializer::ScalarFunction<1>;
-using VectorFunctionT = PHARE::initializer::VectorFunction<1>;
 
 PHARE::initializer::PHAREDict<1> createIonsDict()
 {
@@ -223,17 +253,29 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop0"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
     dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
-
-
 
     dict["ions"]["pop1"]["name"] = std::string{"alpha"};
     dict["ions"]["pop1"]["mass"] = 1.;
@@ -241,16 +283,29 @@ PHARE::initializer::PHAREDict<1> createIonsDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop1"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;
     dict["ions"]["pop1"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
-
 
     dict["electromag"]["name"]             = std::string{"EM"};
     dict["electromag"]["electric"]["name"] = std::string{"E"};

--- a/tests/amr/resources_manager/resource_test_1d.cpp
+++ b/tests/amr/resources_manager/resource_test_1d.cpp
@@ -27,18 +27,49 @@ double density(double x)
     return x * x + 2.;
 }
 
-std::array<double, 3> bulkVelocity(double x)
+double vx(double x)
 {
     (void)x;
-    return std::array<double, 3>{{1.0, 0.0, 0.0}};
+    return 1.;
 }
 
 
-std::array<double, 3> thermalVelocity(double x)
+double vy(double x)
 {
     (void)x;
-    return std::array<double, 3>{{0.5, 0.0, 0.0}};
+    return 1.;
 }
+
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+
+double vthz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
 
 double bx(double x)
 {
@@ -74,7 +105,6 @@ double ez(double x)
 
 
 using ScalarFunctionT = PHARE::initializer::ScalarFunction<1>;
-using VectorFunctionT = PHARE::initializer::VectorFunction<1>;
 
 PHARE::initializer::PHAREDict<1> createInitDict()
 {
@@ -87,17 +117,29 @@ PHARE::initializer::PHAREDict<1> createInitDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop0"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop0"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
     dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
-
-
 
     dict["ions"]["pop1"]["name"] = std::string{"alpha"};
     dict["ions"]["pop1"]["mass"] = 1.;
@@ -105,11 +147,25 @@ PHARE::initializer::PHAREDict<1> createInitDict()
         = std::string{"MaxwellianParticleInitializer"};
     dict["ions"]["pop1"]["ParticleInitializer"]["density"] = static_cast<ScalarFunctionT>(density);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["bulkVelocity"]
-        = static_cast<VectorFunctionT>(bulkVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<ScalarFunctionT>(vx);
 
-    dict["ions"]["pop1"]["ParticleInitializer"]["thermalVelocity"]
-        = static_cast<VectorFunctionT>(thermalVelocity);
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<ScalarFunctionT>(vy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<ScalarFunctionT>(vz);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<ScalarFunctionT>(vthx);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<ScalarFunctionT>(vthy);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<ScalarFunctionT>(vthz);
+
 
     dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
     dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;

--- a/tests/core/data/ions/test_main.cpp
+++ b/tests/core/data/ions/test_main.cpp
@@ -35,26 +35,56 @@ double density(double x)
     return x * x + 2.;
 }
 
-std::array<double, 3> bulkVelocity([[maybe_unused]] double x)
+
+double vx(double x)
 {
-    return std::array<double, 3>{{1.0, 0.0, 0.0}};
+    (void)x;
+    return 1.;
 }
 
 
-std::array<double, 3> thermalVelocity([[maybe_unused]] double x)
+double vy(double x)
 {
-    return std::array<double, 3>{{0.5, 0.0, 0.0}};
+    (void)x;
+    return 1.;
 }
 
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+
+double vthz(double x)
+{
+    (void)x;
+    return 1.;
+}
 
 
 
 class theIons : public ::testing::Test
 {
 protected:
-    using VecField1D     = VecField<NdArrayVector1D<>, HybridQuantity>;
-    using ScalarFunction = PHARE::initializer::ScalarFunction<1>;
-    using VectorFunction = PHARE::initializer::VectorFunction<1>;
+    using VecField1D      = VecField<NdArrayVector1D<>, HybridQuantity>;
+    using ScalarFunctionT = PHARE::initializer::ScalarFunction<1>;
 
     using IonPopulation1D = IonPopulation<ParticleArray<1>, VecField1D, GridYee1D>;
     Ions<IonPopulation1D, GridYee1D> ions;
@@ -62,46 +92,76 @@ protected:
     PHARE::initializer::PHAREDict<1> createIonsDict()
     {
         PHARE::initializer::PHAREDict<1> dict;
-        dict["name"]                                = std::string{"ions"};
-        dict["nbrPopulations"]                      = std::size_t{2};
-        dict["pop0"]["name"]                        = std::string{"protons"};
-        dict["pop0"]["mass"]                        = 1.;
-        dict["pop0"]["ParticleInitializer"]["name"] = std::string{"MaxwellianParticleInitializer"};
-        dict["pop0"]["ParticleInitializer"]["density"] = static_cast<ScalarFunction>(density);
+        dict["ions"]["name"]           = std::string{"ions"};
+        dict["ions"]["nbrPopulations"] = std::size_t{2};
+        dict["ions"]["pop0"]["name"]   = std::string{"protons"};
+        dict["ions"]["pop0"]["mass"]   = 1.;
+        dict["ions"]["pop0"]["ParticleInitializer"]["name"]
+            = std::string{"MaxwellianParticleInitializer"};
+        dict["ions"]["pop0"]["ParticleInitializer"]["density"]
+            = static_cast<ScalarFunctionT>(density);
 
-        dict["pop0"]["ParticleInitializer"]["bulkVelocity"]
-            = static_cast<VectorFunction>(bulkVelocity);
+        dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+            = static_cast<ScalarFunctionT>(vx);
 
-        dict["pop0"]["ParticleInitializer"]["thermalVelocity"]
-            = static_cast<VectorFunction>(thermalVelocity);
+        dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+            = static_cast<ScalarFunctionT>(vy);
 
-        dict["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
-        dict["pop0"]["ParticleInitializer"]["charge"]         = -1.;
-        dict["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
-
+        dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+            = static_cast<ScalarFunctionT>(vz);
 
 
-        dict["pop1"]["name"]                        = std::string{"protons"};
-        dict["pop1"]["mass"]                        = 1.;
-        dict["pop1"]["ParticleInitializer"]["name"] = std::string{"MaxwellianParticleInitializer"};
-        dict["pop1"]["ParticleInitializer"]["density"] = static_cast<ScalarFunction>(density);
+        dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+            = static_cast<ScalarFunctionT>(vthx);
 
-        dict["pop1"]["ParticleInitializer"]["bulkVelocity"]
-            = static_cast<VectorFunction>(bulkVelocity);
+        dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+            = static_cast<ScalarFunctionT>(vthy);
 
-        dict["pop1"]["ParticleInitializer"]["thermalVelocity"]
-            = static_cast<VectorFunction>(thermalVelocity);
+        dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+            = static_cast<ScalarFunctionT>(vthz);
 
-        dict["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
-        dict["pop1"]["ParticleInitializer"]["charge"]         = -1.;
-        dict["pop1"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
+
+        dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
+        dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
+        dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
+
+        dict["ions"]["pop1"]["name"] = std::string{"alpha"};
+        dict["ions"]["pop1"]["mass"] = 1.;
+        dict["ions"]["pop1"]["ParticleInitializer"]["name"]
+            = std::string{"MaxwellianParticleInitializer"};
+        dict["ions"]["pop1"]["ParticleInitializer"]["density"]
+            = static_cast<ScalarFunctionT>(density);
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+            = static_cast<ScalarFunctionT>(vx);
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+            = static_cast<ScalarFunctionT>(vy);
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+            = static_cast<ScalarFunctionT>(vz);
+
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+            = static_cast<ScalarFunctionT>(vthx);
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+            = static_cast<ScalarFunctionT>(vthy);
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+            = static_cast<ScalarFunctionT>(vthz);
+
+
+        dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = std::size_t{100};
+        dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;
+        dict["ions"]["pop1"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
 
         return dict;
     }
 
 
     theIons()
-        : ions{createIonsDict()}
+        : ions{createIonsDict()["ions"]}
     {
     }
 

--- a/tests/core/data/maxwellian_particle_initializer/test_main.cpp
+++ b/tests/core/data/maxwellian_particle_initializer/test_main.cpp
@@ -15,6 +15,7 @@
 
 
 using namespace PHARE::core;
+using namespace PHARE::initializer;
 
 
 double density([[maybe_unused]] double x)
@@ -22,17 +23,50 @@ double density([[maybe_unused]] double x)
     return 1.;
 }
 
-std::array<double, 3> bulkVelocity([[maybe_unused]] double x)
+
+double vx(double x)
 {
-    return {{1.0, 0., 0.}};
+    (void)x;
+    return 1.;
+}
+
+
+double vy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
 }
 
 
 
-std::array<double, 3> thermalvelocity([[maybe_unused]] double x)
+double vthz(double x)
 {
-    return {{0.2, 0.2, 0.2}};
+    (void)x;
+    return 1.;
 }
+
+
 
 
 class AMaxwellianParticleInitializer1D : public ::testing::Test
@@ -40,12 +74,14 @@ class AMaxwellianParticleInitializer1D : public ::testing::Test
 private:
     using GridLayoutT    = GridLayout<GridLayoutImplYee<1, 1>>;
     using ParticleArrayT = ParticleArray<1>;
+    using VectorFunction = std::array<ScalarFunction<1>, 3>;
 
 public:
     AMaxwellianParticleInitializer1D()
         : layout{{{0.1}}, {{50}}, Point{0.}, Box{Point{50}, Point{99}}}
         , initializer{std::make_unique<MaxwellianParticleInitializer<ParticleArrayT, GridLayoutT>>(
-              density, bulkVelocity, thermalvelocity, 1., nbrParticlesPerCell)}
+              density, VectorFunction{vx, vy, vz}, VectorFunction{vthx, vthy, vthz}, 1.,
+              nbrParticlesPerCell)}
     {
         //
     }

--- a/tests/core/data/particle_initializer/test_main.cpp
+++ b/tests/core/data/particle_initializer/test_main.cpp
@@ -24,16 +24,47 @@ double density([[maybe_unused]] double x)
 }
 
 
-std::array<double, 3> bulkVelocity([[maybe_unused]] double x)
+
+double vx(double x)
 {
-    return {{1.0, 0., 0.}};
+    (void)x;
+    return 1.;
+}
+
+
+double vy(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vz(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthx(double x)
+{
+    (void)x;
+    return 1.;
+}
+
+
+double vthy(double x)
+{
+    (void)x;
+    return 1.;
 }
 
 
 
-std::array<double, 3> thermalVelocity([[maybe_unused]] double x)
+double vthz(double x)
 {
-    return {{0.2, 0.2, 0.2}};
+    (void)x;
+    return 1.;
 }
 
 
@@ -44,11 +75,17 @@ TEST(AParticleIinitializerFactory, takesAPHAREDictToCreateAParticleInitializer)
     PHARE::initializer::PHAREDict<1> dict;
     dict["name"]            = std::string{"MaxwellianParticleInitializer"};
     dict["density"]         = static_cast<PHARE::initializer::ScalarFunction<1>>(density);
-    dict["bulkVelocity"]    = static_cast<PHARE::initializer::VectorFunction<1>>(bulkVelocity);
-    dict["thermalVelocity"] = static_cast<PHARE::initializer::VectorFunction<1>>(thermalVelocity);
-    dict["charge"]          = 1.;
-    dict["nbrPartPerCell"]  = std::size_t{100};
-    dict["basis"]           = std::string{"Cartesian"};
+    dict["bulk_velocity_x"] = static_cast<PHARE::initializer::ScalarFunction<1>>(vx);
+    dict["bulk_velocity_y"] = static_cast<PHARE::initializer::ScalarFunction<1>>(vx);
+    dict["bulk_velocity_z"] = static_cast<PHARE::initializer::ScalarFunction<1>>(vx);
+
+    dict["thermal_velocity_x"] = static_cast<PHARE::initializer::ScalarFunction<1>>(vthx);
+    dict["thermal_velocity_y"] = static_cast<PHARE::initializer::ScalarFunction<1>>(vthy);
+    dict["thermal_velocity_z"] = static_cast<PHARE::initializer::ScalarFunction<1>>(vthz);
+
+    dict["charge"]         = 1.;
+    dict["nbrPartPerCell"] = std::size_t{100};
+    dict["basis"]          = std::string{"Cartesian"};
 
     auto initializer = ParticleInitializerFactory<ParticleArrayT, GridLayoutT>::create(dict);
 }

--- a/tests/initializer/CMakeLists.txt
+++ b/tests/initializer/CMakeLists.txt
@@ -13,11 +13,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${PHARE_WERROR_FLAGS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  initializer phare_core
-  gtest
-  gmock)
+  initializer phare_core)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setpythonpath.py.in ${CMAKE_CURRENT_BINARY_DIR}/setpythonpath.py @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init.py ${CMAKE_CURRENT_BINARY_DIR}/init.py @ONLY)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 

--- a/tests/initializer/CMakeLists.txt
+++ b/tests/initializer/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setpythonpath.py.in ${CMAKE_CURRENT_BINARY_DIR}/setpythonpath.py @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init.py ${CMAKE_CURRENT_BINARY_DIR}/init.py @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/job.py ${CMAKE_CURRENT_BINARY_DIR}/job.py @ONLY)
 
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/initializer/CMakeLists.txt
+++ b/tests/initializer/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   gmock)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setpythonpath.py.in ${CMAKE_CURRENT_BINARY_DIR}/setpythonpath.py @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init.py ${CMAKE_CURRENT_BINARY_DIR}/init.py @ONLY)
+
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 

--- a/tests/initializer/CMakeLists.txt
+++ b/tests/initializer/CMakeLists.txt
@@ -13,10 +13,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${PHARE_WERROR_FLAGS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  initializer phare_core)
+  initializer phare_core
+  gtest
+  gmock)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setpythonpath.py.in ${CMAKE_CURRENT_BINARY_DIR}/setpythonpath.py @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init.py ${CMAKE_CURRENT_BINARY_DIR}/init.py @ONLY)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 

--- a/tests/initializer/init.py
+++ b/tests/initializer/init.py
@@ -3,19 +3,50 @@
 
 import src.initializer.pyphare as pp
 
-
-def f(x):
+def density(x):
     return 2.*x
 
-#pp.add("test", f)
+def vx(x):
+    return 2*x
+
+def vy(x):
+    return 3*x
+
+def vz(x):
+    return 4*x
+
+
+def vthx(x):
+    return 5*x
+
+def vthy(x):
+    return 6*x
+
+def vthz(x):
+    return 7*x
+
+
 
 pp.add("simulation/name", "simulation_test")
 pp.add("simulation/ions/nbr_populations", 2)
 pp.add("simulation/ions/pop0/name", "protons")
 pp.add("simulation/ions/pop0/mass", 1.)
-pp.add("simulation/ions/pop0/charge", 1.)
 pp.add("simulation/ions/pop0/particle_initializer/name", "maxwellian")
-pp.add("simulation/ions/pop0/particle_initializer/density", f)
+
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/density", density)
+
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/bulk_velocity_x", vx)
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/bulk_velocity_y", vy)
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/bulk_velocity_z", vz)
+
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/thermal_velocity_x", vthx)
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/thermal_velocity_y", vthy)
+pp.addScalarFunction1D("simulation/ions/pop0/particle_initializer/thermal_velocity_z", vthz)
+
+pp.add("simulation/ions/pop0/particle_initializer/nbr_part_per_cell", 100)
+pp.add("simulation/ions/pop0/particle_initializer/charge", 1.)
+pp.add("simulation/ions/pop0/particle_initializer/basis", "cartesian")
+
 
 
 

--- a/tests/initializer/init.py
+++ b/tests/initializer/init.py
@@ -7,15 +7,15 @@ import src.initializer.pyphare as pp
 def f(x):
     return 2.*x
 
-pp.add("test", f)
+#pp.add("test", f)
 
-#pp.add("simulation/name", "simulation_test")
-#pp.add("simulation/ions/nbr_populations", 2)
-#pp.add("simulation/ions/pop0/name", "protons")
-#pp.add("simulation/ions/pop0/mass", 1.)
-#pp.add("simulation/ions/pop0/charge", 1.)
-#pp.add("simulation/ions/pop0/particle_initializer/name", "maxwellian")
-#pp.add("simulation/ions/pop0/particle_initializer/density", f)
+pp.add("simulation/name", "simulation_test")
+pp.add("simulation/ions/nbr_populations", 2)
+pp.add("simulation/ions/pop0/name", "protons")
+pp.add("simulation/ions/pop0/mass", 1.)
+pp.add("simulation/ions/pop0/charge", 1.)
+pp.add("simulation/ions/pop0/particle_initializer/name", "maxwellian")
+pp.add("simulation/ions/pop0/particle_initializer/density", f)
 
 
 

--- a/tests/initializer/init.py
+++ b/tests/initializer/init.py
@@ -32,11 +32,30 @@ simulation = job.ph.globals.sim
 
 pp.add("simulation/name", "simulation_test")
 pp.add("simulation/dimension", simulation.dims)
-pp.add("simulation/nbr_cells/x", simulation.cells[0])
+
+
+pp.add("simulation/grid/layout_type", simulation.layout)
+pp.add("simulation/grid/nbr_cells/x", simulation.cells[0])
+pp.add("simulation/grid/meshsize/x", simulation.dl[0])
+pp.add("simulation/grid/origin/x", simulation.origin[0])
+
 if (simulation.dims>1):
-    pp.add("simulation/nbr_cells/x", simulation.cells[1])
-    if (simulation.dims >1):
-        pp.add("simulation/nbr_cells/x", simulation.cells[2])
+    pp.add("simulation/grid/nbr_cells/y", simulation.cells[1])
+    pp.add("simulation/grid/meshsize/y", simulation.dl[1])
+    pp.add("simulation/grid/origin/y", simulation.origin[1])
+
+    if (simulation.dims >2):
+        pp.add("simulation/grid/nbr_cells/z", simulation.cells[2])
+        pp.add("simulation/grid/meshsize/z", simulation.dl[2])
+        pp.add("simulation/grid/origin/z", simulation.origin[2])
+
+
+
+pp.add("simulation/interp_order", simulation.interp_order)
+pp.add("simulation/time_step", simulation.time_step)
+
+
+pp.add("simulation/algo/pusher/name", simulation.particle_pusher)
 
 pp.add("simulation/ions/nbr_populations", 2)
 pp.add("simulation/ions/pop0/name", "protons")

--- a/tests/initializer/init.py
+++ b/tests/initializer/init.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+
+
+import src.initializer.pyphare as pp
+
+
+def f(x):
+    return 2.*x
+
+pp.add("test", f)
+
+#pp.add("simulation/name", "simulation_test")
+#pp.add("simulation/ions/nbr_populations", 2)
+#pp.add("simulation/ions/pop0/name", "protons")
+#pp.add("simulation/ions/pop0/mass", 1.)
+#pp.add("simulation/ions/pop0/charge", 1.)
+#pp.add("simulation/ions/pop0/particle_initializer/name", "maxwellian")
+#pp.add("simulation/ions/pop0/particle_initializer/density", f)
+
+
+

--- a/tests/initializer/init.py
+++ b/tests/initializer/init.py
@@ -2,6 +2,8 @@
 
 
 import src.initializer.pyphare as pp
+import job
+
 
 def density(x):
     return 2.*x
@@ -26,8 +28,16 @@ def vthz(x):
     return 7*x
 
 
+simulation = job.ph.globals.sim
 
 pp.add("simulation/name", "simulation_test")
+pp.add("simulation/dimension", simulation.dims)
+pp.add("simulation/nbr_cells/x", simulation.cells[0])
+if (simulation.dims>1):
+    pp.add("simulation/nbr_cells/x", simulation.cells[1])
+    if (simulation.dims >1):
+        pp.add("simulation/nbr_cells/x", simulation.cells[2])
+
 pp.add("simulation/ions/nbr_populations", 2)
 pp.add("simulation/ions/pop0/name", "protons")
 pp.add("simulation/ions/pop0/mass", 1.)

--- a/tests/initializer/job.py
+++ b/tests/initializer/job.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import pharein as ph
+
+print("test")
+# configure the simulation
+
+ph.Simulation(
+    time_step_nbr=1000,                 # number of time steps (not specified if time_step and final_time provided)
+    final_time=1.,                      # simulation final time (not specified if time_step and time_step_nbr provided)
+    boundary_types="periodic",          # boundary condition, string or tuple, length == len(cell) == len(dl)
+    cells=80,                           # integer or tuple length == dimension
+    dl=0.1,                             # mesh size of the root level, float or tuple
+    path='test5'                        # directory where INI file and diagnostics directories will be
+
+  # time_step = 0.005,                  # simulation time step (not specified if time_step_nbr and final_time provided)
+  # domain_size = 8.,                   # float or tuple, not specified if dl and cells are
+  # interp_order = 1,                   # interpolation order, [default = 1] can be 1, 2, 3 or 4
+  # layout = "yee"                      # grid layout, [default="yee"]
+  # origin = 0.,                        # position of the origin of the domain, float or tuple (length = dimension)
+  # particle_pusher = "modified_boris", # particle pusher method, [default = "modified_boris"]
+  # refined_particle_nbr = 2,           # number of refined particle a particle is split into [default : ]
+  # diag_export_format = 'ascii',       # export format of the diagnostics [default = 'ascii']
+  #, refinement = {"level":[0,1],       # AMR parameters
+  #                "extent_ratio":[0.4, 0.6],
+  #                "refinement_iterations":[0, 3]},
+
+)
+
+
+# configure the model for the initial condition
+ph.UniformModel(proton1={},
+                proton2={"density":2,
+                         "vbulk":(1., 0., 0.)}
+
+                # demo_species = {density: 2,           # default = 1
+                #                 vbulk: (10,0,0),      # default = (0., 0., 0.)
+                #                 charge: 1,            # default = 1
+                #                 mass: 16,             # default = 1
+                #                 beta: 0.05,           # default = 1
+                #                 anisotropy=1          # default = 1 (Tperp/Tpara)
+                #                 }
+)
+
+
+ph.FluidDiagnostics(
+    name="FluidDiagnostics1",       # name of the diagnostics
+    diag_type="rho_s",              # choose in (rho_s, flux_s)
+    write_every=10,                 # write on disk every x iterations
+    compute_every=5,                # compute diagnostics every x iterations ( x <= write_every)
+    start_iteration=0,              # iteration at which diag is enabled
+    last_iteration=990,             # iteration at which diag is turned off
+    species_name="proton1"          # name of the species for which the diagnostics is made
+  #,path = 'FluidDiagnostics1'      # where output files will be written, [default: name]
+)
+
+
+ph.FluidDiagnostics(
+    name="FluidDiagnostics2",
+    diag_type="flux_s",
+    write_every=10,
+    compute_every=5,
+    start_iteration=0,
+    last_iteration=990,
+    species_name="proton1"
+)
+
+
+ph.ElectromagDiagnostics(
+    name="ElectromagDiagnostics1",
+    diag_type="E",                  # available : ("E", "B")
+    write_every=10,
+    compute_every=5,
+    start_teration=0,
+    last_iteration=990
+#,path = 'ElectromagDiagnostics1'   # where output files will be written, [default: name]
+)
+
+
+ph.ElectromagDiagnostics(
+    name="ElectromagDiagnostics2",
+    diag_type="B",
+    write_every=10,
+    compute_every=5,
+    start_teration=0,
+    last_iteration=990
+)
+
+
+ph.ParticleDiagnostics(
+        name = "ParticleDiagnostics1",
+        compute_every=10,
+        write_every=10,
+        start_iteration=0,
+        last_iteration=90,
+        diag_type="space_box",          # choose particles within a spatial box
+        extent=(2., 4.),                # extent of the box
+        species_name="proton1"
+        )
+
+
+
+
+

--- a/tests/initializer/setpythonpath.py.in
+++ b/tests/initializer/setpythonpath.py.in
@@ -6,6 +6,8 @@ import sys
 
 
 cmake_build_dir = "@CMAKE_BINARY_DIR@"
+cmake_source_dir = "@CMAKE_SOURCE_DIR@"
+pharein_dir      = os.path.join(cmake_source_dir, "subprojects")
 venv_path = os.environ.get('VIRTUAL_ENV')
 
 if venv_path is not None:
@@ -19,6 +21,7 @@ if venv_path is not None:
     sys.path = sys.path + pythonpath +  [cmake_build_dir]
 
 else:
-    sys.path  = sys.path + [cmake_build_dir]
+    sys.path  = sys.path + [cmake_build_dir, pharein_dir]
+
 
 

--- a/tests/initializer/setpythonpath.py.in
+++ b/tests/initializer/setpythonpath.py.in
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
+print("SETUP PYTHONPATH")
 import os
 import subprocess
 import sys
 
 
-
+cmake_build_dir = "@CMAKE_BINARY_DIR@"
 venv_path = os.environ.get('VIRTUAL_ENV')
 
 if venv_path is not None:
@@ -16,6 +17,9 @@ if venv_path is not None:
     s = s.replace('[','').replace(']','').replace('"',"").replace("\n","").replace("'",'')
     s = s.split(",")[1:]
     pythonpath = [ss.strip() for ss in s]
-    sys.path = sys.path + pythonpath
+    sys.path = sys.path + pythonpath +  [cmake_build_dir]
+
+else:
+    sys.path  = sys.path + [cmake_build_dir]
 
 

--- a/tests/initializer/setpythonpath.py.in
+++ b/tests/initializer/setpythonpath.py.in
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-print("SETUP PYTHONPATH")
 import os
 import subprocess
 import sys

--- a/tests/initializer/test_initializer.cpp
+++ b/tests/initializer/test_initializer.cpp
@@ -22,15 +22,17 @@
 #include "data/grid/gridlayoutimplyee.h"
 #include "data/particles/particle_array.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
 #include <memory>
 
 using namespace PHARE::initializer;
 
 using GridLayoutT    = PHARE::core::GridLayout<PHARE::core::GridLayoutImplYee<1, 1>>;
 using ParticleArrayT = PHARE::core::ParticleArray<1>;
+
+#if 0
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 
 
 
@@ -48,10 +50,33 @@ TEST(ARestartTimeDataProvider, isADataProvider)
 
 
 
+TEST(APythonDataProvider, providesAValidTree)
+{
+    // auto density0
+    //   = pop0["particle_initializer"]["density"].to<PHARE::initializer::ScalarFunction<1>>();
+    // auto d = density0(2.);
+    // EXPECT_EQ(4., d);
+}
+#endif
+
 
 int main(int argc, char** argv)
 {
-    ::testing::InitGoogleTest(&argc, argv);
+    //::testing::InitGoogleTest(&argc, argv);
 
-    return RUN_ALL_TESTS();
+    char const* name                         = "init.py";
+    std::unique_ptr<PythonDataProvider> pydp = std::make_unique<PythonDataProvider>(2, name);
+    pydp->read();
+    // auto& input = dict<1>();
+
+    // EXPECT_EQ("simulation_test", input["simulation"]["name"].to<std::string>());
+    // EXPECT_EQ(2, input["simulation"]["ions"]["nbr_populations"].to<int>());
+    //
+    // auto& pop0 = input["simulation"]["ions"]["pop0"];
+    // EXPECT_EQ("protons", pop0["name"].to<std::string>());
+    // EXPECT_EQ(1., pop0["mass"].to<double>());
+    // EXPECT_EQ(1., pop0["charge"].to<double>());
+    // EXPECT_EQ("maxwellian", pop0["particle_initializer"]["name"].to<std::string>());
+    //
+    // return RUN_ALL_TESTS();
 }

--- a/tests/initializer/test_initializer.cpp
+++ b/tests/initializer/test_initializer.cpp
@@ -61,6 +61,8 @@ TEST(APythonDataProvider, providesAValidTree)
     auto& input = PHAREDictHandler::INSTANCE().dict<1>();
 
     auto simulationName = input["simulation"]["name"].to<std::string>();
+    auto dim            = input["simulation"]["dimension"].to<int>();
+    auto nx             = input["simulation"]["nbr_cells"]["x"].to<int>();
     auto nbrPopulations = input["simulation"]["ions"]["nbr_populations"].to<int>();
 
     auto& pop0                       = input["simulation"]["ions"]["pop0"];
@@ -81,6 +83,8 @@ TEST(APythonDataProvider, providesAValidTree)
 
 
     EXPECT_EQ("simulation_test", simulationName);
+    EXPECT_EQ(1, dim);
+    EXPECT_EQ(80, nx);
     EXPECT_EQ(2, nbrPopulations);
     EXPECT_EQ("protons", pop0Name);
     EXPECT_DOUBLE_EQ(1., pop0Mass);

--- a/tests/initializer/test_initializer.cpp
+++ b/tests/initializer/test_initializer.cpp
@@ -62,9 +62,18 @@ TEST(APythonDataProvider, providesAValidTree)
 
     auto simulationName = input["simulation"]["name"].to<std::string>();
     auto dim            = input["simulation"]["dimension"].to<int>();
-    auto nx             = input["simulation"]["nbr_cells"]["x"].to<int>();
-    auto nbrPopulations = input["simulation"]["ions"]["nbr_populations"].to<int>();
+    auto interp_order   = input["simulation"]["interp_order"].to<int>();
+    auto dt             = input["simulation"]["time_step"].to<double>();
 
+    auto layout = input["simulation"]["grid"]["layout_type"].to<std::string>();
+    auto nx     = input["simulation"]["grid"]["nbr_cells"]["x"].to<int>();
+    auto dx     = input["simulation"]["grid"]["meshsize"]["x"].to<double>();
+    auto origin = input["simulation"]["grid"]["origin"]["x"].to<double>();
+
+    auto pusherName = input["simulation"]["algo"]["pusher"]["name"].to<std::string>();
+
+
+    auto nbrPopulations              = input["simulation"]["ions"]["nbr_populations"].to<int>();
     auto& pop0                       = input["simulation"]["ions"]["pop0"];
     auto pop0Name                    = pop0["name"].to<std::string>();
     auto pop0Mass                    = pop0["mass"].to<double>();
@@ -83,8 +92,17 @@ TEST(APythonDataProvider, providesAValidTree)
 
 
     EXPECT_EQ("simulation_test", simulationName);
+    EXPECT_EQ(1, interp_order);
+
     EXPECT_EQ(1, dim);
     EXPECT_EQ(80, nx);
+    EXPECT_DOUBLE_EQ(0.1, dx);
+    EXPECT_DOUBLE_EQ(0.001, dt);
+    EXPECT_DOUBLE_EQ(0., origin);
+    EXPECT_EQ("yee", layout);
+
+    EXPECT_EQ("modified_boris", pusherName);
+
     EXPECT_EQ(2, nbrPopulations);
     EXPECT_EQ("protons", pop0Name);
     EXPECT_DOUBLE_EQ(1., pop0Mass);

--- a/tests/initializer/test_initializer.cpp
+++ b/tests/initializer/test_initializer.cpp
@@ -29,7 +29,6 @@ using namespace PHARE::initializer;
 using GridLayoutT    = PHARE::core::GridLayout<PHARE::core::GridLayoutImplYee<1, 1>>;
 using ParticleArrayT = PHARE::core::ParticleArray<1>;
 
-#if 0
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -38,8 +37,10 @@ using ParticleArrayT = PHARE::core::ParticleArray<1>;
 
 TEST(APythonDataProvider, isADataProvider)
 {
+    PHAREDictHandler::INSTANCE().init<1>();
     char const* argv                   = "job_super.py";
     std::unique_ptr<DataProvider> pydp = std::make_unique<PythonDataProvider>(2, argv);
+    PHAREDictHandler::INSTANCE().stop<1>();
 }
 
 
@@ -52,31 +53,35 @@ TEST(ARestartTimeDataProvider, isADataProvider)
 
 TEST(APythonDataProvider, providesAValidTree)
 {
-    // auto density0
-    //   = pop0["particle_initializer"]["density"].to<PHARE::initializer::ScalarFunction<1>>();
-    // auto d = density0(2.);
-    // EXPECT_EQ(4., d);
-}
-#endif
-
-
-int main(int argc, char** argv)
-{
-    //::testing::InitGoogleTest(&argc, argv);
+    PHAREDictHandler::INSTANCE().init<1>();
 
     char const* name                         = "init.py";
     std::unique_ptr<PythonDataProvider> pydp = std::make_unique<PythonDataProvider>(2, name);
     pydp->read();
-    // auto& input = dict<1>();
+    auto& input = PHAREDictHandler::INSTANCE().dict<1>(); // dict<1>();
 
-    // EXPECT_EQ("simulation_test", input["simulation"]["name"].to<std::string>());
-    // EXPECT_EQ(2, input["simulation"]["ions"]["nbr_populations"].to<int>());
-    //
-    // auto& pop0 = input["simulation"]["ions"]["pop0"];
-    // EXPECT_EQ("protons", pop0["name"].to<std::string>());
-    // EXPECT_EQ(1., pop0["mass"].to<double>());
-    // EXPECT_EQ(1., pop0["charge"].to<double>());
-    // EXPECT_EQ("maxwellian", pop0["particle_initializer"]["name"].to<std::string>());
-    //
-    // return RUN_ALL_TESTS();
+    EXPECT_EQ("simulation_test", input["simulation"]["name"].to<std::string>());
+    EXPECT_EQ(2, input["simulation"]["ions"]["nbr_populations"].to<int>());
+
+    auto& pop0 = input["simulation"]["ions"]["pop0"];
+    EXPECT_EQ("protons", pop0["name"].to<std::string>());
+    EXPECT_EQ(1., pop0["mass"].to<double>());
+    EXPECT_EQ(1., pop0["charge"].to<double>());
+    EXPECT_EQ("maxwellian", pop0["particle_initializer"]["name"].to<std::string>());
+
+    auto density0
+        = pop0["particle_initializer"]["density"].to<PHARE::initializer::ScalarFunction<1>>();
+    auto d = density0(2.);
+    EXPECT_EQ(4., d);
+    PHAREDictHandler::INSTANCE().stop<1>();
+}
+
+
+
+int main(int argc, char** argv)
+
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
 }

--- a/tests/initializer/test_initializer.cpp
+++ b/tests/initializer/test_initializer.cpp
@@ -55,9 +55,9 @@ TEST(APythonDataProvider, providesAValidTree)
 {
     PHAREDictHandler::INSTANCE().init<1>();
 
-    char const* name                         = "init.py";
-    std::unique_ptr<PythonDataProvider> pydp = std::make_unique<PythonDataProvider>(2, name);
-    pydp->read();
+    char const* name = "init.py";
+    PythonDataProvider pydp{2, name};
+    pydp.read();
     auto& input = PHAREDictHandler::INSTANCE().dict<1>();
 
     auto simulationName = input["simulation"]["name"].to<std::string>();

--- a/tests/initializer/test_initializer.cpp
+++ b/tests/initializer/test_initializer.cpp
@@ -58,21 +58,44 @@ TEST(APythonDataProvider, providesAValidTree)
     char const* name                         = "init.py";
     std::unique_ptr<PythonDataProvider> pydp = std::make_unique<PythonDataProvider>(2, name);
     pydp->read();
-    auto& input = PHAREDictHandler::INSTANCE().dict<1>(); // dict<1>();
+    auto& input = PHAREDictHandler::INSTANCE().dict<1>();
 
-    EXPECT_EQ("simulation_test", input["simulation"]["name"].to<std::string>());
-    EXPECT_EQ(2, input["simulation"]["ions"]["nbr_populations"].to<int>());
+    auto simulationName = input["simulation"]["name"].to<std::string>();
+    auto nbrPopulations = input["simulation"]["ions"]["nbr_populations"].to<int>();
 
-    auto& pop0 = input["simulation"]["ions"]["pop0"];
-    EXPECT_EQ("protons", pop0["name"].to<std::string>());
-    EXPECT_EQ(1., pop0["mass"].to<double>());
-    EXPECT_EQ(1., pop0["charge"].to<double>());
-    EXPECT_EQ("maxwellian", pop0["particle_initializer"]["name"].to<std::string>());
+    auto& pop0                       = input["simulation"]["ions"]["pop0"];
+    auto pop0Name                    = pop0["name"].to<std::string>();
+    auto pop0Mass                    = pop0["mass"].to<double>();
+    auto& pop0ParticleInitializer    = pop0["particle_initializer"];
+    auto pop0ParticleInitializerName = pop0ParticleInitializer["name"].to<std::string>();
+    auto pop0density                 = pop0ParticleInitializer["density"].to<ScalarFunction<1>>();
+    auto bulk0x             = pop0ParticleInitializer["bulk_velocity_x"].to<ScalarFunction<1>>();
+    auto bulk0y             = pop0ParticleInitializer["bulk_velocity_y"].to<ScalarFunction<1>>();
+    auto bulk0z             = pop0ParticleInitializer["bulk_velocity_z"].to<ScalarFunction<1>>();
+    auto vth0x              = pop0ParticleInitializer["thermal_velocity_x"].to<ScalarFunction<1>>();
+    auto vth0y              = pop0ParticleInitializer["thermal_velocity_y"].to<ScalarFunction<1>>();
+    auto vth0z              = pop0ParticleInitializer["thermal_velocity_z"].to<ScalarFunction<1>>();
+    auto pop0NbrPartPerCell = pop0ParticleInitializer["nbr_part_per_cell"].to<int>();
+    auto pop0Charge         = pop0ParticleInitializer["charge"].to<double>();
+    auto pop0Basis          = pop0ParticleInitializer["basis"].to<std::string>();
 
-    auto density0
-        = pop0["particle_initializer"]["density"].to<PHARE::initializer::ScalarFunction<1>>();
-    auto d = density0(2.);
-    EXPECT_EQ(4., d);
+
+    EXPECT_EQ("simulation_test", simulationName);
+    EXPECT_EQ(2, nbrPopulations);
+    EXPECT_EQ("protons", pop0Name);
+    EXPECT_DOUBLE_EQ(1., pop0Mass);
+    EXPECT_EQ("maxwellian", pop0ParticleInitializerName);
+    EXPECT_DOUBLE_EQ(4., pop0density(2.));
+    EXPECT_DOUBLE_EQ(4., bulk0x(2.));
+    EXPECT_DOUBLE_EQ(6., bulk0y(2.));
+    EXPECT_DOUBLE_EQ(8., bulk0z(2.));
+    EXPECT_DOUBLE_EQ(10., vth0x(2.));
+    EXPECT_DOUBLE_EQ(12., vth0y(2.));
+    EXPECT_DOUBLE_EQ(14., vth0z(2.));
+    EXPECT_EQ(100, pop0NbrPartPerCell);
+    EXPECT_DOUBLE_EQ(1., pop0Charge);
+    EXPECT_EQ("cartesian", pop0Basis);
+
     PHAREDictHandler::INSTANCE().stop<1>();
 }
 


### PR DESCRIPTION
This PR links PHARE to the user script job.py for initialising the simulation.
PHARE reads init.py which imports job.py and takes user inputs from there to fill a PHAREDict using PyPHARE.
A test shows an example of a standard pharedict (to be completed with models and diagnostics later) obtained from the pharein simulation object.
The PhareDict will then be passed to various objects in the code for their initialization