### PR TITLE
Add SAMRAI generated config file include dir

### DIFF
--- a/res/cmake/samrai.cmake
+++ b/res/cmake/samrai.cmake
@@ -16,12 +16,7 @@ if (NOT SAMRAI_FOUND)
     option(ENABLE_TESTS "Enable Samrai Test" OFF ) # disable SAMRAI Test so that we can use the googletest pulled after
 
     add_subdirectory(${SAMRAI_SRCDIR})
+    include_directories(${CMAKE_BINARY_DIR}/include) # this is needed to find build-dir/include/SAMRAI/SAMRAI_config.h
   endif()
 
-endif()
-
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/build/include/SAMRAI")
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}/build/include
-)
 endif()


### PR DESCRIPTION
This is only needed when SAMRAI is used as subproject.