### PR TITLE
Ionupdater

### DIFF
--- a/src/core/data/ions/ions.h
+++ b/src/core/data/ions/ions.h
@@ -236,7 +236,8 @@ namespace core
 
 
 
-    template<typename Ions, typename GridLayout>
+    template<typename Ions, typename GridLayout,
+             std::enable_if_t<std::decay_t<Ions>::dimension == 1, int> = 0>
     void setNansOnGhosts(Ions& ions, GridLayout const& layout)
     {
         auto ix0 = layout.physicalStartIndex(QtyCentering::primal, Direction::X);
@@ -257,6 +258,22 @@ namespace core
             set(pop, 0u, ix0); // leftGhostNodes
             set(pop, ix1 + 1, ix2 + 1);
         }
+    }
+
+
+
+
+    template<typename Ions, typename GridLayout,
+             std::enable_if_t<std::decay_t<Ions>::dimension == 2, int> = 0>
+    void setNansOnGhosts(Ions& ions, GridLayout const& layout)
+    {
+    }
+
+
+    template<typename Ions, typename GridLayout,
+             std::enable_if_t<std::decay_t<Ions>::dimension == 3, int> = 0>
+    void setNansOnGhosts(Ions& ions, GridLayout const& layout)
+    {
     }
 
 

--- a/src/core/data/ions/ions.h
+++ b/src/core/data/ions/ions.h
@@ -167,6 +167,8 @@ namespace core
             return settable;
         }
 
+
+
         //-------------------------------------------------------------------------
         //                  start the ResourcesUser interface
         //-------------------------------------------------------------------------
@@ -232,6 +234,30 @@ namespace core
                                                  // although only 1 Ions should exist.
     };
 
+
+
+    template<typename Ions, typename GridLayout>
+    void setNansOnGhosts(Ions& ions, GridLayout const& layout)
+    {
+        auto ix0 = layout.physicalStartIndex(QtyCentering::primal, Direction::X);
+        auto ix1 = layout.physicalEndIndex(QtyCentering::primal, Direction::X);
+        auto ix2 = layout.ghostEndIndex(QtyCentering::primal, Direction::X);
+
+        auto set = [](auto& pop, auto start, auto stop) {
+            for (auto i = start; i < stop; ++i)
+            {
+                pop.density()(i) = NAN;
+                for (auto& [id, type] : Components::componentMap)
+                    pop.flux().getComponent(type)(i) = NAN;
+            }
+        };
+
+        for (auto& pop : ions)
+        {
+            set(pop, 0u, ix0); // leftGhostNodes
+            set(pop, ix1 + 1, ix2 + 1);
+        }
+    }
 
 
 

--- a/src/core/data/ions/ions.h
+++ b/src/core/data/ions/ions.h
@@ -236,45 +236,40 @@ namespace core
 
 
 
-    template<typename Ions, typename GridLayout,
-             std::enable_if_t<std::decay_t<Ions>::dimension == 1, int> = 0>
+    template<typename Ions, typename GridLayout>
     void setNansOnGhosts(Ions& ions, GridLayout const& layout)
     {
-        auto ix0 = layout.physicalStartIndex(QtyCentering::primal, Direction::X);
-        auto ix1 = layout.physicalEndIndex(QtyCentering::primal, Direction::X);
-        auto ix2 = layout.ghostEndIndex(QtyCentering::primal, Direction::X);
-
-        auto set = [](auto& pop, auto start, auto stop) {
-            for (auto i = start; i < stop; ++i)
-            {
-                pop.density()(i) = NAN;
-                for (auto& [id, type] : Components::componentMap)
-                    pop.flux().getComponent(type)(i) = NAN;
-            }
-        };
-
-        for (auto& pop : ions)
+        if constexpr (Ions::dimension == 1)
         {
-            set(pop, 0u, ix0); // leftGhostNodes
-            set(pop, ix1 + 1, ix2 + 1);
+            auto ix0 = layout.physicalStartIndex(QtyCentering::primal, Direction::X);
+            auto ix1 = layout.physicalEndIndex(QtyCentering::primal, Direction::X);
+            auto ix2 = layout.ghostEndIndex(QtyCentering::primal, Direction::X);
+
+            auto set = [](auto& pop, auto start, auto stop) {
+                for (auto i = start; i < stop; ++i)
+                {
+                    pop.density()(i) = NAN;
+                    for (auto& [id, type] : Components::componentMap)
+                        pop.flux().getComponent(type)(i) = NAN;
+                }
+            };
+
+            for (auto& pop : ions)
+            {
+                set(pop, 0u, ix0); // leftGhostNodes
+                set(pop, ix1 + 1, ix2 + 1);
+            }
+        }
+        else if constexpr (Ions::dimension == 2)
+        {
+            std::cout << "test2\n";
+        }
+        else if constexpr (Ions::dimension == 3)
+        {
+            std::cout << "test 3\n";
         }
     }
 
-
-
-
-    template<typename Ions, typename GridLayout,
-             std::enable_if_t<std::decay_t<Ions>::dimension == 2, int> = 0>
-    void setNansOnGhosts(Ions& ions, GridLayout const& layout)
-    {
-    }
-
-
-    template<typename Ions, typename GridLayout,
-             std::enable_if_t<std::decay_t<Ions>::dimension == 3, int> = 0>
-    void setNansOnGhosts(Ions& ions, GridLayout const& layout)
-    {
-    }
 
 
 

--- a/src/core/numerics/ion_updater/ion_updater.h
+++ b/src/core/numerics/ion_updater/ion_updater.h
@@ -96,7 +96,7 @@ void IonUpdater<Ions, Electromag, GridLayout>::updatePopulations(Ions& ions, Ele
 template<typename Ions, typename Electromag, typename GridLayout>
 void IonUpdater<Ions, Electromag, GridLayout>::updateIons(Ions& ions, GridLayout const& layout)
 {
-    setNansOnGhosts<Ions, GridLayout>(ions, layout);
+    setNansOnGhosts(ions, layout);
     ions.computeDensity();
     ions.computeBulkVelocity();
 }

--- a/src/solver/level_initializer/hybrid_level_initializer.h
+++ b/src/solver/level_initializer/hybrid_level_initializer.h
@@ -11,6 +11,7 @@
 #include "level_initializer.h"
 #include "solver/physical_models/hybrid_model.h"
 #include "solver/physical_models/physical_model.h"
+#include "core/data/ions/ions.h"
 
 namespace PHARE
 {
@@ -80,6 +81,7 @@ namespace solver
                     core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
                 }
 
+                core::setNansOnGhosts<decltype(ions), GridLayoutT>(ions, layout);
                 ions.computeDensity();
                 ions.computeBulkVelocity();
             }

--- a/src/solver/level_initializer/hybrid_level_initializer.h
+++ b/src/solver/level_initializer/hybrid_level_initializer.h
@@ -81,7 +81,7 @@ namespace solver
                     core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
                 }
 
-                core::setNansOnGhosts<std::decay_t<decltype(ions)>, GridLayoutT>(ions, layout);
+                core::setNansOnGhosts(ions, layout);
                 ions.computeDensity();
                 ions.computeBulkVelocity();
             }

--- a/src/solver/level_initializer/hybrid_level_initializer.h
+++ b/src/solver/level_initializer/hybrid_level_initializer.h
@@ -81,7 +81,7 @@ namespace solver
                     core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
                 }
 
-                core::setNansOnGhosts<decltype(ions), GridLayoutT>(ions, layout);
+                core::setNansOnGhosts<std::decay_t<decltype(ions)>, GridLayoutT>(ions, layout);
                 ions.computeDensity();
                 ions.computeBulkVelocity();
             }

--- a/tests/core/numerics/ion_updater/test_updater.cpp
+++ b/tests/core/numerics/ion_updater/test_updater.cpp
@@ -733,8 +733,8 @@ struct IonUpdaterTest : public ::testing::Test
 
                 auto diff = std::abs(density(ix) - function(x));
 
-                EXPECT_GE(0.05, diff);
-                if (diff >= 0.05)
+                EXPECT_GE(0.07, diff);
+                if (diff >= 0.07)
                     std::cout << "actual : " << density(ix) << " prescribed : " << function(x)
                               << " diff : " << diff << " ix : " << ix << "\n";
             }

--- a/tests/core/numerics/ion_updater/test_updater.cpp
+++ b/tests/core/numerics/ion_updater/test_updater.cpp
@@ -870,9 +870,13 @@ TYPED_TEST(IonUpdaterTest, particlesUntouchedInMomentOnlyMode)
 
     IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
 
-    ionUpdater.update(
-        this->ions, this->EM, this->layout, this->dt, [this]() { this->fillIonsMomentsGhosts(); },
-        UpdaterMode::moments_only);
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
+
 
     auto& populations = this->ions.getRunTimeResourcesUserList();
 
@@ -915,9 +919,12 @@ TYPED_TEST(IonUpdaterTest, particlesAreChangedInParticlesAndMomentsMode)
 
     IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
 
-    ionUpdater.update(
-        this->ions, this->EM, this->layout, this->dt, [this]() { this->fillIonsMomentsGhosts(); },
-        UpdaterMode::particles_and_moments);
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::particles_and_moments);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
 
     auto& populations = this->ions.getRunTimeResourcesUserList();
 
@@ -936,9 +943,12 @@ TYPED_TEST(IonUpdaterTest, momentsAreChangedInParticlesAndMomentsMode)
 
     IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
 
-    ionUpdater.update(
-        this->ions, this->EM, this->layout, this->dt, [this]() { this->fillIonsMomentsGhosts(); },
-        UpdaterMode::particles_and_moments);
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::particles_and_moments);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
 
     this->checkMomentsHaveEvolved(ionsBufferCpy);
     this->checkDensityIsAsPrescribed();
@@ -953,9 +963,12 @@ TYPED_TEST(IonUpdaterTest, momentsAreChangedInMomentsOnlyMode)
 
     IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
 
-    ionUpdater.update(
-        this->ions, this->EM, this->layout, this->dt, [this]() { this->fillIonsMomentsGhosts(); },
-        UpdaterMode::moments_only);
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
 
     this->checkMomentsHaveEvolved(ionsBufferCpy);
     this->checkDensityIsAsPrescribed();
@@ -967,8 +980,12 @@ TYPED_TEST(IonUpdaterTest, thatNoNaNsExistOnPhysicalNodesMoments)
 {
     typename IonUpdaterTest<TypeParam>::IonUpdater ionUpdater{createDict()["simulation"]["pusher"]};
 
-    ionUpdater.update(
-        this->ions, this->EM, this->layout, this->dt, []() {}, UpdaterMode::moments_only);
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
 
     auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);
     auto ix1 = this->layout.physicalEndIndex(QtyCentering::primal, Direction::X);
@@ -998,9 +1015,12 @@ TYPED_TEST(IonUpdaterTest, thatUnusedMomentNodesAreNaN)
 {
     typename IonUpdaterTest<TypeParam>::IonUpdater ionUpdater{createDict()["simulation"]["pusher"]};
 
-    ionUpdater.update(
-        this->ions, this->EM, this->layout, this->dt, [this]() { this->fillIonsMomentsGhosts(); },
-        UpdaterMode::moments_only);
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
 
 
     auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);

--- a/tests/diagnostic/test_main.cpp
+++ b/tests/diagnostic/test_main.cpp
@@ -18,11 +18,11 @@ void validateFluidDump(Simulator& sim, Writer& hi5)
 
     auto checkF = [&](auto& layout, auto& path, auto tree, auto& val) {
         auto hifile = hi5.makeFile(hi5.fileString(tree));
-        checkField(hifile->file(), layout, val, path + tree);
+        checkField(hifile->file(), layout, val, path + tree, FieldDomainFilter{});
     };
     auto checkVF = [&](auto& layout, auto& path, auto tree, auto& val) {
         auto hifile = hi5.makeFile(hi5.fileString(tree));
-        checkVecField(hifile->file(), layout, val, path + tree);
+        checkVecField(hifile->file(), layout, val, path + tree, FieldDomainFilter{});
     };
 
     auto visit = [&](GridLayout& layout, std::string patchID, size_t iLevel) {
@@ -37,8 +37,7 @@ void validateFluidDump(Simulator& sim, Writer& hi5)
 
         std::string tree{"/ions/bulkVelocity"};
         auto hifile = hi5.makeFile(hi5.fileString(tree));
-        checkVecField(hifile->file(), layout, ions.velocity(), path + tree,
-                      PHARE::FieldDomainPlusNFilter{1});
+        checkVecField(hifile->file(), layout, ions.velocity(), path + tree, FieldDomainFilter{});
     };
 
     PHARE::amr::visitHierarchy<GridLayout>(*sim.hierarchy, *hybridModel.resourcesManager, visit, 0,


### PR DESCRIPTION
splits ion update in two functions because the ghost filling is a level operation and the update is within a patch.
also set unused ion ghost moments to Nan