### PR TITLE
cpp_simulator use span rather than std::array / minimize MPI array collection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ mpi4py
 pyyaml
 numpy
 scipy
-

--- a/src/core/utilities/mpi_utils.h
+++ b/src/core/utilities/mpi_utils.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <string>
+#include <cassert>
 #include <cstring>
 
 // clang-format off
@@ -69,21 +70,11 @@ void _collect(Data const* const sendbuf, std::vector<Data>& rcvBuff,
 
 template<typename Data, typename SendBuff, typename RcvBuff>
 void _collect_vector(SendBuff const& sendBuff, RcvBuff& rcvBuff, std::vector<int> const& recvcounts,
-                     int const mpi_size)
+                     std::vector<int> const& displs, int const mpi_size)
 {
+    assert(recvcounts.size() == displs.size() and static_cast<int>(displs.size()) == mpi_size);
+
     _gather<Data>([&](auto const mpi_type) {
-        std::vector<int> displs(mpi_size);
-
-        {
-            int offset = 0;
-
-            for (int i = 0; i < mpi_size; i++)
-            {
-                displs[i] = offset;
-                offset += recvcounts[i];
-            }
-        }
-
         MPI_Allgatherv(        // MPI_Allgatherv
             sendBuff.data(),   //   void         *sendbuf,
             sendBuff.size(),   //   int          sendcount,
@@ -107,7 +98,18 @@ std::vector<Vector> collectVector(Vector const& sendBuff, int mpi_size = 0)
 
     auto const perMPISize = collect(static_cast<int>(sendBuff.size()), mpi_size);
     std::vector<Data> rcvBuff(std::accumulate(perMPISize.begin(), perMPISize.end(), 0));
-    _collect_vector<Data>(sendBuff, rcvBuff, perMPISize, mpi_size);
+
+    std::vector<int> displs(mpi_size);
+    {
+        int offset = 0;
+        for (int i = 0; i < mpi_size; i++)
+        {
+            displs[i] = offset;
+            offset += perMPISize[i];
+        }
+    }
+
+    _collect_vector<Data>(sendBuff, rcvBuff, perMPISize, displs, mpi_size);
 
     std::size_t offset = 0;
     std::vector<Vector> collected;
@@ -126,60 +128,41 @@ SpanSet<T, int> collectSpanSet(Vector const& sendBuff, int mpi_size = 0)
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
     SpanSet<T, int> rcvBuff{collect(static_cast<int>(sendBuff.size()), mpi_size)};
-    _collect_vector<T>(sendBuff, rcvBuff, rcvBuff.sizes, mpi_size);
+    _collect_vector<T>(sendBuff, rcvBuff, rcvBuff.sizes, rcvBuff.displs, mpi_size);
 
     return rcvBuff;
 }
 
 
 
-template<typename Container>
-auto collectArrays(Container const& data, int mpi_size)
+template<typename T, std::size_t size>
+auto collectArrays(std::array<T, size> const& arr, int mpi_size)
 {
+    using Array = std::array<T, size>;
+    using Data  = typename Array::value_type;
+
     if (mpi_size == 0)
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-    std::size_t maxMPISize = 0;
-    if constexpr (core::is_std_vector_v<Container>)
-        maxMPISize = max(data.size(), mpi_size);
-    else if constexpr (core::is_std_array_v<typename Container::value_type, 1>)
-        maxMPISize = data.size();
+    std::size_t maxMPISize = arr.size();
+    std::vector<Data> datas(maxMPISize * mpi_size);
+    _collect(arr.data(), datas, arr.size(), maxMPISize);
 
-    auto perMPISize = collect(data.size(), mpi_size);
+    std::vector<Array> values(mpi_size);
+    for (int i = 0; i < mpi_size; i++)
+        std::memcpy(&values[i], &datas[maxMPISize * i], maxMPISize);
 
-    std::vector<typename Container::value_type> datas(maxMPISize * mpi_size);
-    _collect(data.data(), datas, data.size(), maxMPISize);
-    if constexpr (core::is_std_vector_v<Container>)
-    {
-        std::vector<Container> values;
-        for (int i = 0; i < mpi_size; i++)
-        {
-            auto const* const array = &datas[maxMPISize * i];
-            values.emplace_back(array, array + perMPISize[i]);
-        }
-        return values;
-    }
-    else
-    {
-        std::vector<Container> values(mpi_size);
-        for (int i = 0; i < mpi_size; i++)
-        {
-            auto* array = &datas[maxMPISize * i];
-            auto* valp  = &values[i];
-            std::memcpy(valp, array, maxMPISize);
-        }
-        return values;
-    }
+    return values;
 }
 
 
-template<typename T>
-SpanSet<T, int> collect_raw(std::vector<T> const& data, int mpi_size)
+template<typename Vector>
+SpanSet<typename Vector::value_type, int> collect_raw(Vector const& data, int mpi_size)
 {
     if (mpi_size == 0)
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-    return collectSpanSet<T>(data, mpi_size);
+    return collectSpanSet<typename Vector::value_type>(data, mpi_size);
 }
 
 

--- a/src/core/utilities/mpi_utils.h
+++ b/src/core/utilities/mpi_utils.h
@@ -96,19 +96,9 @@ std::vector<Vector> collectVector(Vector const& sendBuff, int mpi_size = 0)
     if (mpi_size == 0)
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-    auto const perMPISize = collect(static_cast<int>(sendBuff.size()), mpi_size);
+    std::vector<int> const perMPISize = collect(static_cast<int>(sendBuff.size()), mpi_size);
+    std::vector<int> const displs     = core::displacementFrom(perMPISize);
     std::vector<Data> rcvBuff(std::accumulate(perMPISize.begin(), perMPISize.end(), 0));
-
-    std::vector<int> displs(mpi_size);
-    {
-        int offset = 0;
-        for (int i = 0; i < mpi_size; i++)
-        {
-            displs[i] = offset;
-            offset += perMPISize[i];
-        }
-    }
-
     _collect_vector<Data>(sendBuff, rcvBuff, perMPISize, displs, mpi_size);
 
     std::size_t offset = 0;

--- a/src/core/utilities/span.h
+++ b/src/core/utilities/span.h
@@ -6,6 +6,7 @@
 #include <cstddef> // for size_t
 #include <numeric> // for accumulate
 #include <vector>  // for vector
+#include "core/utilities/types.h"
 
 namespace PHARE::core
 {
@@ -36,22 +37,16 @@ struct SpanSet
     SpanSet(std::vector<SIZE>&& sizes_)
         : size{std::accumulate(sizes_.begin(), sizes_.end(), 0)}
         , sizes(sizes_)
-        , displs(sizes_.size())
+        , displs(core::displacementFrom(sizes))
         , vec(size)
     {
-        SIZE off = 0;
-        for (SIZE i = 0; i < static_cast<SIZE>(sizes_.size()); i++)
-        {
-            displs[i] = off;
-            off += sizes_[i];
-        }
     }
 
     SpanSet(SpanSet&& from)
         : size{from.size}
-        , sizes{std::move(from.sizes)}
-        , displs{std::move(from.displs)}
-        , vec{std::move(from.vec)}
+        , sizes(std::move(from.sizes))
+        , displs(std::move(from.displs))
+        , vec(std::move(from.vec))
     {
     }
 
@@ -87,7 +82,8 @@ struct SpanSet
     auto cend() const { return iterator(this); }
 
     SIZE size;
-    std::vector<SIZE> sizes, displs;
+    std::vector<SIZE> sizes;
+    std::vector<SIZE> displs;
     std::vector<T> vec;
 };
 } // namespace PHARE::core

--- a/src/core/utilities/span.h
+++ b/src/core/utilities/span.h
@@ -12,6 +12,8 @@ namespace PHARE::core
 template<typename T, typename SIZE = size_t>
 struct Span
 {
+    using value_type = T;
+
     T& operator[](SIZE i) const { return ptr[i]; }
     T const* const& data() const { return ptr; }
     T const* const& begin() const { return ptr; }

--- a/src/core/utilities/types.h
+++ b/src/core/utilities/types.h
@@ -163,6 +163,19 @@ namespace core
         return arr;
     }
 
+    template<typename Type>
+    std::vector<Type> displacementFrom(std::vector<Type> const& input)
+    {
+        std::vector<Type> displs(input.size());
+        Type off = 0;
+        for (Type i = 0; i < static_cast<Type>(input.size()); i++)
+        {
+            displs[i] = off;
+            off += input[i];
+        }
+        return displs;
+    }
+
 
 } // namespace core
 } // namespace PHARE

--- a/src/python3/data_wrangler.h
+++ b/src/python3/data_wrangler.h
@@ -82,11 +82,11 @@ public:
                 *static_cast<std::size_t*>(py_array.request().ptr));
         };
 
-        auto collect = [&](auto& patch_data) {
+        auto collect = [&](PatchData<std::vector<double>, dimension> const& patch_data) {
             auto patchIDs = core::mpi::collect(patch_data.patchID, mpi_size);
             auto origins  = core::mpi::collect(patch_data.origin, mpi_size);
-            auto lower    = core::mpi::collect(reinterpret_array(patch_data.lower), mpi_size);
-            auto upper    = core::mpi::collect(reinterpret_array(patch_data.upper), mpi_size);
+            auto lower    = core::mpi::collect_raw(to_span(patch_data.lower), mpi_size);
+            auto upper    = core::mpi::collect_raw(to_span(patch_data.upper), mpi_size);
             auto ghosts   = core::mpi::collect(patch_data.nGhosts, mpi_size);
             auto datas    = core::mpi::collect(patch_data.data, mpi_size);
 
@@ -99,7 +99,7 @@ public:
             }
         };
 
-        auto max = core::mpi::max(input.size(), mpi_size);
+        std::size_t max = core::mpi::max(input.size(), mpi_size);
 
         PatchData<std::vector<double>, dimension> empty;
 

--- a/src/python3/patch_data.h
+++ b/src/python3/patch_data.h
@@ -31,10 +31,9 @@ struct PatchData
 };
 
 
-template<typename PatchData>
-void setPatchData(PatchData& data, std::string patchID, std::string origin,
-                  std::array<std::size_t, PatchData::dimension> lower,
-                  std::array<std::size_t, PatchData::dimension> upper)
+template<typename PatchData, typename Container>
+void setPatchData(PatchData& data, std::string const patchID, std::string const origin,
+                  Container lower, Container upper)
 {
     constexpr std::size_t bytes = PatchData::dimension * sizeof(size_t);
     std::memcpy(data.lower.request().ptr, lower.data(), bytes);

--- a/src/python3/pybind_def.h
+++ b/src/python3/pybind_def.h
@@ -1,8 +1,11 @@
 #ifndef PHARE_PYTHON_PYBIND_DEF_H
 #define PHARE_PYTHON_PYBIND_DEF_H
 
-#include <cstdint>
 #include <tuple>
+#include <cstdint>
+#include <stdexcept>
+
+#include "pybind11/stl.h"
 #include "pybind11/numpy.h"
 
 namespace PHARE::pydata
@@ -17,6 +20,19 @@ using pyarray_particles_t = std::tuple<py_array_t<int32_t>, py_array_t<float>, p
 using pyarray_particles_crt
     = std::tuple<py_array_t<int32_t> const&, py_array_t<float> const&, py_array_t<double> const&,
                  py_array_t<double> const&, py_array_t<double> const&>;
+
+
+
+template<typename T>
+core::Span<T, int> to_span(py_array_t<T> const& py_array)
+{
+    py::buffer_info info = py_array.request();
+    if (!info.ptr)
+        throw std::runtime_error("to_span received an array with an invalid internal ptr");
+    assert(info.ndim == 1 or info.ndim == 2);
+    int size = info.ndim == 1 ? info.shape[0] : info.shape[0] * info.shape[1];
+    return {static_cast<T*>(info.ptr), size};
+}
 
 
 } // namespace PHARE::pydata


### PR DESCRIPTION
- src/core/utilities/mpi_utils.h
   Minimize collectArrays, it's not used for vectors anymore
   Use dispels from SpanSet, move dispels creation to normal vector
collection

- src/python3/cpp_simulator.cpp
   Use Span instead of arrays to avoid copies/reinterpret cast of pybind
arrays

- requirements.txt
   State explicitly numpy and scipy are used