### PR TITLE
GCC 10 -fanalyzer

### DIFF
--- a/tests/core/utilities/box/test_main.cpp
+++ b/tests/core/utilities/box/test_main.cpp
@@ -82,24 +82,20 @@ TEST(PointInBox, returnFalseIfPointNotInBox1D)
 
 TEST(PointInBox, returnTrueIfPointInOneBox)
 {
-    Point<int, 1> point{5};
-    Box<int, 1> box1{Point<int, 1>{0}, Point<int, 1>{2}};
-    Box<int, 1> box2{Point<int, 1>{3}, Point<int, 1>{6}};
     std::vector<Box<int, 1>> boxes;
-    boxes.push_back(std::move(box1));
-    boxes.push_back(std::move(box2));
+    boxes.emplace_back(Point<int, 1>{0}, Point<int, 1>{2});
+    boxes.emplace_back(Point<int, 1>{3}, Point<int, 1>{6});
+    Point<int, 1> point{5};
     EXPECT_TRUE(isIn(point, boxes));
 }
 
 
 TEST(PointInBox, returnFalseIfIsNoBox)
 {
-    Point<int, 1> point{5};
-    Box<int, 1> box1{Point<int, 1>{0}, Point<int, 1>{2}};
-    Box<int, 1> box2{Point<int, 1>{6}, Point<int, 1>{7}};
     std::vector<Box<int, 1>> boxes;
-    boxes.push_back(std::move(box1));
-    boxes.push_back(std::move(box2));
+    boxes.emplace_back(Point<int, 1>{0}, Point<int, 1>{2});
+    boxes.emplace_back(Point<int, 1>{6}, Point<int, 1>{7});
+    Point<int, 1> point{5};
     EXPECT_FALSE(isIn(point, boxes));
 }
 


### PR DESCRIPTION
replace pointer dynamic_casts with & casts which throw on failure.
```
src/amr/data/field/field_data.h 
src/amr/data/particles/particles_data.h 
```

emplace_back rather than push_back(move(thing))
```
 tests/core/utilities/box/test_main.cpp 
```

the static analysis logs about the casts was about null deref that I couldn't see happening, but changing it to use ref cast got rid of that it seems. I don't see a point where these functions should be called and we should allow classes other than our own, so throw.


