### PR TITLE
Run simulator tests that don't require h5 when h5 is not available

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -24,7 +24,7 @@ extraction:
       - SAMRAI_DIR=/opt/work/samrai
       - git submodule update --init
       - python3 -m pip install pip --upgrade
-      - python3 -m pip install ddt mpi4py numpy scipy --upgrade
+      - python3 -m pip install -r requirements.txt --upgrade
       - git clone $SAMRAI_GIT --depth 1 $SAMRAI_DIR -b ubuntu_18_04_openmpi
       - cd $SAMRAI_DIR; ./unzip.sh;
       - cd $BD; mkdir build; cd build; cmake .. -DSAMRAI_ROOT=$SAMRAI_DIR -DHighFive=OFF -DforceGetPybind=ON

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 ddt
 mpi4py
 pyyaml
+numpy
+scipy
+

--- a/tests/simulator/CMakeLists.txt
+++ b/tests/simulator/CMakeLists.txt
@@ -2,19 +2,21 @@ cmake_minimum_required (VERSION 3.3)
 
 project(test-simulator)
 
+if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  file(GLOB PYFILES "*.py")
+  file(COPY ${PYFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 if(HighFive)
 
-  if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-    file(GLOB PYFILES "*.py")
-    file(COPY ${PYFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-  endif()
-
-  add_python3_test(sim-refineboxes      refinement_boxes.py     ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(sim-refineParticlNbr refined_particle_nbr.py ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(data-wrangler        data_wrangler.py        ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(diagnostics          diagnostics.py          ${CMAKE_CURRENT_BINARY_DIR})
+  ## These test use dump diagnostics so require HighFive!
+  add_python3_test(diagnostics     diagnostics.py          ${CMAKE_CURRENT_BINARY_DIR})
   add_python3_test(init-particles  test_initialization.py ${CMAKE_CURRENT_BINARY_DIR})
-
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.py ${CMAKE_CURRENT_BINARY_DIR}/config.py @ONLY)
+  add_python3_test(sim-refineboxes refinement_boxes.py     ${CMAKE_CURRENT_BINARY_DIR})
 
 endif()
+
+add_python3_test(data-wrangler        data_wrangler.py        ${CMAKE_CURRENT_BINARY_DIR})
+add_python3_test(sim-refineParticlNbr refined_particle_nbr.py ${CMAKE_CURRENT_BINARY_DIR})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.py ${CMAKE_CURRENT_BINARY_DIR}/config.py @ONLY)


### PR DESCRIPTION
This might be why LGTM doesn't have more files showing