### PR TITLE
symlink phare python directory in build directory to prevent copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,14 @@ include("${PHARE_PROJECT_DIR}/res/cmake/test.cmake")
 #*******************************************************************************
 
 if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-  file(COPY ${PHARE_PROJECT_DIR}/phare DESTINATION ${CMAKE_BINARY_DIR})
+  if(WIN32)
+
+      file(COPY ${PHARE_PROJECT_DIR}/phare DESTINATION ${CMAKE_BINARY_DIR})
+
+  else()
+    ADD_CUSTOM_TARGET(link_target ALL
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink ${PHARE_PROJECT_DIR}/phare ${CMAKE_BINARY_DIR}/phare)
+  endif()
 endif()
 
 add_subdirectory(src/core)

--- a/phare/data/wrangler.py
+++ b/phare/data/wrangler.py
@@ -2,12 +2,12 @@ class DataWrangler:
     is_primal = {"bx": True, "by": False, "bz": False, "ex": False, "ey": True, "ez": True}
 
     def __init__(self, sim, hier):
-        import phare.pharein as ph, phare.data.data_wrangler
+        import phare.pharein as ph, phare_lib.data_wrangler as data_wrangler
 
         self.dim = ph.globals.sim.dims
         self.interp = ph.globals.sim.interp_order
         self.cpp = getattr(
-            phare.data.data_wrangler,
+            data_wrangler,
             "DataWrangler_" + str(self.dim) + "_" + str(self.interp),
         )(sim, hier)
 

--- a/phare/pharein/__init__.py
+++ b/phare/pharein/__init__.py
@@ -13,7 +13,7 @@ def getSimulation():
 def populateDict():
 
     from phare.pharein.globals import sim as simulation
-    import phare.pyphare as pp
+    import phare_lib.pyphare as pp
 
     add = pp.add
     addScalarFunction = getattr(pp, 'addScalarFunction{:d}'.format(simulation.dims)+'D')

--- a/src/initializer/CMakeLists.txt
+++ b/src/initializer/CMakeLists.txt
@@ -29,7 +29,7 @@ pybind11_add_module(pyphare pyphare.cpp)
 target_link_libraries(pyphare PUBLIC phare_initializer)
 set_target_properties(pyphare
     PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/phare"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/phare_lib"
 )
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in ${CMAKE_BINARY_DIR}/phare/__init__.py @ONLY)
+#configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in ${CMAKE_BINARY_DIR}/phare/__init__.py @ONLY)

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -2,17 +2,17 @@ cmake_minimum_required (VERSION 3.3)
 
 project(phare_python3)
 
-pybind11_add_module(cpp cpp_simulator.cpp)
-target_link_libraries(cpp PUBLIC phare_simulator)
-set_target_properties(cpp
+pybind11_add_module(cpp_simulator cpp_simulator.cpp)
+target_link_libraries(cpp_simulator PUBLIC phare_simulator)
+set_target_properties(cpp_simulator
     PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/phare"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/phare_lib"
 )
 
 pybind11_add_module(data_wrangler data_wrangler.cpp)
 target_link_libraries(data_wrangler PUBLIC phare_simulator)
 set_target_properties(data_wrangler
     PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/phare/data"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/phare_lib"
 )
 

--- a/src/python3/cpp_simulator.cpp
+++ b/src/python3/cpp_simulator.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 
 namespace PHARE::pydata
 {
-PYBIND11_MODULE(cpp, m)
+PYBIND11_MODULE(cpp_simulator, m)
 {
     StaticSamraiLifeCycle::INSTANCE(); // init
 

--- a/tests/simulator/py/__init__.py
+++ b/tests/simulator/py/__init__.py
@@ -1,6 +1,6 @@
 
 
-from phare import cpp
+from phare_lib import cpp_simulator
 import phare.pharein as ph, numpy as np
 from phare.pharein import ElectronModel
 
@@ -78,7 +78,7 @@ def makeBasicModel(extra_pops={}):
 
 def create_simulator(dim, interp, **input):
 
-    cpp.reset()
+    cpp_simulator.reset()
     ph.globals.sim = None
     ph.Simulation(**basicSimulatorArgs(dim, interp, **input))
     extra_pops = {}
@@ -94,10 +94,10 @@ def create_simulator(dim, interp, **input):
     ElectronModel(closure="isothermal",Te = 0.12)
 
     ph.populateDict()
-    hier = cpp.make_hierarchy()
-    sim = cpp.make_simulator(hier)
+    hier = cpp_simulator.make_hierarchy()
+    sim = cpp_simulator.make_simulator(hier)
     sim.initialize()
-    return [cpp.make_diagnostic_manager(sim, hier), sim, hier]
+    return [cpp_simulator.make_diagnostic_manager(sim, hier), sim, hier]
 
 
 

--- a/tests/simulator/py/data_wrangler.py
+++ b/tests/simulator/py/data_wrangler.py
@@ -2,7 +2,7 @@
 #
 # formatted with black
 
-from phare import cpp
+from phare_lib import cpp_simulator
 from tests.simulator.py import create_simulator
 from phare.data.wrangler import DataWrangler
 
@@ -13,7 +13,7 @@ import unittest
 class DataWranglerTest(unittest.TestCase):
 
     def tearDown(self):
-        cpp.reset()
+        cpp_simulator.reset()
 
     def test_1d(self):
 
@@ -34,7 +34,7 @@ class DataWranglerTest(unittest.TestCase):
                 self.sim,
                 self.hier,
             )
-            cpp.reset()
+            cpp_simulator.reset()
 
 
 if __name__ == "__main__":

--- a/tests/simulator/py/refinement_boxes.py
+++ b/tests/simulator/py/refinement_boxes.py
@@ -2,7 +2,7 @@
 #
 # formatted with black
 
-from phare import cpp
+from phare_lib import cpp_simulator
 
 import unittest, os, phare.pharein as ph
 from datetime import datetime, timezone
@@ -43,7 +43,7 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
             if hasattr(self, k):
                 v = getattr(self, k)
                 del v  # blocks segfault on test failure, could be None
-        cpp.reset()
+        cpp_simulator.reset()
 
 
     def _do_dim(self, dim, input, valid: bool = False):
@@ -57,7 +57,7 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
                     self.sim,
                     self.hier,
                 )
-                cpp.reset()
+                cpp_simulator.reset()
             except ValueError as e:
                 self.assertTrue(not valid)
 


### PR DESCRIPTION
move pybind modules out of phare python directory hierarchy -> phare_lib

so now pyphare import is like

```
import phare_lib.pyphare"
```