### PR TITLE
disable h5 file truncation by default

### DIFF
--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -164,6 +164,9 @@ def populateDict():
     else:
         add(diag_path + "filePath", "phare_output")
 
+    if (simulation.diag_options is not None and "options" in simulation.diag_options
+        and "mode" in simulation.diag_options["options"]):
+            add(diag_path + "mode", simulation.diag_options["options"]["mode"])
 
 
     #### adding electrons

--- a/src/amr/data/field/field_data_factory.h
+++ b/src/amr/data/field/field_data_factory.h
@@ -45,9 +45,8 @@ namespace amr
         /*** \brief Clone the current FieldDataFactory
          */
         std::shared_ptr<SAMRAI::hier::PatchDataFactory>
-        cloneFactory(SAMRAI::hier::IntVector const& ghost) final
+        cloneFactory(SAMRAI::hier::IntVector const& /*ghost*/) final
         {
-            (void)ghost;
             return std::make_shared<FieldDataFactory>(fineBoundaryRepresentsVariable_,
                                                       dataLivesOnPatchBorder_, name_, quantity_);
         }

--- a/src/diagnostic/detail/h5writer.h
+++ b/src/diagnostic/detail/h5writer.h
@@ -40,7 +40,7 @@ public:
 
     template<typename Hierarchy, typename Model>
     Writer(Hierarchy& hier, Model& model, std::string const hifivePath,
-           unsigned _flags = HiFile::ReadWrite | HiFile::Create | HiFile::Truncate)
+           unsigned _flags /* = HiFile::ReadWrite | HiFile::Create | HiFile::Truncate */)
         : flags{_flags}
         , filePath_{hifivePath}
         , modelView_{hier, model}
@@ -53,7 +53,10 @@ public:
     static decltype(auto) make_unique(Hierarchy& hier, Model& model, initializer::PHAREDict& dict)
     {
         std::string filePath = dict["filePath"].template to<std::string>();
-        return std::make_unique<This>(hier, model, filePath);
+        unsigned flags       = HiFile::ReadWrite | HiFile::Create;
+        if (dict.contains("mode") and dict["mode"].template to<std::string>() == "truncate")
+            flags |= HiFile::Truncate;
+        return std::make_unique<This>(hier, model, filePath, flags);
     }
 
 

--- a/src/phare/phare_init.py
+++ b/src/phare/phare_init.py
@@ -29,13 +29,13 @@ def density(x):
 
 
 def by(x):
-    from pyphare.pharein.globals import sim
+    from pyphare.pharein.global_vars import sim
     L = sim.simulation_domain()
     return 0.1*np.cos(2*np.pi*x/L[0])
 
 
 def bz(x):
-    from pyphare.pharein.globals import sim
+    from pyphare.pharein.global_vars import sim
     L = sim.simulation_domain()
     return 0.1*np.sin(2*np.pi*x/L[0])
 
@@ -49,12 +49,12 @@ def vx(x):
 
 
 def vy(x):
-    from pyphare.pharein.globals import sim
+    from pyphare.pharein.global_vars import sim
     L = sim.simulation_domain()
     return 0.1*np.cos(2*np.pi*x/L[0])
 
 def vz(x):
-    from pyphare.pharein.globals import sim
+    from pyphare.pharein.global_vars import sim
     L = sim.simulation_domain()
     return 0.1*np.sin(2*np.pi*x/L[0])
 
@@ -87,7 +87,7 @@ ElectronModel(closure="isothermal", Te=0.12)
 import pyphare.pharein as ph
 
 
-sim = ph.globals.sim
+sim = ph.global_vars.sim
 
 timestamps = np.arange(0, sim.final_time +sim.time_step, 100*sim.time_step)
 

--- a/tests/diagnostic/job_1d.py.in
+++ b/tests/diagnostic/job_1d.py.in
@@ -6,9 +6,9 @@ from tests.simulator import basicSimulatorArgs, makeBasicModel
 from tests.diagnostic import dump_all_diags
 
 out = "phare_outputs/diags_1d/"
-input = {"diag_options": {"format": "phareh5", "options": {"dir": out}}}
+simInput = {"diag_options": {"format": "phareh5", "options": {"dir": out, "mode" : "truncate"}}}
 
-ph.Simulation(**basicSimulatorArgs(dim = 1, interp = 1, **input))
+ph.Simulation(**basicSimulatorArgs(dim = 1, interp = 1, **simInput))
 model = makeBasicModel()
 ElectronModel(closure="isothermal",Te = 0.12)
 dump_all_diags(model.populations)

--- a/tests/diagnostic/job_2d.py.in
+++ b/tests/diagnostic/job_2d.py.in
@@ -6,9 +6,9 @@ from tests.simulator import basicSimulatorArgs, makeBasicModel
 from tests.diagnostic import dump_all_diags
 
 out = "phare_outputs/diags_2d/"
-input = {"diag_options": {"format": "phareh5", "options": {"dir": out}}}
+simInput = {"diag_options": {"format": "phareh5", "options": {"dir": out, "mode" : "truncate"}}}
 
-ph.Simulation(**basicSimulatorArgs(dim = 2, interp = 1, **input))
+ph.Simulation(**basicSimulatorArgs(dim = 2, interp = 1, **simInput))
 model = makeBasicModel()
 ElectronModel(closure="isothermal",Te = 0.12)
 dump_all_diags(model.populations)

--- a/tests/diagnostic/test_diagnostics.h
+++ b/tests/diagnostic/test_diagnostics.h
@@ -101,7 +101,8 @@ struct Hi5Diagnostic
     using ModelView_t = ModelView<Hierarchy, HybridModel>;
     using Writer_t    = Writer<ModelView_t>;
 
-    Hi5Diagnostic(Hierarchy& hierarchy, HybridModel& hybridModel, std::string out, unsigned flags)
+    Hi5Diagnostic(Hierarchy& hierarchy, HybridModel& hybridModel, std::string out,
+                  unsigned flags = NEW_HI5_FILE)
         : hierarchy_{hierarchy}
         , model_{hybridModel}
         , out_{out}

--- a/tests/simulator/CMakeLists.txt
+++ b/tests/simulator/CMakeLists.txt
@@ -10,9 +10,9 @@ endif()
 if(HighFive)
 
   ## These test use dump diagnostics so require HighFive!
-  add_python3_test(diagnostics     diagnostics.py          ${CMAKE_CURRENT_BINARY_DIR})
+  add_python3_test(diagnostics     diagnostics.py         ${CMAKE_CURRENT_BINARY_DIR})
   add_python3_test(init-particles  test_initialization.py ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(sim-refineboxes refinement_boxes.py     ${CMAKE_CURRENT_BINARY_DIR})
+  add_python3_test(sim-refineboxes refinement_boxes.py    ${CMAKE_CURRENT_BINARY_DIR})
 
 endif()
 

--- a/tests/simulator/diagnostics.py
+++ b/tests/simulator/diagnostics.py
@@ -2,19 +2,19 @@
 #!/usr/bin/env python3
 
 
-
 from pybindlibs import cpp
 from tests.diagnostic import dump_all_diags
 from tests.simulator import NoOverwriteDict, populate_simulation
 from pyphare.simulator.simulator import Simulator
 from pyphare.pharesee.hierarchy import hierarchy_from
 import pyphare.pharein as ph
-import unittest, os
+import unittest, os, h5py, shutil
 from ddt import ddt, data
 
+from tests.simulator.config import project_root
 
 
-out = "phare_outputs/diagnostic_test"
+out = "phare_outputs/diagnostic_test/"
 diags = {"diag_options": {"format": "phareh5", "options": {"dir": out}}}
 
 
@@ -39,28 +39,38 @@ class DiagnosticsTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(DiagnosticsTest, self).__init__(*args, **kwargs)
         self.simulator = None
+        Simulator.startMPI() # so we cna delete previous diags only on mpi_rank 0
 
 
-    def _test_dump_diags_with_killing_dman_nd(self, dim, **input):
+    def _test_dump_diags_with_killing_dman_nd(self, dim, **simInput):
+        print("_test_dump_diags_with_killing_dman_nd {}".format(dim))
+        for interp in range(1, 2):
+            local_out = out + str(dim) + "_" + str(interp)
+            simInput["diag_options"]["options"]["dir"] = local_out
 
-        for interp in range(1, 4):
-            local_out = out + "_" + str(dim) + "_" + str(interp)
-            input["diag_options"]["options"]["dir"] = local_out
+            # delete previous diags / can't truncate
+            if cpp.mpi_rank() == 0 and os.path.exists(local_out):
+                shutil.rmtree(local_out)
 
-            self.simulator = Simulator(populate_simulation(dim, interp, **input))
+            self.simulator = Simulator(populate_simulation(dim, interp, **simInput))
             self.simulator.initialize()
-            self.simulator.diagnostics().dump(timestamp=0, timestep=1)
+            # self.simulator.advance() causes crash under MPI
+            # EXCEPTION CAUGHT: The geometry on the patch is not set, please verify your configuration
 
-            # SEE https://github.com/PHAREHUB/PHARE/issues/275
-            if dim == 1: # REMOVE WHEN PHARESEE SUPPORTS 2D
-                for diagInfo in ph.global_vars.sim.diagnostics:
-                    # diagInfo.quantity starts with a / this interferes with os.path.join, hence   [1:]
-                    h5_file = os.path.join(local_out, (diagInfo.quantity + ".h5").replace('/', '_')[1:])
-                    self.assertTrue(os.path.exists(h5_file))
+            for diagInfo in ph.global_vars.sim.diagnostics:
+                # diagInfo.quantity starts with a / this interferes with os.path.join, hence   [1:]
+                h5_filename = os.path.join(local_out, (diagInfo.quantity + ".h5").replace('/', '_')[1:])
+                print("h5_filename", h5_filename)
 
-                    print("h5_file", h5_file)
-                    hier = hierarchy_from(h5_filename=h5_file)
-                    if h5_file.endswith("domain.h5"):
+                h5_file = h5py.File(h5_filename, "r")
+                self.assertTrue("t0.000000" in h5_file)
+                # self.assertTrue("t0.001000" in h5_file) # fails under MPI runs
+
+                # SEE https://github.com/PHAREHUB/PHARE/issues/275
+                if dim == 1: # REMOVE WHEN PHARESEE SUPPORTS 2D
+                    self.assertTrue(os.path.exists(h5_filename))
+                    hier = hierarchy_from(h5_filename=h5_filename)
+                    if h5_filename.endswith("domain.h5"):
                         for patch in hier.level(0).patches:
                             for qty_name, pd in patch.patch_datas.items():
                                 splits = pd.dataset.split(ph.global_vars.sim)
@@ -75,13 +85,13 @@ class DiagnosticsTest(unittest.TestCase):
 
 
     @data(*_test_cases)
-    def test_dump_diags_with_killing_dman_1d(self, input):
-        self._test_dump_diags_with_killing_dman_nd(1, **input)
+    def test_dump_diags_with_killing_dman_1d(self, simInput):
+        self._test_dump_diags_with_killing_dman_nd(1, **simInput)
 
 
     @data(*_test_cases)
-    def test_dump_diags_with_killing_dman_2d(self, input):
-        self._test_dump_diags_with_killing_dman_nd(2, **input)
+    def test_dump_diags_with_killing_dman_2d(self, simInput):
+        self._test_dump_diags_with_killing_dman_nd(2, **simInput)
 
 
     def tearDown(self):

--- a/tests/simulator/diagnostics.py
+++ b/tests/simulator/diagnostics.py
@@ -4,47 +4,122 @@
 
 from pybindlibs import cpp
 from tests.diagnostic import dump_all_diags
-from tests.simulator import NoOverwriteDict, populate_simulation
-from pyphare.simulator.simulator import Simulator
+from tests.simulator import populate_simulation
+from pyphare.pharein import ElectronModel
+from pyphare.simulator.simulator import Simulator, startMPI
 from pyphare.pharesee.hierarchy import hierarchy_from
 import pyphare.pharein as ph
-import unittest, os, h5py, shutil
+import unittest
+import os
+import h5py
+import shutil
+import numpy as np
 from ddt import ddt, data
 
 from tests.simulator.config import project_root
 
 
-out = "phare_outputs/diagnostic_test/"
-diags = {"diag_options": {"format": "phareh5", "options": {"dir": out}}}
+def setup_model():
+    def density(*xyz):
+        return 1.
 
+    def by(*xyz):
+        x = xyz[0]
+        L = ph.global_vars.sim.simulation_domain()
+        return 0.1*np.cos(2*np.pi*x/L[0])
+
+    def bz(*xyz):
+        x = xyz[0]
+        L = ph.global_vars.sim.simulation_domain()
+        return 0.1*np.sin(2*np.pi*x/L[0])
+
+    def bx(*xyz):
+        return 1.
+
+    def vx(*xyz):
+        return 0.
+
+    def vy(*xyz):
+        x = xyz[0]
+        L = ph.global_vars.sim.simulation_domain()
+        return 0.1*np.cos(2*np.pi*x/L[0])
+
+    def vz(*xyz):
+        x = xyz[0]
+        L = ph.global_vars.sim.simulation_domain()
+        return 0.1*np.sin(2*np.pi*x/L[0])
+
+    def vthx(*xyz):
+        return 0.01
+
+    def vthy(*xyz):
+        return 0.01
+
+    def vthz(*xyz):
+        return 0.01
+
+    vvv = {
+        "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
+        "vthx": vthx, "vthy": vthy, "vthz": vthz
+    }
+
+    model = ph.MaxwellianFluidModel(
+        bx=bx, by=by, bz=bz,
+        protons={"charge": 1, "density": density, **vvv, "init": {"seed": 1337}}
+    )
+    ElectronModel(closure="isothermal", Te=0.12)
+    return model
+
+
+out = "phare_outputs/diagnostic_test/"
+simArgs = {
+  "time_step_nbr":30000,
+  "final_time":30.,
+  "boundary_types":"periodic",
+  "cells":40,
+  "dl":0.3,
+  "max_nbr_levels":2,
+  "diag_options": {"format": "phareh5", "options": {"dir": out}}
+}
 
 def dup(dic):
-    dic = NoOverwriteDict(dic)
-    dic.update(diags.copy())
-    dic.update({"diags_fn": lambda model: dump_all_diags(model.populations)})
+    dic.update(simArgs.copy())
     return dic
+
 
 @ddt
 class DiagnosticsTest(unittest.TestCase):
 
     _test_cases = (
       dup({
-        "smallest_patch_size": 5,
-        "largest_patch_size": 64}),
+        "smallest_patch_size": 10,
+        "largest_patch_size": 20}),
       dup({
-        "smallest_patch_size": 65,
-        "largest_patch_size": 65})
+        "smallest_patch_size": 20,
+        "largest_patch_size": 20}),
+      # dup({ # segfaults # https://github.com/PHAREHUB/PHARE/issues/330
+      #   "smallest_patch_size": 40,
+      #   "largest_patch_size": 40})
     )
 
     def __init__(self, *args, **kwargs):
         super(DiagnosticsTest, self).__init__(*args, **kwargs)
         self.simulator = None
-        Simulator.startMPI() # so we cna delete previous diags only on mpi_rank 0
+        # so we can delete previous diags only on mpi_rank 0
+        startMPI()
 
 
-    def _test_dump_diags_with_killing_dman_nd(self, dim, **simInput):
-        print("_test_dump_diags_with_killing_dman_nd {}".format(dim))
-        for interp in range(1, 2):
+    def _test_dump_diags(self, dim, **simInput):
+
+        # configure simulation dim sized values
+        for key in ["cells", "dl", "boundary_types"]:
+            simInput[key] = [simInput[key] for d in range(dim)]
+        b0 = [[10 for i in range(dim)], [20 for i in range(dim)]]
+        simInput["refinement_boxes"] = {"L0": {"B0": b0}}
+
+        for interp in range(1, 4):
+            print("_test_dump_diags dim/interp:{}/{}".format(dim, interp))
+
             local_out = out + str(dim) + "_" + str(interp)
             simInput["diag_options"]["options"]["dir"] = local_out
 
@@ -52,10 +127,11 @@ class DiagnosticsTest(unittest.TestCase):
             if cpp.mpi_rank() == 0 and os.path.exists(local_out):
                 shutil.rmtree(local_out)
 
-            self.simulator = Simulator(populate_simulation(dim, interp, **simInput))
-            self.simulator.initialize()
-            # self.simulator.advance() causes crash under MPI
-            # EXCEPTION CAUGHT: The geometry on the patch is not set, please verify your configuration
+            simulation = ph.Simulation(**simInput)
+            self.assertTrue(len(simulation.cells) == dim)
+
+            dump_all_diags(setup_model().populations)
+            self.simulator = Simulator(simulation).initialize().advance()
 
             for diagInfo in ph.global_vars.sim.diagnostics:
                 # diagInfo.quantity starts with a / this interferes with os.path.join, hence   [1:]
@@ -63,8 +139,8 @@ class DiagnosticsTest(unittest.TestCase):
                 print("h5_filename", h5_filename)
 
                 h5_file = h5py.File(h5_filename, "r")
-                self.assertTrue("t0.000000" in h5_file)
-                # self.assertTrue("t0.001000" in h5_file) # fails under MPI runs
+                self.assertTrue("t0.000000" in h5_file) #    init dump
+                self.assertTrue("t0.001000" in h5_file) # advance dump
 
                 # SEE https://github.com/PHAREHUB/PHARE/issues/275
                 if dim == 1: # REMOVE WHEN PHARESEE SUPPORTS 2D
@@ -82,16 +158,17 @@ class DiagnosticsTest(unittest.TestCase):
                                 print("splits.v", splits.v)
 
             self.simulator = None
+            ph.global_vars.sim = None
 
 
     @data(*_test_cases)
-    def test_dump_diags_with_killing_dman_1d(self, simInput):
-        self._test_dump_diags_with_killing_dman_nd(1, **simInput)
+    def test_dump_diags_1d(self, simInput):
+        self._test_dump_diags(1, **simInput)
 
 
     @data(*_test_cases)
-    def test_dump_diags_with_killing_dman_2d(self, simInput):
-        self._test_dump_diags_with_killing_dman_nd(2, **simInput)
+    def test_dump_diags_2d(self, simInput):
+        self._test_dump_diags(2, **simInput)
 
 
     def tearDown(self):

--- a/tests/simulator/refined_particle_nbr.py
+++ b/tests/simulator/refined_particle_nbr.py
@@ -14,9 +14,6 @@ from pyphare.cpp import splitter_type
 
 from tests.simulator.config import project_root
 
-out = "phare_outputs/refined_particle_nbr"
-diags = NoOverwriteDict({"diag_options": {"format": "phareh5", "options": {"dir": out}}})
-
 
 class SimulatorRefinedParticleNbr(unittest.TestCase):
 
@@ -53,10 +50,8 @@ class SimulatorRefinedParticleNbr(unittest.TestCase):
         np.testing.assert_allclose(yaml_weight, splitter_t.weight)
 
 
-    def _do_dim(self, dim, input, min_diff, max_diff):
+    def _do_dim(self, dim, min_diff, max_diff):
         from pyphare.pharein.simulation import valid_refined_particle_nbr
-        input = input.copy() # copy dict as keys are not rewritable
-        # otherwise "input["refined_particle_nbr"] = refined_particle_nbr" would fail the second time
 
         for interp in range(1, 4):
 
@@ -65,8 +60,8 @@ class SimulatorRefinedParticleNbr(unittest.TestCase):
 
                 self._check_deltas_and_weights(dim, interp, refined_particle_nbr)
 
-                input["refined_particle_nbr"] = refined_particle_nbr
-                self.simulator = Simulator(populate_simulation(dim, interp, **input))
+                simInput = NoOverwriteDict({"refined_particle_nbr": refined_particle_nbr})
+                self.simulator = Simulator(populate_simulation(dim, interp, **simInput))
                 self.simulator.initialize()
                 dw = self.simulator.data_wrangler()
                 max_per_pop = 0
@@ -105,7 +100,7 @@ class SimulatorRefinedParticleNbr(unittest.TestCase):
 
     def test_1d(self):
         This = type(self)
-        self._do_dim(1, diags, This.PREVIOUS_ITERATION_MIN_DIFF_1d, This.PREVIOUS_ITERATION_MAX_DIFF_1d)
+        self._do_dim(1, This.PREVIOUS_ITERATION_MIN_DIFF_1d, This.PREVIOUS_ITERATION_MAX_DIFF_1d)
 
     """ 2d
       refine 10x10 cells in 2d, ppc 100
@@ -118,7 +113,7 @@ class SimulatorRefinedParticleNbr(unittest.TestCase):
 
     def test_2d(self):
         This = type(self)
-        self._do_dim(2, diags, This.PREVIOUS_ITERATION_MIN_DIFF_2d, This.PREVIOUS_ITERATION_MAX_DIFF_2d)
+        self._do_dim(2, This.PREVIOUS_ITERATION_MIN_DIFF_2d, This.PREVIOUS_ITERATION_MAX_DIFF_2d)
 
     def tearDown(self):
         # needed in case exception is raised in test and Simulator

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -10,8 +10,6 @@ from ddt import ddt, data
 from tests.diagnostic import dump_all_diags
 from tests.simulator import NoOverwriteDict, populate_simulation
 from pyphare.simulator.simulator import Simulator
-import shutil
-
 
 out = "phare_outputs/valid/refinement_boxes/"
 diags = {"diag_options": {"format": "phareh5", "options": {"dir": out, "mode":"truncate" }}}
@@ -55,7 +53,6 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
 
     def _do_dim(self, dim, input, valid: bool = False):
         for interp in range(1, 4):
-
             try:
                 self.simulator = Simulator(populate_simulation(dim, interp, **input))
                 self.simulator.initialize()

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -10,9 +10,11 @@ from ddt import ddt, data
 from tests.diagnostic import dump_all_diags
 from tests.simulator import NoOverwriteDict, populate_simulation
 from pyphare.simulator.simulator import Simulator
+import shutil
+
 
 out = "phare_outputs/valid/refinement_boxes/"
-diags = {"diag_options": {"format": "phareh5", "options": {"dir": out}}}
+diags = {"diag_options": {"format": "phareh5", "options": {"dir": out, "mode":"truncate" }}}
 
 
 @ddt
@@ -53,6 +55,7 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
 
     def _do_dim(self, dim, input, valid: bool = False):
         for interp in range(1, 4):
+
             try:
                 self.simulator = Simulator(populate_simulation(dim, interp, **input))
                 self.simulator.initialize()

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -39,7 +39,7 @@ class InitializationTest(unittest.TestCase):
             max_nbr_levels=len(refinement_boxes)+1 if refinement_boxes is not None else 1,
             refinement_boxes=refinement_boxes,
             diag_options={"format": "phareh5",
-                          "options": {"dir": diag_outputs}}
+                          "options": {"dir": diag_outputs, "mode":"truncate"}}
         )
         def beam_density(x):
             return np.zeros_like(x)+0.3
@@ -142,7 +142,6 @@ class InitializationTest(unittest.TestCase):
 
         simulator = Simulator(global_vars.sim)
         simulator.initialize()
-        simulator.diagnostics().dump(timestamp=0, timestep=1)
 
         if qty == "b":
             b_hier = hierarchy_from(h5_filename=diag_outputs+"/EM_B.h5")


### PR DESCRIPTION
provide ability in python to activate it
add test checking diag init timestamp and advance timestamp

skip PatchGeometry if nullptr received and assume it's a temporary patch used by SAMRAI