### PR TITLE
introduces a consistent way to compute ion moments

### DIFF
--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -186,7 +186,7 @@ namespace amr
             interiorParticles_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             levelGhostParticlesOld_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             copyLevelGhostOldToPushable_(*level, model);
-            computeIonMoments_(*level, model);
+            // computeIonMoments_(*level, model);
             // levelGhostNew will be refined in next firstStep
         }
 
@@ -249,7 +249,7 @@ namespace amr
             // they need to be identical to levelGhostParticlesOld before advance
             copyLevelGhostOldToPushable_(level, model);
 
-            computeIonMoments_(level, model);
+            // computeIonMoments_(level, model);
         }
 
 
@@ -459,7 +459,7 @@ namespace amr
             // at some point in the future levelGhostParticles could be filled with injected
             // particles depending on the domain boundary condition.
 
-            computeIonMoments_(level, model);
+            // computeIonMoments_(level, model);
         }
 
 
@@ -606,22 +606,6 @@ namespace amr
                     std::copy(std::begin(levelGhostParticlesOld), std::end(levelGhostParticlesOld),
                               std::back_inserter(levelGhostParticles));
                 }
-            }
-        }
-
-
-
-
-        void computeIonMoments_(SAMRAI::hier::PatchLevel& level, IPhysicalModel& model)
-        {
-            auto& hybridModel = static_cast<HybridModel&>(model);
-            for (auto& patch : level)
-            {
-                auto& ions       = hybridModel.state.ions;
-                auto dataOnPatch = resourcesManager_->setOnPatch(*patch, ions);
-                auto layout      = layoutFromPatch<GridLayoutT>(*patch);
-
-                core::computeIonMoments(ions, layout, interpolate_);
             }
         }
 

--- a/src/amr/types/amr_types.h
+++ b/src/amr/types/amr_types.h
@@ -3,6 +3,7 @@
 
 
 #include "SAMRAI/hier/Patch.h"
+#include "SAMRAI/hier/PatchHierarchy.h"
 #include "SAMRAI/hier/PatchLevel.h"
 #include "SAMRAI/hier/PatchHierarchy.h"
 
@@ -15,7 +16,13 @@ namespace amr
         using patch_t     = SAMRAI::hier::Patch;
         using level_t     = SAMRAI::hier::PatchLevel;
         using hierarchy_t = SAMRAI::hier::PatchHierarchy;
+
+        static level_t& getLevel(hierarchy_t const& hierarchy, int levelNumber)
+        {
+            return *hierarchy.getPatchLevel(levelNumber);
+        }
     };
+
 } // namespace amr
 } // namespace PHARE
 

--- a/src/core/numerics/interpolator/interpolator.h
+++ b/src/core/numerics/interpolator/interpolator.h
@@ -286,7 +286,8 @@ namespace core
         inline void operator()(Field& density, Field& xFlux, Field& yFlux, Field& zFlux,
                                std::array<QtyCentering, 1> const& densityCentering,
                                VectorCenteringArray const& fluxCentering, Particle const& particle,
-                               Array1 const& startIndex, Array2 const& weights, double coef = 1.)
+                               Array1 const& startIndex, Array2 const& weights, double cellVolume,
+                               double coef = 1.)
         {
             auto const& xDenStartIndex = startIndex[static_cast<int>(densityCentering[0])][0];
             auto const& xDenWeights    = weights[static_cast<int>(densityCentering[0])][0];
@@ -302,10 +303,10 @@ namespace core
 
             auto order_size = xDenWeights.size();
 
-            auto const partRho   = particle.weight;
-            auto const xPartFlux = particle.v[0] * particle.weight;
-            auto const yPartFlux = particle.v[1] * particle.weight;
-            auto const zPartFlux = particle.v[2] * particle.weight;
+            auto const partRho   = particle.weight / cellVolume;
+            auto const xPartFlux = particle.v[0] * particle.weight / cellVolume;
+            auto const yPartFlux = particle.v[1] * particle.weight / cellVolume;
+            auto const zPartFlux = particle.v[2] * particle.weight / cellVolume;
 
             for (auto ik = 0u; ik < order_size; ++ik)
             {
@@ -341,7 +342,8 @@ namespace core
         inline void operator()(Field& density, Field& xFlux, Field& yFlux, Field& zFlux,
                                std::array<QtyCentering, 2> const& densityCentering,
                                VectorCenteringArray const& fluxCentering, Particle const& particle,
-                               Array1 const& startIndex, Array2 const& weights, double coef = 1.)
+                               Array1 const& startIndex, Array2 const& weights, double cellVolume,
+                               double coef = 1.)
         {
             auto const& xDenStartIndex = startIndex[static_cast<int>(densityCentering[0])][0];
             auto const& xDenWeights    = weights[static_cast<int>(densityCentering[0])][0];
@@ -372,10 +374,10 @@ namespace core
 
 
 
-            auto const partRho   = particle.weight * coef;
-            auto const xPartFlux = particle.v[0] * particle.weight * coef;
-            auto const yPartFlux = particle.v[1] * particle.weight * coef;
-            auto const zPartFlux = particle.v[2] * particle.weight * coef;
+            auto const partRho   = particle.weight * coef / cellVolume;
+            auto const xPartFlux = particle.v[0] * particle.weight * coef / cellVolume;
+            auto const yPartFlux = particle.v[1] * particle.weight * coef / cellVolume;
+            auto const zPartFlux = particle.v[2] * particle.weight * coef / cellVolume;
 
             auto order_size = xDenWeights.size();
             for (auto ix = 0u; ix < order_size; ++ix)
@@ -421,7 +423,8 @@ namespace core
         inline void operator()(Field& density, Field& xFlux, Field& yFlux, Field& zFlux,
                                std::array<QtyCentering, 3> const& densityCentering,
                                VectorCenteringArray const& fluxCentering, Particle const& particle,
-                               Array1 const& startIndex, Array2 const& weights, double coef = 1.)
+                               Array1 const& startIndex, Array2 const& weights, double cellVolume,
+                               double coef = 1.)
         {
             auto const& xDenStartIndex = startIndex[static_cast<int>(densityCentering[0])][0];
             auto const& xDenWeights    = weights[static_cast<int>(densityCentering[0])][0];
@@ -465,10 +468,10 @@ namespace core
             auto const& zZFluxStartIndex = startIndex[static_cast<int>(fluxCentering[2][2])][0];
             auto const& zZFluxWeights    = weights[static_cast<int>(fluxCentering[2][2])][0];
 
-            auto const partRho   = particle.weight * coef;
-            auto const xPartFlux = particle.v[0] * particle.weight * coef;
-            auto const yPartFlux = particle.v[1] * particle.weight * coef;
-            auto const zPartFlux = particle.v[2] * particle.weight * coef;
+            auto const partRho   = particle.weight * coef / cellVolume;
+            auto const xPartFlux = particle.v[0] * particle.weight * coef / cellVolume;
+            auto const yPartFlux = particle.v[1] * particle.weight * coef / cellVolume;
+            auto const zPartFlux = particle.v[2] * particle.weight * coef / cellVolume;
 
             auto order_size = xDenWeights.size();
             for (auto ix = 0u; ix < order_size; ++ix)
@@ -656,15 +659,18 @@ namespace core
             // component, we use Interpol to actually perform the interpolation.
             // the trick here is that the StartIndex and weights have only been calculated
             // twice, and not for each E,B component.
+            auto dl         = layout.meshSize();
+            auto cellVolume = std::accumulate(std::begin(dl), std::end(dl), 1.,
+                                              std::multiplies<typename decltype(dl)::value_type>());
+
             for (auto currPart = begin; currPart != end; ++currPart)
             {
                 // TODO #3375
                 indexAndWeightPrimal(*currPart);
                 indexAndWeightDual(*currPart);
 
-
                 particleToMesh_(density, xFlux, yFlux, zFlux, densityCentering, fluxCentering,
-                                *currPart, startIndex_, weights_, coef);
+                                *currPart, startIndex_, weights_, cellVolume, coef);
             }
         }
 

--- a/src/phare/phare.cpp
+++ b/src/phare/phare.cpp
@@ -1,11 +1,11 @@
 
 
+
 #include "initializer/data_provider.h"
 #include "initializer/data_provider.h"
 #include "initializer/python_data_provider.h"
 #include "simulator/simulator.h"
 #include "core/utilities/algorithm.h"
-
 #include <iostream>
 
 

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -4,6 +4,7 @@
 #include "initializer/python_data_provider.h"
 // intended blank HAVE_SYS_TIMES_His defined by samrai
 #include "amr/types/amr_types.h"
+
 #include "core/models/physical_state.h"
 #include "core/data/electromag/electromag.h"
 #include "core/data/grid/gridlayout.h"
@@ -14,8 +15,16 @@
 #include "core/data/ndarray/ndarray_vector.h"
 #include "core/data/particles/particle_array.h"
 #include "core/data/vecfield/vecfield.h"
+#include "core/models/physical_state.h"
+#include "core/utilities/meta/meta_utilities.h"
+#include "core/utilities/algorithm.h"
+
 #include "initializer/data_provider.h"
+
 #include "amr/messengers/messenger_factory.h"
+
+#include "solver/level_initializer/level_initializer.h"
+#include "solver/level_initializer/level_initializer_factory.h"
 #include "solver/multiphysics_integrator.h"
 #include "solver/physical_models/hybrid_model.h"
 #include "solver/physical_models/mhd_model.h"
@@ -23,8 +32,7 @@
 #include "solver/solvers/solver.h"
 #include "solver/solvers/solver_mhd.h"
 #include "solver/solvers/solver_ppc.h"
-#include "core/utilities/algorithm.h"
-#include "core/utilities/meta/meta_utilities.h"
+
 
 #include <SAMRAI/algs/TimeRefinementIntegrator.h>
 #include <SAMRAI/geom/CartesianGridGeometry.h>
@@ -328,6 +336,7 @@ struct PHARE_Types
     using MHDModel_t  = PHARE::solver::MHDModel<GridLayout_t, VecField_t, PHARE::amr::SAMRAI_Types>;
     using SolverPPC_t = PHARE::solver::SolverPPC<HybridModel_t, PHARE::amr::SAMRAI_Types>;
     using SolverMHD_t = PHARE::solver::SolverMHD<MHDModel_t, PHARE::amr::SAMRAI_Types>;
+    using LevelInitializerFactory_t = PHARE::solver::LevelInitializerFactory<HybridModel_t>;
 };
 
 
@@ -361,10 +370,13 @@ private:
     using SolverMHD = typename PHARETypes::SolverMHD_t;
     using SolverPPC = typename PHARETypes::SolverPPC_t;
 
+    using LevelIntializerFactory = typename PHARETypes::LevelInitializerFactory_t;
+
     using MessengerFactory = PHARE::amr::MessengerFactory<MHDModel, HybridModel, IPhysicalModel>;
 
     using MultiPhysicsIntegrator
-        = PHARE::solver::MultiPhysicsIntegrator<MessengerFactory, SAMRAITypes>;
+        = PHARE::solver::MultiPhysicsIntegrator<MessengerFactory, LevelIntializerFactory,
+                                                SAMRAITypes>;
 
 public:
     Simulator(PHARE::initializer::PHAREDict dict)

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -10,6 +10,9 @@ set( SOURCES_INC
      physical_models/mhd_model.h
      multiphysics_integrator.h
      messenger_registration.h
+     level_initializer/level_initializer.h
+     level_initializer/hybrid_level_initializer.h
+     level_initializer/level_initializer_factory.h
    )
 set( SOURCES_CPP
      solvers/solver.cpp

--- a/src/solver/level_initializer/hybrid_level_initializer.h
+++ b/src/solver/level_initializer/hybrid_level_initializer.h
@@ -1,0 +1,91 @@
+
+
+#ifndef PHARE_HYBRID_LEVEL_INITIALIZE_H
+#define PHARE_HYBRID_LEVEL_INITIALIZE_H
+
+#include "amr/messengers/hybrid_messenger.h"
+#include "amr/messengers/messenger.h"
+#include "amr/resources_manager/amr_utils.h"
+#include "core/numerics/interpolator/interpolator.h"
+#include "core/numerics/moments/moments.h"
+#include "level_initializer.h"
+#include "physical_models/hybrid_model.h"
+#include "physical_models/physical_model.h"
+
+namespace PHARE
+{
+namespace solver
+{
+    template<typename HybridModel>
+    class HybridLevelInitializer : public LevelInitializer<typename HybridModel::amr_types>
+    {
+        using amr_types                    = typename HybridModel::amr_types;
+        using hierarchy_t                  = typename amr_types::hierarchy_t;
+        using level_t                      = typename amr_types::level_t;
+        using patch_t                      = typename amr_types::patch_t;
+        using IPhysicalModelT              = IPhysicalModel<amr_types>;
+        using IMessengerT                  = amr::IMessenger<IPhysicalModelT>;
+        using GridLayoutT                  = typename HybridModel::gridLayout_type;
+        static constexpr auto dimension    = GridLayoutT::dimension;
+        static constexpr auto interp_order = GridLayoutT::interp_order;
+
+
+        inline bool isRootLevel(int levelNumber) const { return levelNumber == 0; }
+
+    public:
+        virtual void initialize(std::shared_ptr<hierarchy_t> const& hierarchy, int levelNumber,
+                                std::shared_ptr<level_t> const& oldLevel, IPhysicalModelT& model,
+                                amr::IMessenger<IPhysicalModelT>& messenger, double initDataTime,
+                                bool isRegridding) const override
+        {
+            core::Interpolator<dimension, interp_order> interpolate_;
+            auto& hybridModel = static_cast<HybridModel&>(model);
+            auto& level       = amr_types::getLevel(*hierarchy, levelNumber);
+
+            if (isRootLevel(levelNumber))
+            {
+                model.initialize(level);
+                messenger.fillRootGhosts(model, level, initDataTime);
+            }
+
+            else
+            {
+                if (isRegridding)
+                {
+                    messenger.regrid(hierarchy, levelNumber, oldLevel, model, initDataTime);
+                }
+                else
+                {
+                    messenger.initLevel(model, level, initDataTime);
+                }
+            }
+
+            // now all particles are here
+
+            for (auto& patch : level)
+            {
+                auto& ions             = hybridModel.state.ions;
+                auto& resourcesManager = hybridModel.resourcesManager;
+                auto dataOnPatch       = resourcesManager->setOnPatch(*patch, ions);
+                auto layout            = amr::layoutFromPatch<GridLayoutT>(*patch);
+
+
+                core::resetMoments(ions);
+                core::depositParticles(ions, layout, interpolate_, core::DomainDeposit{});
+                core::depositParticles(ions, layout, interpolate_, core::PatchGhostDeposit{});
+
+
+                if (!isRootLevel(levelNumber))
+                {
+                    core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
+                }
+
+                ions.computeDensity();
+                ions.computeBulkVelocity();
+            }
+        }
+    };
+} // namespace solver
+} // namespace PHARE
+
+#endif

--- a/src/solver/level_initializer/level_initializer.h
+++ b/src/solver/level_initializer/level_initializer.h
@@ -1,0 +1,31 @@
+#ifndef PHARE_LEVEL_INITIALIZER_H
+#define PHARE_LEVEL_INITIALIZER_H
+
+#include "amr/messengers/messenger.h"
+#include "physical_models/physical_model.h"
+
+namespace PHARE
+{
+namespace solver
+{
+    template<typename AMRTypes>
+    class LevelInitializer
+    {
+        using level_t         = typename AMRTypes::level_t;
+        using patch_t         = typename AMRTypes::patch_t;
+        using hierarchy_t     = typename AMRTypes::hierarchy_t;
+        using IPhysicalModelT = IPhysicalModel<AMRTypes>;
+        using IMessengerT     = amr::IMessenger<IPhysicalModelT>;
+
+    public:
+        virtual void initialize(std::shared_ptr<hierarchy_t> const& hierarchy, int levelNumber,
+                                std::shared_ptr<level_t> const& oldLevel, IPhysicalModelT& model,
+                                amr::IMessenger<IPhysicalModelT>& messenger, double initDataTime,
+                                bool isRegridding) const = 0;
+
+
+        virtual ~LevelInitializer() {}
+    };
+} // namespace solver
+} // namespace PHARE
+#endif

--- a/src/solver/level_initializer/level_initializer_factory.h
+++ b/src/solver/level_initializer/level_initializer_factory.h
@@ -1,0 +1,35 @@
+#ifndef PHARE_LEVEL_INITIALIZER_FACTORY_H
+#define PHARE_LEVEL_INITIALIZER_FACTORY_H
+
+#include "hybrid_level_initializer.h"
+#include "level_initializer.h"
+
+#include <memory>
+#include <string>
+
+namespace PHARE
+{
+namespace solver
+{
+    template<typename HybridModel>
+    class LevelInitializerFactory
+    {
+        using AMRTypes = typename HybridModel::amr_types;
+
+    public:
+        static std::unique_ptr<LevelInitializer<AMRTypes>> create(std::string modelName)
+        {
+            if (modelName == "HybridModel")
+            {
+                return std::make_unique<HybridLevelInitializer<HybridModel>>();
+            }
+            return nullptr;
+        }
+    };
+
+} // namespace solver
+} // namespace PHARE
+
+
+
+#endif

--- a/src/solver/physical_models/hybrid_model.h
+++ b/src/solver/physical_models/hybrid_model.h
@@ -26,6 +26,7 @@ namespace solver
     {
     public:
         using type_list = PHARE::core::type_list<GridLayoutT, Electromag, Ions, AMR_Types>;
+        using amr_types = AMR_Types;
         using patch_t   = typename AMR_Types::patch_t;
         using level_t   = typename AMR_Types::level_t;
         static const std::string model_name;

--- a/tests/amr/multiphysics_integrator/test_main.cpp
+++ b/tests/amr/multiphysics_integrator/test_main.cpp
@@ -21,22 +21,26 @@
 #include <memory>
 
 
-#include "amr/types/amr_types.h"
 #include "core/data/electromag/electromag.h"
-#include "amr/data/field/coarsening/field_coarsen_operator.h"
-#include "amr/data/field/refine/field_refine_operator.h"
 #include "core/data/grid/gridlayout.h"
 #include "core/data/grid/gridlayout_impl.h"
 #include "core/data/ions/ions.h"
 #include "core/data/ions/particle_initializers/maxwellian_particle_initializer.h"
 #include "core/data/particles/particle_array.h"
 #include "core/data/vecfield/vecfield.h"
-#include "initializer/data_provider.h"
+
+#include "amr/types/amr_types.h"
+#include "amr/data/field/coarsening/field_coarsen_operator.h"
+#include "amr/data/field/refine/field_refine_operator.h"
 #include "amr/messengers/messenger_factory.h"
+#include "amr/resources_manager/resources_manager.h"
+
+#include "initializer/data_provider.h"
+
 #include "solver/multiphysics_integrator.h"
 #include "solver/physical_models/hybrid_model.h"
 #include "solver/physical_models/mhd_model.h"
-#include "amr/resources_manager/resources_manager.h"
+#include "solver/level_initializer/level_initializer_factory.h"
 
 #include "input_config.h"
 
@@ -335,10 +339,13 @@ public:
 
     // IonsInit1D ionsInit;
 
-    using HybridModelT = HybridModel<GridYee1D, Electromag1D, Ions1D, SAMRAI_Types>;
-    using MHDModelT    = MHDModel<GridYee1D, VecField1D, SAMRAI_Types>;
-    using SolverMHDT   = SolverMHD<MHDModelT, SAMRAI_Types>;
-    using SolverPPCT   = SolverPPC<HybridModelT, SAMRAI_Types>;
+    using HybridModelT             = HybridModel<GridYee1D, Electromag1D, Ions1D, SAMRAI_Types>;
+    using MHDModelT                = MHDModel<GridYee1D, VecField1D, SAMRAI_Types>;
+    using SolverMHDT               = SolverMHD<MHDModelT, SAMRAI_Types>;
+    using SolverPPCT               = SolverPPC<HybridModelT, SAMRAI_Types>;
+    using LevelInitializerFactoryT = LevelInitializerFactory<HybridModelT>;
+    using MessengerFactoryT
+        = MessengerFactory<MHDModelT, HybridModelT, IPhysicalModel<SAMRAI_Types>>;
 
 
     // physical models that can be used
@@ -357,8 +364,8 @@ public:
     std::shared_ptr<SAMRAI::hier::PatchHierarchy> hierarchy;
     std::shared_ptr<SAMRAI::algs::TimeRefinementIntegrator> timeRefIntegrator;
 
-    using MultiPhysicsIntegratorT = MultiPhysicsIntegrator<
-        MessengerFactory<MHDModelT, HybridModelT, IPhysicalModel<SAMRAI_Types>>, SAMRAI_Types>;
+    using MultiPhysicsIntegratorT
+        = MultiPhysicsIntegrator<MessengerFactoryT, LevelInitializerFactoryT, SAMRAI_Types>;
 
     std::shared_ptr<MultiPhysicsIntegratorT> multiphysInteg;
 

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -560,7 +560,7 @@ public:
         {
             part.iCell[0] = 19; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 1.0;
+            part.weight   = 1.0 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -568,7 +568,7 @@ public:
 
             part.iCell[0] = 20; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 0.4;
+            part.weight   = 0.4 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -576,7 +576,7 @@ public:
 
             part.iCell[0] = 20; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 0.6;
+            part.weight   = 0.6 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -587,7 +587,7 @@ public:
         {
             part.iCell[0] = 19; // AMR index
             part.delta[0] = 0.0f;
-            part.weight   = 1.0;
+            part.weight   = 1.0 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -595,7 +595,7 @@ public:
 
             part.iCell[0] = 20; // AMR index
             part.delta[0] = 0.0f;
-            part.weight   = 0.2;
+            part.weight   = 0.2 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -603,7 +603,7 @@ public:
 
             part.iCell[0] = 20; // AMR index
             part.delta[0] = 0.0f;
-            part.weight   = 0.8;
+            part.weight   = 0.8 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -611,7 +611,7 @@ public:
 
             part.iCell[0] = 21; // AMR index
             part.delta[0] = 0.0f;
-            part.weight   = 1.0;
+            part.weight   = 1.0 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -622,7 +622,7 @@ public:
         {
             part.iCell[0] = 18; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 1.0;
+            part.weight   = 1.0 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -630,7 +630,7 @@ public:
 
             part.iCell[0] = 19; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 1.0;
+            part.weight   = 1.0 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -638,7 +638,7 @@ public:
 
             part.iCell[0] = 20; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 1.0;
+            part.weight   = 1.0 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -646,7 +646,7 @@ public:
 
             part.iCell[0] = 21; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 0.1;
+            part.weight   = 0.1 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;
@@ -654,7 +654,7 @@ public:
 
             part.iCell[0] = 21; // AMR index
             part.delta[0] = 0.5f;
-            part.weight   = 0.9;
+            part.weight   = 0.9 * layout.meshSize()[0];
             part.v[0]     = +2.;
             part.v[1]     = -1.;
             part.v[2]     = +1.;


### PR DESCRIPTION

## Enhancement

The goal of the PR is to propose a consistent way to compute population moments and ion moments between each part of the code that need it.

Reminder, this is needed:

- at root level initialization
- at refined level initialization (brand new finest)
- at regridding
- when advancing the hierarchy.

The ion bulk velocity is not additive. Meaning we need to make sure ALL particles of all populations are deposited on the mesh before calculating it.

Among the four cases above, the first 3 are simular in that they only need to deposit:

- domain particles
- patch ghost particles
- level ghost particles if not on root (although on root they should be empty so not a problem)

the deposit on advanceLevel() is a bit special since the interpolation levelGhost particles need to account for both `levelGhostOld` and `levelGhostNew`while all the other three cases only take ù levelGhostOld` because they occur at AMR synchronization time points where `new` are not defined.

For the first 3 cases then, the `MultiPhysicsIntegrator` does not distinguish between root/non-root and regridding or not. It calls a LevelInitializer that does the right thing in the right order.

This way: 

- on root : model.initialize() loads the particles in the domain, and messenger.fillRootGhosts() fills the ghost cells by calling the SAMRAI schedule, all that *before* domain and patch ghost particles are deposited.
- on refined level (resp. regrid) the particles are intialized via refinement or regridding, *before* domain, patch and levelGhost particles are deposited.

## Bug Fix
the PR also fixes #78 



