### PR TITLE
Fix possible deadlock when no coarsest patch is found locally under MPI

### DIFF
--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -62,6 +62,11 @@ if (test)
       add_test(NAME py3_${name} COMMAND mpirun -n ${PHARE_MPI_PROCS} python3 ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name})
     endfunction(add_python3_test)
+
+    function(add_mpi_python3_test N name file directory)
+      add_test(NAME py3_${name}_mpi_n_${N} COMMAND mpirun -n ${N} python3 ${file} WORKING_DIRECTORY ${directory})
+      set_exe_paths_(py3_${name}_mpi_n_${N})
+    endfunction(add_mpi_python3_test)
   else()
     function(add_phare_test binary directory)
       add_no_mpi_phare_test(${binary} ${directory})
@@ -70,6 +75,10 @@ if (test)
     function(add_python3_test name file directory)
       add_no_mpi_python3_test(${name} ${file} ${directory})
     endfunction(add_python3_test)
+
+    function(add_mpi_python3_test N name file directory)
+      # do nothing
+    endfunction(add_mpi_python3_test)
   endif(testMPI)
 
 

--- a/src/diagnostic/detail/h5writer.h
+++ b/src/diagnostic/detail/h5writer.h
@@ -321,7 +321,7 @@ void Writer<ModelView>::initializeDatasets_(std::vector<DiagnosticProperties*> c
 
     // sets empty vectors in case current process lacks patch on a level
     std::size_t maxMPILevel = core::mpi::max(maxLocalLevel);
-    for (std::size_t lvl = maxLocalLevel; lvl <= maxMPILevel; lvl++)
+    for (std::size_t lvl = minLevel; lvl <= maxMPILevel; lvl++)
         if (!lvlPatchIDs.count(lvl))
             lvlPatchIDs.emplace(lvl, std::vector<std::string>());
 
@@ -354,7 +354,8 @@ void Writer<ModelView>::writeDatasets_(std::vector<DiagnosticProperties*> const&
     modelView_.visitHierarchy(writePatch, minLevel, maxLevel);
 
     std::size_t maxMPILevel = core::mpi::max(maxLocalLevel);
-    for (std::size_t lvl = maxLocalLevel; lvl <= maxMPILevel; lvl++)
+    // sets empty vectors in case current process lacks patch on a level
+    for (std::size_t lvl = minLevel; lvl <= maxMPILevel; lvl++)
         if (!patchAttributes.count(lvl))
             patchAttributes.emplace(lvl, std::vector<std::pair<std::string, Attributes>>{});
 

--- a/tests/simulator/CMakeLists.txt
+++ b/tests/simulator/CMakeLists.txt
@@ -10,9 +10,12 @@ endif()
 if(HighFive)
 
   ## These test use dump diagnostics so require HighFive!
-  add_python3_test(diagnostics     diagnostics.py         ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(init-particles  test_initialization.py ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(sim-refineboxes refinement_boxes.py    ${CMAKE_CURRENT_BINARY_DIR})
+  add_python3_test(      diagnostics diagnostics.py  ${CMAKE_CURRENT_BINARY_DIR}) # serial or n = 2
+  add_mpi_python3_test(3 diagnostics diagnostics.py  ${CMAKE_CURRENT_BINARY_DIR})
+  add_mpi_python3_test(4 diagnostics diagnostics.py  ${CMAKE_CURRENT_BINARY_DIR})
+
+  add_python3_test(init-particles  test_initialization.py  ${CMAKE_CURRENT_BINARY_DIR})
+  add_python3_test(sim-refineboxes refinement_boxes.py     ${CMAKE_CURRENT_BINARY_DIR})
 
 endif()
 

--- a/tests/simulator/diagnostics.py
+++ b/tests/simulator/diagnostics.py
@@ -120,7 +120,7 @@ class DiagnosticsTest(unittest.TestCase):
         for interp in range(1, 4):
             print("_test_dump_diags dim/interp:{}/{}".format(dim, interp))
 
-            local_out = out + str(dim) + "_" + str(interp)
+            local_out = out + str(dim) + "_" + str(interp) + "_mpi_n_" + str(cpp.mpi_size())
             simInput["diag_options"]["options"]["dir"] = local_out
 
             # delete previous diags / can't truncate


### PR DESCRIPTION
- start patch.size() check on "minlevel" in case current process lack lower level patch  
- add more MPI tests with N  = 3/4 for diagnostics

https://github.com/PHAREHUB/PHARE/issues/332