### PR TITLE
build subproject/samrai if not found

### DIFF
--- a/res/cmake/def.cmake
+++ b/res/cmake/def.cmake
@@ -26,14 +26,14 @@ endif(testMPI)
 if(MSVC)
   set (PHARE_WERROR_FLAGS /W4 /WX)
 else()
-  set (PHARE_WERROR_FLAGS -Wall -Wextra -pedantic -Werror)
+  set (PHARE_WERROR_FLAGS -Wall -Wextra -pedantic -Werror
+        -Wno-unused-variable -Wno-unused-parameter)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set (PHARE_WERROR_FLAGS ${PHARE_WERROR_FLAGS}
-                        -Wno-unused-variable -Wno-unused-parameter
-                        -Wno-gnu-zero-variadic-macro-arguments)
+      -Wno-gnu-zero-variadic-macro-arguments)
 else()
   set (PHARE_WERROR_FLAGS ${PHARE_WERROR_FLAGS}
-                          -Wno-unused-variable -Wno-unused-parameter
-                          -Wno-unused-but-set-variable -Wno-unused-but-set-parameter)
+      -Wno-class-memaccess
+      -Wno-unused-but-set-variable -Wno-unused-but-set-parameter)
 endif()
 endif()


### PR DESCRIPTION
currently the method for building samrai doesn't configure samrai properly and results in werror compile failures.