### PR TITLE
set afterPushCoarseTime_ from coarser newTime

### DIFF
--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -72,6 +72,10 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
       set_exe_paths_(py3_${name})
     endfunction(add_python3_test)
 
+    function(add_mpi_python3_test N name file directory)
+      add_test(NAME py3_${name}_mpi_n_${N} COMMAND mpirun -n ${N} python3 ${file} WORKING_DIRECTORY ${directory})
+      set_exe_paths_(py3_${name}_mpi_n_${N})
+    endfunction(add_mpi_python3_test)
   else()
     function(add_phare_test binary directory)
       add_no_mpi_phare_test(${binary} ${directory})
@@ -80,6 +84,10 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
     function(add_python3_test name file directory)
       add_no_mpi_python3_test(${name} ${file} ${directory})
     endfunction(add_python3_test)
+
+    function(add_mpi_python3_test N name file directory)
+      # do nothing
+    endfunction(add_mpi_python3_test)
   endif(testMPI)
 
 

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -365,25 +365,20 @@ namespace amr
          * The method is does nothing if the level is the root level because the root level
          * cannot get levelGhost from next coarser (it has none).
          */
-        void firstStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
-                       const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& hierarchy,
-                       double time) override
+        void firstNonRootStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& level,
+                              std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& /*hierarchy*/,
+                              double time, double newCoarserTime) override
         {
             auto levelNumber = level.getLevelNumber();
-            if (levelNumber != 0)
-            {
-                auto& hybridModel = static_cast<HybridModel&>(model);
-                levelGhostParticlesNew_.fill(levelNumber, time);
 
-                // during firstStep() coarser level and current level are at the same time
-                // so 'time' is also the beforePushCoarseTime_
-                beforePushCoarseTime_ = time;
+            assert(levelNumber > 0);
 
-                auto coarserLevel    = hierarchy->getPatchLevel(levelNumber - 1);
-                auto patch           = *std::begin(*coarserLevel);
-                auto times           = resourcesManager_->getTimes(hybridModel.state.ions, *patch);
-                afterPushCoarseTime_ = times[0];
-            }
+            levelGhostParticlesNew_.fill(levelNumber, time);
+
+            // during firstStep() coarser level and current level are at the same time
+            // so 'time' is also the beforePushCoarseTime_
+            beforePushCoarseTime_ = time;
+            afterPushCoarseTime_  = newCoarserTime;
         }
 
 

--- a/src/amr/messengers/hybrid_messenger.h
+++ b/src/amr/messengers/hybrid_messenger.h
@@ -123,7 +123,7 @@ namespace amr
          * @brief see IMessenger::registerLevel
          */
         void regrid(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
-                    const int levelNumber,
+                    int const levelNumber,
                     std::shared_ptr<SAMRAI::hier::PatchLevel> const& oldLevel,
                     IPhysicalModel& model, double const initDataTime) final
         {
@@ -149,11 +149,11 @@ namespace amr
          * @brief see IMessenger::firstStep
          * @param model
          */
-        void firstStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
-                       const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& hierarchy,
-                       double time) final
+        void firstNonRootStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                              std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
+                              double time, double newCoarserTime) final
         {
-            strat_->firstStep(model, level, hierarchy, time);
+            strat_->firstNonRootStep(model, level, hierarchy, time, newCoarserTime);
         }
 
 

--- a/src/amr/messengers/hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_messenger_strategy.h
@@ -95,9 +95,10 @@ namespace amr
         virtual std::string coarseModelName() const = 0;
 
 
-        virtual void firstStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
-                               const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& hierarchy,
-                               double time)
+        virtual void
+        firstNonRootStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                         std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
+                         double time, double newCoarserTime)
             = 0;
 
         virtual void lastStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level) = 0;

--- a/src/amr/messengers/messenger.h
+++ b/src/amr/messengers/messenger.h
@@ -165,9 +165,10 @@ namespace amr
          * @param level
          * @param time
          */
-        virtual void firstStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
-                               const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& hierarchy,
-                               double time)
+        virtual void
+        firstNonRootStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                         const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& hierarchy,
+                         double time, double newCoarserTime)
             = 0;
 
 

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.h
@@ -122,9 +122,9 @@ namespace amr
 
 
 
-        void firstStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
-                       const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& /*hierarchy*/,
-                       double /*time*/) override
+        void firstNonRootStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
+                              const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& /*hierarchy*/,
+                              double /*time*/, double /*newCoarserTime*/) override
         {
         }
 

--- a/src/amr/messengers/mhd_messenger.h
+++ b/src/amr/messengers/mhd_messenger.h
@@ -82,9 +82,9 @@ namespace amr
         }
 
 
-        void firstStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
-                       const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& /*hierarchy*/,
-                       double /*time*/) final
+        void firstNonRootStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
+                              const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& /*hierarchy*/,
+                              double /*time*/, double /*newCoarserTime*/) final
         {
         }
 

--- a/src/diagnostic/detail/h5writer.h
+++ b/src/diagnostic/detail/h5writer.h
@@ -323,7 +323,7 @@ void Writer<ModelView>::initializeDatasets_(std::vector<DiagnosticProperties*> c
 
     // sets empty vectors in case current process lacks patch on a level
     std::size_t maxMPILevel = core::mpi::max(maxLocalLevel);
-    for (std::size_t lvl = maxLocalLevel; lvl <= maxMPILevel; lvl++)
+    for (std::size_t lvl = minLevel; lvl <= maxMPILevel; lvl++)
         if (!lvlPatchIDs.count(lvl))
             lvlPatchIDs.emplace(lvl, std::vector<std::string>());
 
@@ -356,7 +356,8 @@ void Writer<ModelView>::writeDatasets_(std::vector<DiagnosticProperties*> const&
     modelView_.visitHierarchy(writePatch, minLevel, maxLevel);
 
     std::size_t maxMPILevel = core::mpi::max(maxLocalLevel);
-    for (std::size_t lvl = maxLocalLevel; lvl <= maxMPILevel; lvl++)
+    // sets empty vectors in case current process lacks patch on a level
+    for (std::size_t lvl = minLevel; lvl <= maxMPILevel; lvl++)
         if (!patchAttributes.count(lvl))
             patchAttributes.emplace(lvl, std::vector<std::pair<std::string, Attributes>>{});
 

--- a/tests/simulator/CMakeLists.txt
+++ b/tests/simulator/CMakeLists.txt
@@ -10,9 +10,12 @@ endif()
 if(HighFive)
 
   ## These test use dump diagnostics so require HighFive!
-  add_python3_test(diagnostics     diagnostics.py         ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(init-particles  test_initialization.py ${CMAKE_CURRENT_BINARY_DIR})
-  add_python3_test(sim-refineboxes refinement_boxes.py    ${CMAKE_CURRENT_BINARY_DIR})
+  add_python3_test(      diagnostics diagnostics.py  ${CMAKE_CURRENT_BINARY_DIR}) # serial or n = 2
+  add_mpi_python3_test(3 diagnostics diagnostics.py  ${CMAKE_CURRENT_BINARY_DIR})
+  add_mpi_python3_test(4 diagnostics diagnostics.py  ${CMAKE_CURRENT_BINARY_DIR})
+
+  add_python3_test(init-particles  test_initialization.py  ${CMAKE_CURRENT_BINARY_DIR})
+  add_python3_test(sim-refineboxes refinement_boxes.py     ${CMAKE_CURRENT_BINARY_DIR})
 
 endif()
 


### PR DESCRIPTION
uses no mpi comms

includes #333 to show segfault is fixed

liberties taken to do some east-consting (putting "const" after the type)