### PR TITLE
remove duplicated particle regriding

### DIFF
--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -181,7 +181,6 @@ namespace amr
             magneticInit_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             electricInit_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             interiorParticles_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
-            levelGhostParticlesOld_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             copyLevelGhostOldToPushable_(*level, model);
             // computeIonMoments_(*level, model);
             // levelGhostNew will be refined in next firstStep


### PR DESCRIPTION
this PR fixes a bug where all regrided levels had their particle content doubled. 
The regrid function does not depend on the refinerpool template param and this calling regrid for both interiorParticles_ and levelghostOld was actually doing the regrid twice.
the schedule that gets created in the regrid actually copies particles from old level interior where there is an overlap with the new level, and refines from next coarser where there is not. i.e. levelghost are already refined from nextcoarser and filled in the new level.