### PR TITLE
Block test-updater cmake when building with MPI - 

### DIFF
--- a/tests/core/numerics/ion_updater/CMakeLists.txt
+++ b/tests/core/numerics/ion_updater/CMakeLists.txt
@@ -1,20 +1,24 @@
 cmake_minimum_required (VERSION 3.3)
 
-project(test-updater)
 
-set(SOURCES test_updater.cpp)
+# still tries to compile when building MPI but never gets compiler args
+if(NOT testMPI OR (testMPI AND forceSerialTests))
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+  project(test-updater)
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-  ${GTEST_INCLUDE_DIRS}
-  )
+  set(SOURCES test_updater.cpp)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
-  phare_core
-  phare_simulator
-  ${GTEST_LIBS})
+  add_executable(${PROJECT_NAME} ${SOURCES})
 
-add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+  target_include_directories(${PROJECT_NAME} PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    )
 
+  target_link_libraries(${PROJECT_NAME} PRIVATE
+    phare_core
+    phare_simulator
+    ${GTEST_LIBS})
 
+  add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+
+endif()


### PR DESCRIPTION
tries to compile otherwise and fails


this seems to have come about because we test without MPI before with MPI
so the first time it builds test-updater, and compiles properly, but the second time it isn't built as its' already built.