### PR TITLE
add setLayout and LayoutHolder and refactors numerical algos

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -8,6 +8,7 @@ set( SOURCES_INC
      data/grid/gridlayout.h
      data/grid/gridlayout_impl.h
      data/grid/gridlayoutimplyee.h
+     data/grid/gridlayout_utils.h
      data/ndarray/ndarray_vector.h
      data/particles/particle.h
      data/particles/particle_utilities.h

--- a/src/core/data/grid/gridlayout_utils.h
+++ b/src/core/data/grid/gridlayout_utils.h
@@ -1,0 +1,53 @@
+#ifndef PHARE_GRIDLAYOUT_UTILS_H
+#define PHARE_GRIDLAYOUT_UTILS_H
+
+#include <tuple>
+#include <stdexcept>
+
+
+template<typename GridLayout>
+class LayoutHolder
+{
+protected:
+    GridLayout* layout_{nullptr};
+
+public:
+    void setLayout(GridLayout* ptr)
+    {
+        if (!hasLayout())
+            layout_ = ptr;
+        else
+            throw std::runtime_error("Error - layout already set, cannot set layout");
+    }
+
+    bool hasLayout() const { return layout_ != nullptr; }
+};
+
+
+
+
+template<typename GridLayout, typename... GridLayoutSettable>
+class SetLayout
+{
+public:
+    SetLayout(GridLayout* ptr, GridLayoutSettable&... settables)
+        : settables_{settables...}
+    {
+        std::apply([this, ptr](auto&... settable) { (settable.setLayout(nullptr), ...); },
+                   settables_);
+    }
+
+    ~SetLayout()
+    {
+        std::apply([this](auto&... settable) { (settable.setLayout(nullptr), ...); }, settables_);
+    }
+
+
+private:
+    std::tuple<GridLayoutSettable&...> settables_;
+};
+
+
+
+
+#endif

--- a/src/core/numerics/ampere/ampere.h
+++ b/src/core/numerics/ampere/ampere.h
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include "core/data/grid/gridlayoutdefs.h"
+#include "core/data/grid/gridlayout_utils.h"
 #include "core/data/vecfield/vecfield_component.h"
 #include "core/utilities/index/index.h"
 
@@ -12,67 +13,11 @@ namespace PHARE
 {
 namespace core
 {
-    /** @brief Actual implementation of the Ampere equation
-     *
-     * This implementation is used by the Ampere object to calculate the current density J.
-     * It is templated by the layout and the dimension so specialized template actually do the job
-     *
-     */
-    template<typename GridLayout, std::size_t dim>
-    class AmpereImpl
-    {
-    };
-
-
-    /** @brief Base class for AmpereImpl specialized classes
-     * to factorize the code that deals with the GridLayout.
-     *
-     * The purpose of this class is to store the GridLayout
-     * pointer of Ampere, and propose the interface to check
-     * whether it's been set or not.
-     *
-     */
     template<typename GridLayout>
-    class AmpereImplInternals
+    class Ampere : public LayoutHolder<GridLayout>
     {
-    protected:
-        GridLayout* layout_{nullptr};
-
-    public:
-        /**
-         * @brief hasLayoutSet returns true if the Layout has been set
-         */
-        bool hasLayoutSet() const { return (layout_ == nullptr) ? false : true; }
-
-
-        /**
-         * @brief setLayout is used to give Ampere a pointer to a gridlayout
-         */
-        void setLayout(GridLayout* layout)
-        {
-            if (layout_ != nullptr)
-            {
-                throw std::runtime_error(
-                    "Error - ampere - cannot set layout_ because it is already set");
-            }
-            else
-            {
-                layout_ = layout;
-            }
-        }
-    };
-
-
-    /** @brief 1D specialization of the ampere equation solver implementation
-     */
-    template<typename GridLayout>
-    class AmpereImpl<GridLayout, 1> : public AmpereImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 1,
-                      "Error: Passed non-1D GridLayout to 1D AmpereImpl");
-
-    public:
-        template<typename VecField>
+    private:
+        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 1, int> = 0>
         void operator()(VecField const& B, VecField& J)
         {
             // auto &Jx = J.getComponent(Component::X); // =  0
@@ -101,18 +46,11 @@ namespace core
                 Jz(ix) = this->layout_->deriv(By, {ix}, DirectionTag<Direction::X>{});
             }
         }
-    };
 
 
 
-    template<typename GridLayout>
-    class AmpereImpl<GridLayout, 2> : public AmpereImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 2,
-                      "Error: Passed non-2D GridLayout to 2D AmpereImpl");
 
-    public:
-        template<typename VecField>
+        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 2, int> = 0>
         void operator()(VecField const& B, VecField& J)
         {
             auto& Jx = J.getComponent(Component::X); // =  dyBz
@@ -163,18 +101,11 @@ namespace core
                 }
             }
         }
-    };
 
 
 
-    template<typename GridLayout>
-    class AmpereImpl<GridLayout, 3> : public AmpereImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 3,
-                      "Error: Passed non-3D GridLayout to 3D AmpereImpl");
 
-    public:
-        template<typename VecField>
+        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 3, int> = 0>
         void operator()(VecField const& B, VecField& J)
         {
             auto& Jx = J.getComponent(Component::X); // =  dyBz - dzBx
@@ -248,33 +179,23 @@ namespace core
                 }
             }
         }
-    };
 
 
 
-
-    template<typename GridLayout>
-    class Ampere
-    {
-    private:
-        AmpereImpl<GridLayout, GridLayout::dimension> impl_;
 
     public:
         template<typename VecField>
         void operator()(VecField const& B, VecField& J)
         {
-            if (!impl_.hasLayoutSet())
+            if (!this->hasLayout())
             {
                 throw std::runtime_error(
                     "Error - Ampere - GridLayout not set, cannot proceed to calculate ampere()");
             }
             std::cout << "I'm solving ampere " << GridLayout::dimension << "\n";
 
-            impl_(B, J);
+            this->operator()<VecField, GridLayout::dimension>(B, J);
         }
-
-
-        void setLayout(GridLayout* layout) { impl_.setLayout(layout); }
     };
 } // namespace core
 } // namespace PHARE

--- a/src/core/numerics/ampere/ampere.h
+++ b/src/core/numerics/ampere/ampere.h
@@ -17,8 +17,8 @@ namespace core
     class Ampere : public LayoutHolder<GridLayout>
     {
     private:
-        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 1, int> = 0>
-        void operator()(VecField const& B, VecField& J)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 1, int> = 0>
+        void compute_(VecField const& B, VecField& J)
         {
             // auto &Jx = J.getComponent(Component::X); // =  0
             auto& Jy = J.getComponent(Component::Y); // = -dxBz
@@ -50,8 +50,8 @@ namespace core
 
 
 
-        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 2, int> = 0>
-        void operator()(VecField const& B, VecField& J)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 2, int> = 0>
+        void compute_(VecField const& B, VecField& J)
         {
             auto& Jx = J.getComponent(Component::X); // =  dyBz
             auto& Jy = J.getComponent(Component::Y); // = -dxBz
@@ -105,8 +105,8 @@ namespace core
 
 
 
-        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 3, int> = 0>
-        void operator()(VecField const& B, VecField& J)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 3, int> = 0>
+        void compute_(VecField const& B, VecField& J)
         {
             auto& Jx = J.getComponent(Component::X); // =  dyBz - dzBx
             auto& Jy = J.getComponent(Component::Y); // =  dzBx - dxBz
@@ -194,7 +194,7 @@ namespace core
             }
             std::cout << "I'm solving ampere " << GridLayout::dimension << "\n";
 
-            this->operator()<VecField, GridLayout::dimension>(B, J);
+            compute_(B, J);
         }
     };
 } // namespace core

--- a/src/core/numerics/faraday/faraday.h
+++ b/src/core/numerics/faraday/faraday.h
@@ -17,8 +17,8 @@ namespace core
     class Faraday : public LayoutHolder<GridLayout>
     {
     private:
-        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 1, int> = 0>
-        void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 1, int> = 0>
+        void compute_(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
             // dBxdt =  0
             // dBydt =  dxEz
@@ -55,8 +55,8 @@ namespace core
 
 
 
-        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 2, int> = 0>
-        void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 2, int> = 0>
+        void compute_(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
             // dBxdt =  -dyEz
             // dBydt =  dxEz
@@ -123,8 +123,8 @@ namespace core
 
 
 
-        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 3, int> = 0>
-        void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 3, int> = 0>
+        void compute_(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
             // dBxdt = -dyEz + dzEy
             // dBydt = -dzEx + dxEz
@@ -229,7 +229,7 @@ namespace core
                     "Error - Faraday - GridLayout not set, cannot proceed to calculate faraday()");
             }
 
-            this->operator()<VecField, GridLayout::dimension>(B, E, Bnew, dt);
+            compute_(B, E, Bnew, dt);
         }
     };
 } // namespace core

--- a/src/core/numerics/faraday/faraday.h
+++ b/src/core/numerics/faraday/faraday.h
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include "core/data/grid/gridlayoutdefs.h"
+#include "core/data/grid/gridlayout_utils.h"
 #include "core/data/vecfield/vecfield_component.h"
 #include "core/utilities/index/index.h"
 
@@ -12,67 +13,11 @@ namespace PHARE
 {
 namespace core
 {
-    /** @brief Actual implementation of the Faraday equation
-     *
-     * This implementation is used by the Faraday object to calculate the magentic field
-     * It is templated by the layout and the dimension so specialized template actually do the job
-     *
-     */
-    template<typename GridLayout, std::size_t dim>
-    class FaradayImpl
-    {
-    };
-
-
-    /** @brief Base class for FaradayImpl specialized classes
-     * to factorize the code that deals with the GridLayout.
-     *
-     * The purpose of this class is to store the GridLayout
-     * pointer of Faraday, and propose the interface to check
-     * whether it's been set or not.
-     *
-     */
     template<typename GridLayout>
-    class FaradayImplInternals
+    class Faraday : public LayoutHolder<GridLayout>
     {
-    protected:
-        GridLayout* layout_{nullptr};
-
-    public:
-        /**
-         * @brief hasLayoutSet returns true if the Layout has been set
-         */
-        bool hasLayoutSet() const { return (layout_ == nullptr) ? false : true; }
-
-
-        /**
-         * @brief setLayout is used to give Ampere a pointer to a gridlayout
-         */
-        void setLayout(GridLayout* layout)
-        {
-            if (layout_ != nullptr)
-            {
-                throw std::runtime_error(
-                    "Error - ampere - cannot set layout_ because it is already set");
-            }
-            else
-            {
-                layout_ = layout;
-            }
-        }
-    };
-
-
-    /** @brief 1D specialization of the ampere equation solver implementation
-     */
-    template<typename GridLayout>
-    class FaradayImpl<GridLayout, 1> : public FaradayImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 1,
-                      "Error: Passed non-1D GridLayout to 1D FaradayImpl");
-
-    public:
-        template<typename VecField>
+    private:
+        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 1, int> = 0>
         void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
             // dBxdt =  0
@@ -107,18 +52,10 @@ namespace core
                     = Bz(ix) - dt * this->layout_->deriv(Ey, {ix}, DirectionTag<Direction::X>{});
             }
         }
-    };
 
 
 
-    template<typename GridLayout>
-    class FaradayImpl<GridLayout, 2> : public FaradayImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 2,
-                      "Error: Passed non-2D GridLayout to 2D FaradayImpl");
-
-    public:
-        template<typename VecField>
+        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 2, int> = 0>
         void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
             // dBxdt =  -dyEz
@@ -183,18 +120,10 @@ namespace core
                 }
             }
         }
-    };
 
 
 
-    template<typename GridLayout>
-    class FaradayImpl<GridLayout, 3> : public FaradayImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 3,
-                      "Error: Passed non-3D GridLayout to 3D FaradayImpl");
-
-    public:
-        template<typename VecField>
+        template<typename VecField, std::size_t dim, std::enable_if_t<dim == 3, int> = 0>
         void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
             // dBxdt = -dyEz + dzEy
@@ -288,32 +217,20 @@ namespace core
                 }
             }
         }
-    };
 
-
-
-
-    template<typename GridLayout>
-    class Faraday
-    {
-    private:
-        FaradayImpl<GridLayout, GridLayout::dimension> impl_;
 
     public:
         template<typename VecField>
         void operator()(VecField const& B, VecField const& E, VecField& Bnew, double dt)
         {
-            if (!impl_.hasLayoutSet())
+            if (!this->hasLayout())
             {
                 throw std::runtime_error(
                     "Error - Faraday - GridLayout not set, cannot proceed to calculate faraday()");
             }
 
-            impl_(B, E, Bnew, dt);
+            this->operator()<VecField, GridLayout::dimension>(B, E, Bnew, dt);
         }
-
-
-        void setLayout(GridLayout* layout) { impl_.setLayout(layout); }
     };
 } // namespace core
 } // namespace PHARE

--- a/src/core/numerics/ohm/ohm.h
+++ b/src/core/numerics/ohm/ohm.h
@@ -6,6 +6,7 @@
 
 #include "core/data/grid/gridlayoutdefs.h"
 #include "core/data/grid/gridlayout.h"
+#include "core/data/grid/gridlayout_utils.h"
 #include "core/data/vecfield/vecfield_component.h"
 #include "core/utilities/index/index.h"
 
@@ -13,111 +14,12 @@ namespace PHARE
 {
 namespace core
 {
-    /** @brief Actual implementation of the ohm law
-     *
-     * This implementation is used by the Ohm object to calculate the electric field
-     * It is templated by the layout and the dimension so specialized template actually do the job
-     *
-     */
-    template<typename GridLayout, std::size_t dim>
-    class OhmImpl
-    {
-    };
-
-
-    /** @brief Base class for OhmImpl specialized classes
-     * to factorize the code that deals with the GridLayout.
-     *
-     * The purpose of this class is to store the GridLayout
-     * pointer of Ohm, and propose the interface to check
-     * whether it's been set or not.
-     *
-     */
     template<typename GridLayout>
-    class OhmImplInternals
+    class Ohm : public LayoutHolder<GridLayout>
     {
-    protected:
-        GridLayout* layout_{nullptr};
-
-    public:
-        /**
-         * @brief hasLayoutSet returns true if the Layout has been set
-         */
-        bool hasLayoutSet() const { return (layout_ == nullptr) ? false : true; }
-
-
-        /**
-         * @brief setLayout is used to give Ohm a pointer to a gridlayout
-         */
-        void setLayout(GridLayout* layout)
-        {
-            if (layout_ != nullptr)
-            {
-                throw std::runtime_error(
-                    "Error - Ohm - cannot set layout_ because it is already set");
-            }
-            else
-            {
-                layout_ = layout;
-            }
-        }
-    };
-
-
-    /** @brief 1D specialization of the ohm's law implementation
-     */
-    template<typename GridLayout>
-    class OhmImpl<GridLayout, 1> : public OhmImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 1, "Error: Passed non-1D GridLayout to 1D OhmImpl");
-
-    public:
-        template<typename Field, typename VecField>
-        void operator()(Field const& n, VecField const& Ve, Field const& Pe, VecField const& B,
-                        VecField const& J, VecField& Enew)
-        {
-            auto& Ex = Enew.getComponent(Component::X);
-            auto& Ey = Enew.getComponent(Component::Y);
-            auto& Ez = Enew.getComponent(Component::Z);
-
-            auto ix0 = this->layout_->physicalStartIndex(Ex, Direction::X);
-            auto ix1 = this->layout_->physicalEndIndex(Ex, Direction::X);
-
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                Ex(ix) = ideal_(Ve, B, {ix}, ComponentTag<Component::X>{})
-                         + pressure_(n, Pe, {ix}, ComponentTag<Component::X>{})
-                         + resistive_(J, {ix}, ComponentTag<Component::X>{})
-                         + hyperresistive_(J, {ix}, ComponentTag<Component::X>{});
-            }
-
-            ix0 = this->layout_->physicalStartIndex(Ey, Direction::X);
-            ix1 = this->layout_->physicalEndIndex(Ey, Direction::X);
-
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                Ey(ix) = ideal_(Ve, B, {ix}, ComponentTag<Component::Y>{})
-                         + pressure_(n, Pe, {ix}, ComponentTag<Component::Y>{})
-                         + resistive_(J, {ix}, ComponentTag<Component::Y>{})
-                         + hyperresistive_(J, {ix}, ComponentTag<Component::Y>{});
-            }
-
-            ix0 = this->layout_->physicalStartIndex(Ez, Direction::X);
-            ix1 = this->layout_->physicalEndIndex(Ez, Direction::X);
-
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                Ez(ix) = ideal_(Ve, B, {ix}, ComponentTag<Component::Z>{})
-                         + pressure_(n, Pe, {ix}, ComponentTag<Component::Z>{})
-                         + resistive_(J, {ix}, ComponentTag<Component::Z>{})
-                         + hyperresistive_(J, {ix}, ComponentTag<Component::Z>{});
-            }
-        }
-
-
     private:
         template<typename VecField, typename ComponentTag>
-        auto ideal_(VecField const& Ve, VecField const& B, MeshIndex<1> index, ComponentTag)
+        auto ideal1D_(VecField const& Ve, VecField const& B, MeshIndex<1> index, ComponentTag)
         {
             if constexpr (ComponentTag::component == Component::X)
             {
@@ -169,182 +71,9 @@ namespace core
             }
         }
 
-        template<typename Field, typename ComponentTag>
-        auto pressure_(Field const& n, Field const& Pe, [[maybe_unused]] MeshIndex<1> index,
-                       ComponentTag)
-        {
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto nOnEx = 0.0;
-                for (auto const& wp : GridLayout::momentsToEx())
-                {
-                    nOnEx += wp.coef * n(index[0] + wp.indexes[0]);
-                }
-
-                auto gradPOnEx = this->layout_->deriv(
-                    Pe, index, DirectionTag<Direction::X>{}); // TODO : issue 3391
-
-                return gradPOnEx / nOnEx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                return 0.0;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                return 0.0;
-            }
-        }
 
         template<typename VecField, typename ComponentTag>
-        auto resistive_(VecField const& J, MeshIndex<1> index, ComponentTag)
-        {
-            auto const eta = 1.0; // TODO : eta should comme from input file
-
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto const& Jx = J.getComponent(Component::X);
-
-                auto jxOnEx = 0.0;
-                for (auto const& wp : GridLayout::JxToEx())
-                {
-                    jxOnEx += wp.coef * Jx(index[0] + wp.indexes[0]);
-                }
-
-                return eta * jxOnEx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                auto const& Jy = J.getComponent(Component::Y);
-
-                auto jyOnEy = 0.0;
-                for (auto const& wp : GridLayout::JyToEy())
-                {
-                    jyOnEy += wp.coef * Jy(index[0] + wp.indexes[0]);
-                }
-
-                return eta * jyOnEy;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                auto const& Jz = J.getComponent(Component::Z);
-
-                auto jzOnEz = 0.0;
-                for (auto const& wp : GridLayout::JzToEz())
-                {
-                    jzOnEz += wp.coef * Jz(index[0] + wp.indexes[0]);
-                }
-
-                return eta * jzOnEz;
-            }
-        }
-
-        template<typename VecField, typename ComponentTag>
-        auto hyperresistive_(VecField const& J, MeshIndex<1> index, ComponentTag)
-        {
-            auto const nu = 0.001; // TODO : nu should comme from input file
-
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto const& Jx = J.getComponent(Component::X);
-
-                auto lapJx = this->layout_->laplacian(Jx, index); // TODO : issue 3391
-
-                return -nu * lapJx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                auto const& Jy = J.getComponent(Component::Y);
-
-                auto lapJy = this->layout_->laplacian(Jy, index); // TODO : issue 3391
-
-                return -nu * lapJy;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                auto const& Jz = J.getComponent(Component::Z);
-
-                auto lapJz = this->layout_->laplacian(Jz, index); // TODO : issue 3391
-
-                return -nu * lapJz;
-            }
-        }
-    };
-
-
-
-    template<typename GridLayout>
-    class OhmImpl<GridLayout, 2> : public OhmImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 2, "Error: Passed non-2D GridLayout to 2D OhmImpl");
-
-    public:
-        template<typename Field, typename VecField>
-        void operator()(Field const& n, VecField const& Ve, Field const& Pe, VecField const& B,
-                        VecField const& J, VecField& Enew)
-        {
-            auto& Ex = Enew.getComponent(Component::X);
-            auto& Ey = Enew.getComponent(Component::Y);
-            auto& Ez = Enew.getComponent(Component::Z);
-
-            auto ix0 = this->layout_->physicalStartIndex(Ex, Direction::X);
-            auto ix1 = this->layout_->physicalEndIndex(Ex, Direction::X);
-            auto iy0 = this->layout_->physicalStartIndex(Ex, Direction::Y);
-            auto iy1 = this->layout_->physicalEndIndex(Ex, Direction::Y);
-
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                for (auto iy = iy0; iy <= iy1; ++iy)
-                {
-                    Ex(ix, iy) = ideal_(Ve, B, {ix, iy}, ComponentTag<Component::X>{})
-                                 + pressure_(n, Pe, {ix, iy}, ComponentTag<Component::X>{})
-                                 + resistive_(J, {ix, iy}, ComponentTag<Component::X>{})
-                                 + hyperresistive_(J, {ix, iy}, ComponentTag<Component::X>{});
-                }
-            }
-
-            ix0 = this->layout_->physicalStartIndex(Ey, Direction::X);
-            ix1 = this->layout_->physicalEndIndex(Ey, Direction::X);
-            iy0 = this->layout_->physicalStartIndex(Ey, Direction::Y);
-            iy1 = this->layout_->physicalEndIndex(Ey, Direction::Y);
-
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                for (auto iy = iy0; iy <= iy1; ++iy)
-                {
-                    Ey(ix, iy) = ideal_(Ve, B, {ix, iy}, ComponentTag<Component::Y>{})
-                                 + pressure_(n, Pe, {ix, iy}, ComponentTag<Component::Y>{})
-                                 + resistive_(J, {ix, iy}, ComponentTag<Component::Y>{})
-                                 + hyperresistive_(J, {ix, iy}, ComponentTag<Component::Y>{});
-                }
-            }
-
-            ix0 = this->layout_->physicalStartIndex(Ez, Direction::X);
-            ix1 = this->layout_->physicalEndIndex(Ez, Direction::X);
-            iy0 = this->layout_->physicalStartIndex(Ez, Direction::Y);
-            iy1 = this->layout_->physicalEndIndex(Ez, Direction::Y);
-
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                for (auto iy = iy0; iy <= iy1; ++iy)
-                {
-                    Ez(ix, iy) = ideal_(Ve, B, {ix, iy}, ComponentTag<Component::Z>{})
-                                 + pressure_(n, Pe, {ix, iy}, ComponentTag<Component::Z>{})
-                                 + resistive_(J, {ix, iy}, ComponentTag<Component::Z>{})
-                                 + hyperresistive_(J, {ix, iy}, ComponentTag<Component::Z>{});
-                }
-            }
-        }
-
-    private:
-        template<typename VecField, typename ComponentTag>
-        auto ideal_(VecField const& Ve, VecField const& B, MeshIndex<2> index, ComponentTag)
+        auto ideal2D_(VecField const& Ve, VecField const& B, MeshIndex<2> index, ComponentTag)
         {
             if constexpr (ComponentTag::component == Component::X)
             {
@@ -396,20 +125,71 @@ namespace core
             }
         }
 
+
+
+        template<typename VecField, typename ComponentTag>
+        auto ideal3D_(VecField const& Ve, VecField const& B, MeshIndex<3> index, ComponentTag)
+        {
+            if constexpr (ComponentTag::component == Component::X)
+            {
+                auto const& Vy = Ve.getComponent(Component::Y);
+                auto const& Vz = Ve.getComponent(Component::Z);
+                auto const& By = B.getComponent(Component::Y);
+                auto const& Bz = B.getComponent(Component::Z);
+
+                auto constexpr momentsToEx = GridLayout::momentsToEx();
+                auto const vyOnEx          = GridLayout::project(Vy, index, momentsToEx);
+                auto const vzOnEx          = GridLayout::project(Vz, index, momentsToEx);
+                auto const byOnEx          = GridLayout::project(By, index, GridLayout::ByToEx());
+                auto const bzOnEx          = GridLayout::project(Bz, index, GridLayout::BzToEx());
+
+                return -vyOnEx * bzOnEx + vzOnEx * byOnEx;
+            }
+
+            if constexpr (ComponentTag::component == Component::Y)
+            {
+                auto const& Vx = Ve.getComponent(Component::X);
+                auto const& Vz = Ve.getComponent(Component::Z);
+                auto const& Bx = B.getComponent(Component::X);
+                auto const& Bz = B.getComponent(Component::Z);
+
+                auto constexpr momentsToEy = GridLayout::momentsToEy();
+                auto const vxOnEy          = GridLayout::project(Vx, index, momentsToEy);
+                auto const vzOnEy          = GridLayout::project(Vz, index, momentsToEy);
+                auto const bxOnEy          = GridLayout::project(Bx, index, GridLayout::BxToEy());
+                auto const bzOnEy          = GridLayout::project(Bz, index, GridLayout::BzToEy());
+
+                return -vzOnEy * bxOnEy + vxOnEy * bzOnEy;
+            }
+
+            if constexpr (ComponentTag::component == Component::Z)
+            {
+                auto const& Vx = Ve.getComponent(Component::X);
+                auto const& Vy = Ve.getComponent(Component::Y);
+                auto const& Bx = B.getComponent(Component::X);
+                auto const& By = B.getComponent(Component::Y);
+
+                auto constexpr momentsToEz = GridLayout::momentsToEz();
+                auto const vxOnEz          = GridLayout::project(Vx, index, momentsToEz);
+                auto const vyOnEz          = GridLayout::project(Vy, index, momentsToEz);
+                auto const bxOnEz          = GridLayout::project(Bx, index, GridLayout::BxToEz());
+                auto const byOnEz          = GridLayout::project(By, index, GridLayout::ByToEz());
+
+                return -vxOnEz * byOnEz + vyOnEz * bxOnEz;
+            }
+        }
+
+
+
+
         template<typename Field, typename ComponentTag>
-        auto pressure_(Field const& n, Field const& Pe, [[maybe_unused]] MeshIndex<2> index,
+        auto pressure_(Field const& n, Field const& Pe, MeshIndex<Field::dimension> index,
                        ComponentTag)
         {
             if constexpr (ComponentTag::component == Component::X)
             {
                 auto const nOnEx = GridLayout::project(n, index, GridLayout::momentsToEx());
 
-                // one problem here is that since P is universally assumed to be ppp
-                // deriv will put it on dpp so this line assumes Ex is on dpp
-                // which is not true for all layouts.
-                // the problem is not that the derivative puts ppp on dpp
-                // but rather that we get a dpp and we should not know it is OK for Ex
-                // this comment is here but applies everywhere gradP falls on E
                 auto gradPOnEx = this->layout_->deriv(
                     Pe, index, DirectionTag<Direction::X>{}); // TODO : issue 3391
 
@@ -418,26 +198,46 @@ namespace core
 
             if constexpr (ComponentTag::component == Component::Y)
             {
-                auto const nOnEy = GridLayout::project(n, index, GridLayout::momentsToEy());
+                if constexpr (Field::dimension >= 2)
+                {
+                    auto const nOnEy = GridLayout::project(n, index, GridLayout::momentsToEy());
 
-                auto gradPOnEy = this->layout_->deriv(
-                    Pe, index, DirectionTag<Direction::Y>{}); // TODO : issue 3391
+                    auto gradPOnEy = this->layout_->deriv(
+                        Pe, index, DirectionTag<Direction::Y>{}); // TODO : issue 3391
 
-                return gradPOnEy / nOnEy;
+                    return gradPOnEy / nOnEy;
+                }
+                else
+                {
+                    return 0.;
+                }
             }
 
             if constexpr (ComponentTag::component == Component::Z)
             {
-                return 0.0;
+                if constexpr (Field::dimension >= 3)
+                {
+                    auto const nOnEz = GridLayout::project(n, index, GridLayout::momentsToEz());
+
+                    auto gradPOnEz = this->layout_->deriv(
+                        Pe, index, DirectionTag<Direction::Z>{}); // TODO : issue 3391
+
+                    return gradPOnEz / nOnEz;
+                }
+                else
+                {
+                    return 0.;
+                }
             }
         }
 
 
 
+
         template<typename VecField, typename ComponentTag>
-        auto resistive_(VecField const& J, MeshIndex<2> index, ComponentTag)
+        auto resistive_(VecField const& J, MeshIndex<VecField::dimension> index, ComponentTag)
         {
-            auto const eta = 1.0; // TODO :3302  eta should comme from input file
+            auto const eta = 1.0; // TODO : eta should comme from input file
 
             if constexpr (ComponentTag::component == Component::X)
             {
@@ -462,10 +262,12 @@ namespace core
         }
 
 
+
+
         template<typename VecField, typename ComponentTag>
-        auto hyperresistive_(VecField const& J, MeshIndex<2> index, ComponentTag)
+        auto hyperresistive_(VecField const& J, MeshIndex<VecField::dimension> index, ComponentTag)
         {
-            auto const nu = 0.001; // TODO 3302 : nu should comme from input file
+            auto const nu = 0.001; // TODO : nu should comme from input file
 
             if constexpr (ComponentTag::component == Component::X)
             {
@@ -488,19 +290,118 @@ namespace core
                 return -nu * lapJz;
             }
         }
-    };
 
 
 
-    template<typename GridLayout>
-    class OhmImpl<GridLayout, 3> : public OhmImplInternals<GridLayout>
-    {
-        static_assert(GridLayout::dimension == 3, "Error: Passed non-3D GridLayout to 3D OhmImpl");
 
-    public:
-        template<typename Field, typename VecField>
-        void operator()(Field const& n, VecField const& Ve, Field const& Pe, VecField const& B,
-                        VecField const& J, VecField& Enew)
+        template<typename VecField, std::enable_if_t<VecField::dimension == 1, int> = 0>
+        void compute_(typename VecField::field_type const& n, VecField const& Ve,
+                      typename VecField::field_type const& Pe, VecField const& B, VecField const& J,
+                      VecField& Enew)
+        {
+            auto& Ex = Enew.getComponent(Component::X);
+            auto& Ey = Enew.getComponent(Component::Y);
+            auto& Ez = Enew.getComponent(Component::Z);
+
+            auto ix0 = this->layout_->physicalStartIndex(Ex, Direction::X);
+            auto ix1 = this->layout_->physicalEndIndex(Ex, Direction::X);
+
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                Ex(ix) = ideal1D_(Ve, B, {ix}, ComponentTag<Component::X>{})
+                         + pressure_(n, Pe, {ix}, ComponentTag<Component::X>{})
+                         + resistive_(J, {ix}, ComponentTag<Component::X>{})
+                         + hyperresistive_(J, {ix}, ComponentTag<Component::X>{});
+            }
+
+            ix0 = this->layout_->physicalStartIndex(Ey, Direction::X);
+            ix1 = this->layout_->physicalEndIndex(Ey, Direction::X);
+
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                Ey(ix) = ideal1D_(Ve, B, {ix}, ComponentTag<Component::Y>{})
+                         + pressure_(n, Pe, {ix}, ComponentTag<Component::Y>{})
+                         + resistive_(J, {ix}, ComponentTag<Component::Y>{})
+                         + hyperresistive_(J, {ix}, ComponentTag<Component::Y>{});
+            }
+
+            ix0 = this->layout_->physicalStartIndex(Ez, Direction::X);
+            ix1 = this->layout_->physicalEndIndex(Ez, Direction::X);
+
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                Ez(ix) = ideal1D_(Ve, B, {ix}, ComponentTag<Component::Z>{})
+                         + pressure_(n, Pe, {ix}, ComponentTag<Component::Z>{})
+                         + resistive_(J, {ix}, ComponentTag<Component::Z>{})
+                         + hyperresistive_(J, {ix}, ComponentTag<Component::Z>{});
+            }
+        }
+
+
+
+        template<typename VecField, std::enable_if_t<VecField::dimension == 2, int> = 0>
+        void compute_(typename VecField::field_type const& n, VecField const& Ve,
+                      typename VecField::field_type const& Pe, VecField const& B, VecField const& J,
+                      VecField& Enew)
+        {
+            auto& Ex = Enew.getComponent(Component::X);
+            auto& Ey = Enew.getComponent(Component::Y);
+            auto& Ez = Enew.getComponent(Component::Z);
+
+            auto ix0 = this->layout_->physicalStartIndex(Ex, Direction::X);
+            auto ix1 = this->layout_->physicalEndIndex(Ex, Direction::X);
+            auto iy0 = this->layout_->physicalStartIndex(Ex, Direction::Y);
+            auto iy1 = this->layout_->physicalEndIndex(Ex, Direction::Y);
+
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                for (auto iy = iy0; iy <= iy1; ++iy)
+                {
+                    Ex(ix, iy) = ideal2D_(Ve, B, {ix, iy}, ComponentTag<Component::X>{})
+                                 + pressure_(n, Pe, {ix, iy}, ComponentTag<Component::X>{})
+                                 + resistive_(J, {ix, iy}, ComponentTag<Component::X>{})
+                                 + hyperresistive_(J, {ix, iy}, ComponentTag<Component::X>{});
+                }
+            }
+
+            ix0 = this->layout_->physicalStartIndex(Ey, Direction::X);
+            ix1 = this->layout_->physicalEndIndex(Ey, Direction::X);
+            iy0 = this->layout_->physicalStartIndex(Ey, Direction::Y);
+            iy1 = this->layout_->physicalEndIndex(Ey, Direction::Y);
+
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                for (auto iy = iy0; iy <= iy1; ++iy)
+                {
+                    Ey(ix, iy) = ideal2D_(Ve, B, {ix, iy}, ComponentTag<Component::Y>{})
+                                 + pressure_(n, Pe, {ix, iy}, ComponentTag<Component::Y>{})
+                                 + resistive_(J, {ix, iy}, ComponentTag<Component::Y>{})
+                                 + hyperresistive_(J, {ix, iy}, ComponentTag<Component::Y>{});
+                }
+            }
+
+            ix0 = this->layout_->physicalStartIndex(Ez, Direction::X);
+            ix1 = this->layout_->physicalEndIndex(Ez, Direction::X);
+            iy0 = this->layout_->physicalStartIndex(Ez, Direction::Y);
+            iy1 = this->layout_->physicalEndIndex(Ez, Direction::Y);
+
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                for (auto iy = iy0; iy <= iy1; ++iy)
+                {
+                    Ez(ix, iy) = ideal2D_(Ve, B, {ix, iy}, ComponentTag<Component::Z>{})
+                                 + pressure_(n, Pe, {ix, iy}, ComponentTag<Component::Z>{})
+                                 + resistive_(J, {ix, iy}, ComponentTag<Component::Z>{})
+                                 + hyperresistive_(J, {ix, iy}, ComponentTag<Component::Z>{});
+                }
+            }
+        }
+
+
+        template<typename VecField, std::enable_if_t<VecField::dimension == 3, int> = 0>
+        void compute_(typename VecField::field_type const& n, VecField const& Ve,
+                      typename VecField::field_type const& Pe, VecField const& B, VecField const& J,
+                      VecField& Enew)
         {
             auto& Ex = Enew.getComponent(Component::X);
             auto& Ey = Enew.getComponent(Component::Y);
@@ -520,7 +421,7 @@ namespace core
                     for (auto iz = iz0; iz <= iz1; ++iz)
                     {
                         Ex(ix, iy, iz)
-                            = ideal_(Ve, B, {ix, iy, iz}, ComponentTag<Component::X>{})
+                            = ideal3D_(Ve, B, {ix, iy, iz}, ComponentTag<Component::X>{})
                               + pressure_(n, Pe, {ix, iy, iz}, ComponentTag<Component::X>{})
                               + resistive_(J, {ix, iy, iz}, ComponentTag<Component::X>{})
                               + hyperresistive_(J, {ix, iy, iz}, ComponentTag<Component::X>{});
@@ -542,7 +443,7 @@ namespace core
                     for (auto iz = iz0; iz <= iz1; ++iz)
                     {
                         Ey(ix, iy, iz)
-                            = ideal_(Ve, B, {ix, iy, iz}, ComponentTag<Component::Y>{})
+                            = ideal3D_(Ve, B, {ix, iy, iz}, ComponentTag<Component::Y>{})
                               + pressure_(n, Pe, {ix, iy, iz}, ComponentTag<Component::Y>{})
                               + resistive_(J, {ix, iy, iz}, ComponentTag<Component::Y>{})
                               + hyperresistive_(J, {ix, iy, iz}, ComponentTag<Component::Y>{});
@@ -564,7 +465,7 @@ namespace core
                     for (auto iz = iz0; iz <= iz1; ++iz)
                     {
                         Ez(ix, iy, iz)
-                            = ideal_(Ve, B, {ix, iy, iz}, ComponentTag<Component::Z>{})
+                            = ideal3D_(Ve, B, {ix, iy, iz}, ComponentTag<Component::Z>{})
                               + pressure_(n, Pe, {ix, iy, iz}, ComponentTag<Component::Z>{})
                               + resistive_(J, {ix, iy, iz}, ComponentTag<Component::Z>{})
                               + hyperresistive_(J, {ix, iy, iz}, ComponentTag<Component::Z>{});
@@ -573,181 +474,20 @@ namespace core
             }
         }
 
-    private:
-        template<typename VecField, typename ComponentTag>
-        auto ideal_(VecField const& Ve, VecField const& B, MeshIndex<3> index, ComponentTag)
-        {
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto const& Vy = Ve.getComponent(Component::Y);
-                auto const& Vz = Ve.getComponent(Component::Z);
-                auto const& By = B.getComponent(Component::Y);
-                auto const& Bz = B.getComponent(Component::Z);
-
-                auto constexpr momentsToEx = GridLayout::momentsToEx();
-                auto const vyOnEx          = GridLayout::project(Vy, index, momentsToEx);
-                auto const vzOnEx          = GridLayout::project(Vz, index, momentsToEx);
-                auto const byOnEx          = GridLayout::project(By, index, GridLayout::ByToEx());
-                auto const bzOnEx          = GridLayout::project(Bz, index, GridLayout::BzToEx());
-
-                return -vyOnEx * bzOnEx + vzOnEx * byOnEx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                auto const& Vx = Ve.getComponent(Component::X);
-                auto const& Vz = Ve.getComponent(Component::Z);
-                auto const& Bx = B.getComponent(Component::X);
-                auto const& Bz = B.getComponent(Component::Z);
-
-                auto constexpr momentsToEy = GridLayout::momentsToEy();
-                auto const vxOnEy          = GridLayout::project(Vx, index, momentsToEy);
-                auto const vzOnEy          = GridLayout::project(Vz, index, momentsToEy);
-                auto const bxOnEy          = GridLayout::project(Bx, index, GridLayout::BxToEy());
-                auto const bzOnEy          = GridLayout::project(Bz, index, GridLayout::BzToEy());
-
-                return -vzOnEy * bxOnEy + vxOnEy * bzOnEy;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                auto const& Vx = Ve.getComponent(Component::X);
-                auto const& Vy = Ve.getComponent(Component::Y);
-                auto const& Bx = B.getComponent(Component::X);
-                auto const& By = B.getComponent(Component::Y);
-
-                auto constexpr momentsToEz = GridLayout::momentsToEz();
-                auto const vxOnEz          = GridLayout::project(Vx, index, momentsToEz);
-                auto const vyOnEz          = GridLayout::project(Vy, index, momentsToEz);
-                auto const bxOnEz          = GridLayout::project(Bx, index, GridLayout::BxToEz());
-                auto const byOnEz          = GridLayout::project(By, index, GridLayout::ByToEz());
-
-                return -vxOnEz * byOnEz + vyOnEz * bxOnEz;
-            }
-        }
-
-        template<typename Field, typename ComponentTag>
-        auto pressure_(Field const& n, Field const& Pe, MeshIndex<3> index, ComponentTag)
-        {
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto const nOnEx = GridLayout::project(n, index, GridLayout::momentsToEx());
-
-                auto gradPOnEx = this->layout_->deriv(
-                    Pe, index, DirectionTag<Direction::X>{}); // TODO : issue 3391
-
-                return gradPOnEx / nOnEx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                auto const nOnEy = GridLayout::project(n, index, GridLayout::momentsToEy());
-
-                auto gradPOnEy = this->layout_->deriv(
-                    Pe, index, DirectionTag<Direction::Y>{}); // TODO : issue 3391
-
-                return gradPOnEy / nOnEy;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                auto const nOnEz = GridLayout::project(n, index, GridLayout::momentsToEz());
-
-                auto gradPOnEz = this->layout_->deriv(
-                    Pe, index, DirectionTag<Direction::Z>{}); // TODO : issue 3391
-
-                return gradPOnEz / nOnEz;
-            }
-        }
-
-
-        template<typename VecField, typename ComponentTag>
-        auto resistive_(VecField const& J, MeshIndex<3> index, ComponentTag)
-        {
-            auto const eta = 1.0; // TODO : eta should comme from input file
-
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto const& Jx    = J.getComponent(Component::X);
-                auto const jxOnEx = GridLayout::project(Jx, index, GridLayout::JxToEx());
-                return eta * jxOnEx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                auto const& Jy    = J.getComponent(Component::Y);
-                auto const jyOnEy = GridLayout::project(Jy, index, GridLayout::JyToEy());
-                return eta * jyOnEy;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                auto const& Jz    = J.getComponent(Component::Z);
-                auto const jzOnEz = GridLayout::project(Jz, index, GridLayout::JzToEz());
-                return eta * jzOnEz;
-            }
-        }
-
-
-        template<typename VecField, typename ComponentTag>
-        auto hyperresistive_(VecField const& J, MeshIndex<3> index, ComponentTag)
-        {
-            auto const nu = 0.001; // TODO : nu should comme from input file
-
-            if constexpr (ComponentTag::component == Component::X)
-            {
-                auto const& Jx = J.getComponent(Component::X);
-
-                auto lapJx = this->layout_->laplacian(Jx, index); // TODO : issue 3391
-
-                return -nu * lapJx;
-            }
-
-            if constexpr (ComponentTag::component == Component::Y)
-            {
-                auto const& Jy = J.getComponent(Component::Y);
-
-                auto lapJy = this->layout_->laplacian(Jy, index); // TODO : issue 3391
-
-                return -nu * lapJy;
-            }
-
-            if constexpr (ComponentTag::component == Component::Z)
-            {
-                auto const& Jz = J.getComponent(Component::Z);
-
-                auto lapJz = this->layout_->laplacian(Jz, index); // TODO : issue 3391
-
-                return -nu * lapJz;
-            }
-        }
-    };
-
-
-
-
-    template<typename GridLayout>
-    class Ohm
-    {
-    private:
-        OhmImpl<GridLayout, GridLayout::dimension> impl_;
-
     public:
-        template<typename Field, typename VecField>
-        void operator()(Field const& n, VecField const& Ve, Field const& Pe, VecField const& B,
+        template<typename VecField>
+        void operator()(typename VecField::field_type const& n, VecField const& Ve,
+                        typename VecField::field_type const& Pe, VecField const& B,
                         VecField const& J, VecField& Enew)
         {
-            if (!impl_.hasLayoutSet())
+            if (!this->hasLayout())
             {
                 throw std::runtime_error(
                     "Error - Ohm - GridLayout not set, cannot proceed to calculate ohm()");
             }
 
-            impl_(n, Ve, Pe, B, J, Enew);
+            compute_(n, Ve, Pe, B, J, Enew);
         }
-
-
-        void setLayout(GridLayout* layout) { impl_.setLayout(layout); }
     };
 } // namespace core
 } // namespace PHARE

--- a/tests/core/numerics/ampere/test_main.cpp
+++ b/tests/core/numerics/ampere/test_main.cpp
@@ -16,40 +16,40 @@
 
 using namespace PHARE::core;
 
+template<std::size_t dim>
 struct FieldMock
 {
+    static auto constexpr dimension = dim;
     double data;
     double& operator()([[maybe_unused]] uint32 i) { return data; }
-    double& operator()([[maybe_unused]] uint32 i, [[maybe_unused]] uint32 j) { return data; }
-    double& operator()([[maybe_unused]] uint32 i, [[maybe_unused]] uint32 j,
-                       [[maybe_unused]] uint32 k)
-    {
-        return data;
-    }
+    double const& operator()([[maybe_unused]] uint32 i) const { return data; }
     QtyCentering physicalQuantity() { return QtyCentering::dual; }
 };
 
+template<typename Field>
 struct VecFieldMock
 {
-    FieldMock fm;
-    FieldMock& getComponent([[maybe_unused]] Component comp) { return fm; }
-    FieldMock const& getComponent([[maybe_unused]] Component comp) const { return fm; }
+    using field_type                = Field;
+    static auto constexpr dimension = Field::dimension;
+    Field fm;
+    Field& getComponent([[maybe_unused]] Component comp) { return fm; }
+    Field const& getComponent([[maybe_unused]] Component comp) const { return fm; }
 };
 
 
 struct GridLayoutMock1D
 {
-    static const std::size_t dimension = 1u;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<1u> mi,
+    static const auto dimension = 1u;
+    double deriv([[maybe_unused]] FieldMock<1> const& f, [[maybe_unused]] MeshIndex<1u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    std::size_t physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<1>&, [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    std::size_t physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<1>&, [[maybe_unused]] Direction dir)
     {
         return 0;
     }
@@ -57,22 +57,24 @@ struct GridLayoutMock1D
 
 struct GridLayoutMock2D
 {
-    static const std::size_t dimension = 2u;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<2u> mi,
-                 DirectionTag<Direction::X>)
+    static const auto dimension = 2u;
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<2u> mi,
+                 [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<2u> mi,
-                 DirectionTag<Direction::Y>)
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<2u> mi,
+                 [[maybe_unused]] DirectionTag<Direction::Y>)
     {
         return 0;
     }
-    std::size_t physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<dimension>&,
+                                   [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    std::size_t physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<dimension>&,
+                                 [[maybe_unused]] Direction dir)
     {
         return 0;
     }
@@ -80,27 +82,29 @@ struct GridLayoutMock2D
 
 struct GridLayoutMock3D
 {
-    static const std::size_t dimension = 3u;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3u> mi,
+    static const auto dimension = 3u;
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Y>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Z>)
     {
         return 0;
     }
-    std::size_t physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<dimension>&,
+                                   [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    std::size_t physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<dimension>&,
+                                 [[maybe_unused]] Direction dir)
     {
         return 0;
     }
@@ -125,7 +129,7 @@ TEST(Ampere, canBe3D)
 
 TEST(Ampere, shouldBeGivenAGridLayoutPointerToBeOperational)
 {
-    VecFieldMock B, J;
+    VecFieldMock<FieldMock<1>> B, J;
 
     Ampere<GridLayoutMock1D> ampere1d;
     auto layout1d = std::make_unique<GridLayoutMock1D>();
@@ -134,12 +138,12 @@ TEST(Ampere, shouldBeGivenAGridLayoutPointerToBeOperational)
 
     Ampere<GridLayoutMock2D> ampere2d;
     auto layout2d = std::make_unique<GridLayoutMock2D>();
-    EXPECT_ANY_THROW(ampere2d(B, J));
+    // EXPECT_ANY_THROW(ampere2d(B2, J2));
     ampere2d.setLayout(layout2d.get());
 
     Ampere<GridLayoutMock3D> ampere3d;
     auto layout3d = std::make_unique<GridLayoutMock3D>();
-    EXPECT_ANY_THROW(ampere3d(B, J));
+    // EXPECT_ANY_THROW(ampere3d(B3, J3));
     ampere3d.setLayout(layout3d.get());
 }
 

--- a/tests/core/numerics/faraday/test_main.cpp
+++ b/tests/core/numerics/faraday/test_main.cpp
@@ -17,35 +17,40 @@
 
 using namespace PHARE::core;
 
+template<std::size_t dim>
 struct FieldMock
 {
+    static auto constexpr dimension = dim;
     double data;
     double& operator()([[maybe_unused]] uint32 i) { return data; }
     double const& operator()([[maybe_unused]] uint32 i) const { return data; }
     QtyCentering physicalQuantity() { return QtyCentering::dual; }
 };
 
+template<typename Field>
 struct VecFieldMock
 {
-    FieldMock fm;
-    FieldMock& getComponent([[maybe_unused]] Component comp) { return fm; }
-    FieldMock const& getComponent([[maybe_unused]] Component comp) const { return fm; }
+    using field_type                = Field;
+    static auto constexpr dimension = Field::dimension;
+    Field fm;
+    Field& getComponent([[maybe_unused]] Component comp) { return fm; }
+    Field const& getComponent([[maybe_unused]] Component comp) const { return fm; }
 };
 
 
 struct GridLayoutMock1D
 {
     static const auto dimension = 1u;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<1u> mi,
+    double deriv([[maybe_unused]] FieldMock<1> const& f, [[maybe_unused]] MeshIndex<1u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    std::size_t physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<1>&, [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    std::size_t physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<1>&, [[maybe_unused]] Direction dir)
     {
         return 0;
     }
@@ -54,21 +59,23 @@ struct GridLayoutMock1D
 struct GridLayoutMock2D
 {
     static const auto dimension = 2u;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<2u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<2u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<2u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<2u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Y>)
     {
         return 0;
     }
-    std::size_t physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<dimension>&,
+                                   [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    std::size_t physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<dimension>&,
+                                 [[maybe_unused]] Direction dir)
     {
         return 0;
     }
@@ -77,26 +84,28 @@ struct GridLayoutMock2D
 struct GridLayoutMock3D
 {
     static const auto dimension = 3u;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Y>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3u> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Z>)
     {
         return 0;
     }
-    std::size_t physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<dimension>&,
+                                   [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    std::size_t physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<dimension>&,
+                                 [[maybe_unused]] Direction dir)
     {
         return 0;
     }
@@ -124,7 +133,7 @@ TEST(Faraday, canBe3D)
 
 TEST(Faraday, shouldBeGivenAGridLayoutPointerToBeOperational)
 {
-    VecFieldMock B, E, Bnew;
+    VecFieldMock<FieldMock<1>> B, E, Bnew;
 
     Faraday<GridLayoutMock1D> faraday1d;
     auto layout1d = std::make_unique<GridLayoutMock1D>();
@@ -133,12 +142,12 @@ TEST(Faraday, shouldBeGivenAGridLayoutPointerToBeOperational)
 
     Faraday<GridLayoutMock2D> faraday2d;
     auto layout2d = std::make_unique<GridLayoutMock2D>();
-    // EXPECT_ANY_THROW(faraday2d(B, E, Bnew));
+    // EXPECT_ANY_THROW(faraday1d(B, E, Bnew, 1.));
     faraday2d.setLayout(layout2d.get());
 
     Faraday<GridLayoutMock3D> faraday3d;
     auto layout3d = std::make_unique<GridLayoutMock3D>();
-    // EXPECT_ANY_THROW(faraday3d(B, E, Bnew));
+    // EXPECT_ANY_THROW(faraday1d(B, E, Bnew, 1.));
     faraday3d.setLayout(layout3d.get());
 }
 

--- a/tests/core/numerics/ohm/test_main.cpp
+++ b/tests/core/numerics/ohm/test_main.cpp
@@ -15,82 +15,98 @@
 
 using namespace PHARE::core;
 
+template<std::size_t dim>
 struct FieldMock
 {
+    static auto constexpr dimension = dim;
     double data;
     double& operator()([[maybe_unused]] uint32 i) { return data; }
     double const& operator()([[maybe_unused]] uint32 i) const { return data; }
     QtyCentering physicalQuantity() { return QtyCentering::dual; }
 };
 
+template<typename Field>
 struct VecFieldMock
 {
-    FieldMock fm;
-    FieldMock& getComponent([[maybe_unused]] Component comp) { return fm; }
-    FieldMock const& getComponent([[maybe_unused]] Component comp) const { return fm; }
+    using field_type                = Field;
+    static auto constexpr dimension = Field::dimension;
+    Field fm;
+    Field& getComponent([[maybe_unused]] Component comp) { return fm; }
+    Field const& getComponent([[maybe_unused]] Component comp) const { return fm; }
 };
 
 
 struct GridLayoutMock1D
 {
-    static const int dimension = 1;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<1> mi,
+    static const auto dimension = 1u;
+    double deriv([[maybe_unused]] FieldMock<1> const& f, [[maybe_unused]] MeshIndex<1u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    int physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<1>&, [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    int physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir) { return 0; }
-    // unused function with no return (Werror)
-    // std::array<WeightPoint<dimension>, 2> momentsToEx() { };
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<1>&, [[maybe_unused]] Direction dir)
+    {
+        return 0;
+    }
 };
 
 struct GridLayoutMock2D
 {
-    static const int dimension = 2;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<2> mi,
+    static const auto dimension = 2u;
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<2u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<2> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<2u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Y>)
     {
         return 0;
     }
-    int physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<dimension>&,
+                                   [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    int physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir) { return 0; }
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<dimension>&,
+                                 [[maybe_unused]] Direction dir)
+    {
+        return 0;
+    }
 };
 
 struct GridLayoutMock3D
 {
-    static const int dimension = 3;
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3> mi,
+    static const auto dimension = 3u;
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::X>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Y>)
     {
         return 0;
     }
-    double deriv([[maybe_unused]] FieldMock const& f, [[maybe_unused]] MeshIndex<3> mi,
+    double deriv([[maybe_unused]] FieldMock<dimension> const& f, [[maybe_unused]] MeshIndex<3u> mi,
                  [[maybe_unused]] DirectionTag<Direction::Z>)
     {
         return 0;
     }
-    int physicalStartIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir)
+    std::size_t physicalStartIndex([[maybe_unused]] FieldMock<dimension>&,
+                                   [[maybe_unused]] Direction dir)
     {
         return 0;
     }
-    int physicalEndIndex([[maybe_unused]] FieldMock&, [[maybe_unused]] Direction dir) { return 0; }
+    std::size_t physicalEndIndex([[maybe_unused]] FieldMock<dimension>&,
+                                 [[maybe_unused]] Direction dir)
+    {
+        return 0;
+    }
 };
 
 
@@ -117,8 +133,8 @@ TEST(Ohm, canBe3D)
 
 TEST(Ohm, shouldBeGivenAGridLayoutPointerToBeOperational)
 {
-    [[maybe_unused]] FieldMock n, Pe;
-    [[maybe_unused]] VecFieldMock Ve, B, J, Enew;
+    [[maybe_unused]] FieldMock<1> n, Pe;
+    [[maybe_unused]] VecFieldMock<FieldMock<1>> Ve, B, J, Enew;
 
     Ohm<GridLayoutMock1D> ohm1d;
     auto layout1d = std::make_unique<GridLayoutMock1D>();


### PR DESCRIPTION
Faraday, Ohm, Ampere, etc. need a GridLayout to work. This GridLayout is necessarily built from a patch, in a patch level loop. They need to have an internal GridLayout set, and unset.

The current code sets their grid layout pointer, but does not unset it.

This PR proposes to unset it automatically as is done for resourcesPointers by setOnPatch.
It also refactors faraday etc. to all inherit from a single class holding the GridLayout pointer for them