### PR TITLE
intercept cancel signal and force exit

### DIFF
--- a/src/phare/phare.cpp
+++ b/src/phare/phare.cpp
@@ -2,6 +2,7 @@
 
 #include "include.h"
 #include "amr/wrappers/hierarchy.h"
+#include "kul/signal.hpp"
 
 std::unique_ptr<PHARE::initializer::DataProvider> fromCommandLine(int argc, char** argv)
 {
@@ -24,8 +25,12 @@ std::unique_ptr<PHARE::initializer::DataProvider> fromCommandLine(int argc, char
     return nullptr;
 }
 
+
 int main(int argc, char** argv)
 {
+    kul::Signal sig; // forces exit with ctrl+c, GIL seems to block otherwise
+    sig.intr([&](int16_t s) { exit(s); });
+
     std::string const welcome = R"~(
                   _____   _    _            _____   ______
                  |  __ \ | |  | |    /\    |  __ \ |  ____|


### PR DESCRIPTION
if I was to take a guess as to why this works (on my machine at least)

By registering a signal handler, it's probable that python does not override this, so our registered handler is triggered, and we're able to call exit.

from https://pybind11.readthedocs.io/en/stable/faq.html#how-can-i-properly-handle-ctrl-c-in-long-running-functions :

```
Ctrl-C is received by the Python interpreter, and holds it until the GIL is released, so a long-running function won’t be interrupted.
```