### PR TITLE
LGTM - Exclude subprojects as library

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,12 +1,8 @@
 path_classifiers:
-  tag:
-    exclude: subprojects
-  docs:
-  - README.md
-  - LICENSE.txt
-  test: tests/**/*.cpp
-queries:
-  exclude: subprojects
+  test:
+    - "tests"
+  library:
+    - "subprojects"
 extraction:
   cpp:
     prepare:


### PR DESCRIPTION
LGTM needs two building commits so this should fix that also
should see the LGTM C++ PR job here too

maybe wait for: https://github.com/github/codeql/issues/3997