### PR TITLE
fix SAMRAI config issue

### DIFF
--- a/res/cmake/samrai.cmake
+++ b/res/cmake/samrai.cmake
@@ -1,6 +1,6 @@
 find_package(SAMRAI CONFIG QUIET)
 if (NOT SAMRAI_FOUND)
-
+    message("SAMRAI NOT FOUND")
   if(DEFINED SAMRAI_ROOT)
     find_package(SAMRAI PATHS ${SAMRAI_ROOT} REQUIRED)
   else()
@@ -19,5 +19,7 @@ if (NOT SAMRAI_FOUND)
     unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY CACHE) # undoes what samrai does, so ctest can continue to work
     include_directories(${CMAKE_BINARY_DIR}/include) # this is needed to find build-dir/include/SAMRAI/SAMRAI_config.h
   endif()
-
 endif()
+include_directories(${SAMRAI_INCLUDE_DIRS}) # this is needed to find build-dir/include/SAMRAI/SAMRAI_config.h
+message("SAMRAI HAS BEEN FOUND")
+message(${SAMRAI_INCLUDE_DIRS})

--- a/tests/simulator/pybind.cpp
+++ b/tests/simulator/pybind.cpp
@@ -1,8 +1,8 @@
+#include "phare/include.h"
 
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 
-#include "phare/include.h"
 
 namespace py = pybind11;
 


### PR DESCRIPTION
could not find SAMRAI_config.h even though SAMRAI was found by find_package and not built as a subproject
SAMRAI_INCLUDE_DIRS variable is offered by samrai cmake files and points to where the SAMRAI_config.h is