### PR TITLE
Create lgtm.yml

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,34 @@
+path_classifiers:
+  tag:
+    exclude: subprojects
+  docs:
+  - README.md
+  - LICENSE.txt
+  test: tests/**/*.cpp
+queries:
+  exclude: subprojects
+extraction:
+  cpp:
+    prepare:
+      packages:
+      - build-essential
+      - cmake
+      - python3
+      - python3-pip
+      - openmpi-bin
+      - libopenmpi-dev
+    configure:
+      command:
+      - BD=$PWD
+      - SAMRAI_GIT=https://github.com/PHARCHIVE/SAMRAI_export
+      - SAMRAI_DIR=/opt/work/samrai
+      - git submodule update --init
+      - python3 -m pip install pip --upgrade
+      - python3 -m pip install ddt mpi4py numpy scipy --upgrade
+      - git clone $SAMRAI_GIT --depth 1 $SAMRAI_DIR -b ubuntu_18_04_openmpi
+      - cd $SAMRAI_DIR; ./unzip.sh;
+      - cd $BD; mkdir build; cd build; cmake .. -DSAMRAI_ROOT=$SAMRAI_DIR -DHighFive=OFF
+    index:
+      build_command:
+      - cd build; make
+      - ctest --output-on-failure


### PR DESCRIPTION
static analyses per PR if merged.

currently SAMRAI binaries are stored at https://github.com/PHARCHIVE/SAMRAI_export

could be good to have public non-logged in artifact downloads available from TC