### PR TITLE
Field refiner mishandles negatives

### DIFF
--- a/src/amr/data/field/refine/field_linear_refine.h
+++ b/src/amr/data/field/refine/field_linear_refine.h
@@ -64,22 +64,22 @@ namespace amr
             core::Point<int, dimension> coarseIndex{fineIndex};
 
             // here we perform the floating point division, and then we truncate to integer
-            coarseIndex[dirX] = static_cast<int>(
-                static_cast<double>(fineIndex[dirX] + shifts_[dirX]) / ratio_(dirX)
-                - shifts_[dirX]);
+            coarseIndex[dirX]
+                = std::floor(static_cast<double>(fineIndex[dirX] + shifts_[dirX]) / ratio_(dirX)
+                             - shifts_[dirX]);
 
             if constexpr (dimension > 1)
             {
-                coarseIndex[dirY] = static_cast<int>(
-                    static_cast<double>(fineIndex[dirY] + shifts_[dirY]) / ratio_(dirY)
-                    - shifts_[dirY]);
+                coarseIndex[dirY]
+                    = std::floor(static_cast<double>(fineIndex[dirY] + shifts_[dirY]) / ratio_(dirY)
+                                 - shifts_[dirY]);
             }
 
             if constexpr (dimension > 2)
             {
-                coarseIndex[dirZ] = static_cast<int>(
-                    static_cast<double>(fineIndex[dirZ] + shifts_[dirZ]) / ratio_(dirZ)
-                    - shifts_[dirZ]);
+                coarseIndex[dirZ]
+                    = std::floor(static_cast<double>(fineIndex[dirZ] + shifts_[dirZ]) / ratio_(dirZ)
+                                 - shifts_[dirZ]);
             }
 
             return coarseIndex;
@@ -100,7 +100,7 @@ namespace amr
          */
         core::Point<int, dimension> computeWeightIndex(core::Point<int, dimension> fineIndex) const
         {
-            core::Point<int, dimension> indexesWeights{fineIndex};
+            core::Point<int, dimension> indexesWeights{std::abs(fineIndex)};
 
             indexesWeights[dirX] %= ratio_[dirX];
 

--- a/src/core/utilities/point/point.h
+++ b/src/core/utilities/point/point.h
@@ -145,4 +145,18 @@ namespace core
 } // namespace core
 } // namespace PHARE
 
+namespace std
+{
+template<typename Type, std::size_t dim>
+PHARE::core::Point<Type, dim> abs(PHARE::core::Point<Type, dim> const& point)
+{
+    std::array<Type, dim> postive;
+    for (size_t i = 0; i < dim; ++i)
+        postive[i] = std::abs(point[i]);
+    return postive;
+}
+
+} // namespace std
+
+
 #endif


### PR DESCRIPTION

    src/amr/data/field/refine/field_linear_refine.h
    
      coarseStartIndex:: change from static_cast<int> to floor to support negative values
      computeWeightIndex::  std::abs input to prevent negative weightIndex
    
    src/core/utilities/point/point.h
    
      add support for std::abs(Point<>)
