### PR TITLE
add data getters and ploting routines

### DIFF
--- a/pyphare/pyphare/core/box.py
+++ b/pyphare/pyphare/core/box.py
@@ -1,20 +1,8 @@
 import numpy as np
+from .phare_utilities import np_array_ify, is_scalar, is_nd_array
 
 
-def is_scalar(arg):
-    return not isinstance(arg, list) and not is_nd_array(arg)
 
-
-def is_nd_array(arg):
-    return isinstance(arg, np.ndarray)
-
-
-def np_array_ify(arg):
-    if is_scalar(arg):
-        return np.asarray([arg])
-    if not is_nd_array(arg):
-        return np.asarray(arg)
-    return arg
 
 
 class Box:
@@ -28,6 +16,9 @@ class Box:
         assert (lower <= upper).all()
         self.lower = lower
         self.upper = upper
+
+    def dim(self):
+        return len(self.lower.shape)
 
     def __mul__(self, box2):
         """

--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -4,6 +4,7 @@ import math
 from .phare_utilities import listify
 from .box import Box
 
+
 yee_centering = {
     'x': {
         'Bx':'primal', 'By':'dual', 'Bz':'dual',
@@ -70,6 +71,9 @@ class GridLayout(object):
                           'Y' : self.yeeCentering.centerY,
                           'Z' : self.yeeCentering.centerZ
                          }
+
+    def dim(self):
+        return self.box.dim()
 
     def qtyCentering(self, quantity, direction):
         return self.centering[direction][quantity]

--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 def all_iterables(*args):
     """
     return true if all arguments are either lists or tuples
@@ -39,6 +41,24 @@ def listify(arg):
     if none_iterable(arg):
         return [arg]
     return arg
+
+
+def is_scalar(arg):
+    return not isinstance(arg, list) and not is_nd_array(arg)
+
+
+def is_nd_array(arg):
+    return isinstance(arg, np.ndarray)
+
+
+def np_array_ify(arg):
+    if is_scalar(arg):
+        return np.asarray([arg])
+    if not is_nd_array(arg):
+        return np.asarray(arg)
+    return arg
+
+
 
 
 def not_in_keywords_list(kwd_list,**kwargs):

--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -1,0 +1,73 @@
+import os
+from .hierarchy import hierarchy_from
+import numpy as np
+from pyphare.pharesee.hierarchy import compute_hier_from
+
+
+def _current1d(by, bz, xby, xbz):
+    # jx = 0
+    # jy = -dxBz
+    # jz = dxBy
+    # the following hard-codes yee layout
+    # which is not true in general
+    # we should at some point provide proper
+    # derivation routines in the gridlayout
+    dx = xbz[1]-xbz[0]
+    jy = np.zeros(by.size+1)
+    jy[1:-1] = -(bz[1:]-bz[:-1])/dx
+    dx = xby[1]-xby[0]
+    jz = np.zeros(bz.size+1)
+    jz[1:-1] = (by[1:]-by[:-1])/dx
+    jy[0]=jy[1]
+    jy[-1]=jy[-2]
+    jz[0]=jz[1]
+    jz[-1]=jz[-2]
+    return jy, jz
+
+
+def _compute_current(patch):
+    By = patch.patch_datas["EM_B_y"].dataset[:]
+    xby  = patch.patch_datas["EM_B_y"].x
+    Bz = patch.patch_datas["EM_B_z"].dataset[:]
+    xbz  = patch.patch_datas["EM_B_z"].x
+    Jy, Jz =  _current1d(By, Bz, xby, xbz)
+    return ({"name":"J_y", "data":Jy,"centering":"primal"},
+            {"name":"J_z", "data":Jz,"centering":"primal"})
+
+
+class Run:
+    def __init__(self, path):
+        self.path = path
+
+    def _get_hierarchy(self, time, filename):
+        t = "t{:.6f}".format(time)
+        return hierarchy_from(h5_filename=os.path.join(self.path, filename), time=t)
+
+    def GetB(self, time):
+        return self._get_hierarchy(time, "EM_B.h5")
+
+    def GetE(self, time):
+        return self._get_hierarchy(time, "EM_E.h5")
+
+    def GetNi(self, time):
+        return self._get_hierarchy(time, "ions_density.h5")
+
+    def GetN(self, time, pop_name):
+        return self._get_hierarchy(time, "ions_{}_density.h5".format(pop_name))
+
+    def GetVi(self, time):
+        return self._get_hierarchy(time, "ions_bulkVelocity.h5")
+
+    def GetFlux(self, time, pop_name):
+        return self._get_hierarchy(time, "ions_pop_{}_flux.h5".format(pop_name))
+
+    def GetParticles(self, time, pop_name):
+        return self._get_hierarchy(time, "ions_pop_{}_domain.h5".format(pop_name))
+
+
+    def GetJ(self, time):
+        B = self.GetB(time)
+        dim = B.dim
+        return compute_hier_from(B, _compute_current)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ mpi4py
 pyyaml
 numpy
 scipy
+matplotlib
+seaborn

--- a/tests/functional/td/CMakeLists.txt
+++ b/tests/functional/td/CMakeLists.txt
@@ -10,5 +10,5 @@ endif()
 if(HighFive)
 
   ## These test use dump diagnostics so require HighFive!
-phare_python3_exec(10 test-td td1d.py ${CMAKE_CURRENT_BINARY_DIR})
+phare_python3_exec(11 test-td td1d.py ${CMAKE_CURRENT_BINARY_DIR})
 endif()

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -56,7 +56,6 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
         for interp in range(1, 4):
 
             try:
-                print("START {}".format(cpp.mpi_rank()))
                 self.simulator = Simulator(populate_simulation(dim, interp, **input))
                 self.simulator.initialize()
 

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -56,6 +56,7 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
         for interp in range(1, 4):
 
             try:
+                print("START {}".format(cpp.mpi_rank()))
                 self.simulator = Simulator(populate_simulation(dim, interp, **input))
                 self.simulator.initialize()
 


### PR DESCRIPTION
Typically allows one to do stuff like 

```python
path = "phare_jobs/initialization_tests/phare_outputs_1000"
r = Run(path)

# getting data as hierarchies

B = r.GetB(0)
E = r.GetE(0)
Ni = r.GetNi(0)
Vi = r.GetVi(0)
Fp = r.GetFlux(0, "protons")
J = r.GetJ(0)

# plotting scalars

Ni.plot()
```

![image](https://user-images.githubusercontent.com/3200931/95597606-25ee4b00-0a4f-11eb-9a63-28bb0b417d37.png)

```python

# plotting components of vectors 

Vi.plot(qty="bulkVelocity_z")

``` 

![image](https://user-images.githubusercontent.com/3200931/95597690-40282900-0a4f-11eb-8180-ab12b4a21777.png)



```python

# distribution functions

parts = r.GetParticles(0, "protons")
parts.dist_plot(select=lambda particles: particles.select(Box(2.,12.5), box_type="pos"),
                axis=("x","Vz"),dual
               bins=(100,200))

``` 
![image](https://user-images.githubusercontent.com/3200931/95597851-7665a880-0a4f-11eb-9a98-b9cceb90b79b.png)

or in full velocity space

``` python
parts = r.GetParticles(0, "protons")
parts.dist_plot(select=lambda particles: particles.select(Box(2.,2.5), box_type="pos"),
                kde=True,
                axis=("Vx","Vy"),
               bulk=True)
``` 
![image](https://user-images.githubusercontent.com/3200931/95597943-97c69480-0a4f-11eb-9131-10959a931a09.png)




