### PR TITLE
add average for fields and vecfields and slight refactoring

### DIFF
--- a/src/core/data/field/field.h
+++ b/src/core/data/field/field.h
@@ -78,7 +78,7 @@ namespace core
     template<typename Field>
     void average(Field const& f1, Field const& f2, Field& avg)
     {
-        std::transform(std::begin(f1), std::end(f2), std::begin(f2), std::begin(avg),
+        std::transform(std::begin(f1), std::end(f1), std::begin(f2), std::begin(avg),
                        std::plus<double>());
 
         std::transform(std::begin(avg), std::end(avg), std::begin(avg),

--- a/src/core/data/field/field.h
+++ b/src/core/data/field/field.h
@@ -71,6 +71,21 @@ namespace core
         std::string name_{"No Name"};
         PhysicalQuantity qty_;
     };
+
+
+
+
+    template<typename Field>
+    void average(Field const& f1, Field const& f2, Field& avg)
+    {
+        std::transform(std::begin(f1), std::end(f2), std::begin(f2), std::begin(avg),
+                       std::plus<double>());
+
+        std::transform(std::begin(avg), std::end(avg), std::begin(avg),
+                       [](double x) { return x * 0.5; });
+    }
+
+
 } // namespace core
 } // namespace PHARE
 #endif

--- a/src/core/data/field/field.h
+++ b/src/core/data/field/field.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <algorithm>
 
 #include "core/data/ndarray/ndarray_vector.h"
 

--- a/src/core/data/field/field.h
+++ b/src/core/data/field/field.h
@@ -76,8 +76,10 @@ namespace core
 
 
 
-    template<typename Field>
-    void average(Field const& f1, Field const& f2, Field& avg)
+    template<typename NdArrayImpl, typename PhysicalQuantity>
+    void average(Field<NdArrayImpl, PhysicalQuantity> const& f1,
+                 Field<NdArrayImpl, PhysicalQuantity> const& f2,
+                 Field<NdArrayImpl, PhysicalQuantity>& avg)
     {
         std::transform(std::begin(f1), std::end(f1), std::begin(f2), std::begin(avg),
                        std::plus<double>());

--- a/tests/core/data/field/test_main.cpp
+++ b/tests/core/data/field/test_main.cpp
@@ -168,6 +168,8 @@ TYPED_TEST(GenericField3D, physiscalQuantity)
 }
 
 
+
+
 TEST(Field1D, canBeAssigned)
 {
     auto nx = 10u;
@@ -235,6 +237,102 @@ TEST(Field3D, canBeAssigned)
     for (auto const& v : f)
     {
         EXPECT_DOUBLE_EQ(12., v);
+    }
+}
+
+
+
+
+TEST(Field1D, canBeAveraged)
+{
+    auto nx = 15u;
+    Field<NdArrayVector1D<>, HybridQuantity::Scalar> f1{"f1", HybridQuantity::Scalar::rho, nx};
+    Field<NdArrayVector1D<>, HybridQuantity::Scalar> f2{"f2", HybridQuantity::Scalar::rho, nx};
+    Field<NdArrayVector1D<>, HybridQuantity::Scalar> avg{"f2", HybridQuantity::Scalar::rho, nx};
+
+    //
+    for (auto& v : f1)
+    {
+        v = 10.;
+    }
+
+
+    for (auto& v : f2)
+    {
+        v = 20.;
+    }
+
+    PHARE::core::average(f1, f2, avg);
+
+    for (auto const& v : avg)
+    {
+        EXPECT_DOUBLE_EQ(15., v);
+    }
+}
+
+
+
+
+TEST(Field2D, canBeAveraged)
+{
+    auto nx = 15u;
+    auto ny = 25u;
+    Field<NdArrayVector2D<>, HybridQuantity::Scalar> f1{"f1", HybridQuantity::Scalar::rho, nx, ny};
+    Field<NdArrayVector2D<>, HybridQuantity::Scalar> f2{"f2", HybridQuantity::Scalar::rho, nx, ny};
+    Field<NdArrayVector2D<>, HybridQuantity::Scalar> avg{"f2", HybridQuantity::Scalar::rho, nx, ny};
+
+    //
+    for (auto& v : f1)
+    {
+        v = 10.;
+    }
+
+
+    for (auto& v : f2)
+    {
+        v = 20.;
+    }
+
+    PHARE::core::average(f1, f2, avg);
+
+    for (auto const& v : avg)
+    {
+        EXPECT_DOUBLE_EQ(15., v);
+    }
+}
+
+
+
+
+TEST(Field3D, canBeAveraged)
+{
+    auto nx = 15u;
+    auto ny = 25u;
+    auto nz = 35u;
+    Field<NdArrayVector3D<>, HybridQuantity::Scalar> f1{"f1", HybridQuantity::Scalar::rho, nx, ny,
+                                                        nz};
+    Field<NdArrayVector3D<>, HybridQuantity::Scalar> f2{"f2", HybridQuantity::Scalar::rho, nx, ny,
+                                                        nz};
+    Field<NdArrayVector3D<>, HybridQuantity::Scalar> avg{"f2", HybridQuantity::Scalar::rho, nx, ny,
+                                                         nz};
+
+    //
+    for (auto& v : f1)
+    {
+        v = 10.;
+    }
+
+
+    for (auto& v : f2)
+    {
+        v = 20.;
+    }
+
+    PHARE::core::average(f1, f2, avg);
+
+    for (auto const& v : avg)
+    {
+        EXPECT_DOUBLE_EQ(15., v);
     }
 }
 

--- a/tests/core/data/vecfield/test_main.cpp
+++ b/tests/core/data/vecfield/test_main.cpp
@@ -265,6 +265,15 @@ TEST_F(VecFieldTest, ComponentNames)
 
 
 
+
+TEST_F(VecFieldTest, VecFieldsHaveBeginAndEnd)
+{
+    for (auto const& component : B1D_) {}
+}
+
+
+
+
 TEST_F(VecFieldTest, PhysicalQuantities)
 {
     auto pairs1D = B1D_.getFieldNamesAndQuantities();


### PR DESCRIPTION
This PR adds the code that is necessary to average two fields and vecfields necessary in the predictor predictor corrector solver


![image](https://user-images.githubusercontent.com/3200931/73742849-9bca4600-474d-11ea-9145-58862f69f5d4.png)

