### PR TITLE
zoom zoom 

### DIFF
--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -116,6 +116,12 @@ class PatchLevel:
         self.patches = patches
 
 
+    def level_range(self):
+        name = list(self.patches[0].patch_datas.keys())[0]
+        return min([patch.patch_datas[name].x.min() for patch in self.patches]),\
+     max([patch.patch_datas[name].x.max() for patch in self.patches])
+
+
 class PatchHierarchy:
     """is a collection of patch levels """
 
@@ -190,7 +196,11 @@ class PatchHierarchy:
         qty = kwargs.get("qty",None)
         time = kwargs.get("time", self.times()[0])
 
-        fig, ax = plt.subplots()
+        if "ax" not in kwargs:
+            fig, ax = plt.subplots()
+        else:
+            ax = kwargs["ax"]
+            fig = ax.figure
         for lvl_nbr,level in self.levels(time).items():
             if lvl_nbr not in usr_lvls:
                 continue
@@ -207,7 +217,9 @@ class PatchHierarchy:
                 val = patch.patch_datas[qty].dataset[:]
                 x   = patch.patch_datas[qty].x
                 label = "L{level}P{patch}".format(level=lvl_nbr,patch=ip)
-                ax.plot(x, val, label=label)
+                marker=kwargs.get("marker", "")
+                ls = kwargs.get("ls","--")
+                ax.plot(x, val, label=label, marker=marker, ls=ls)
 
         ax.set_title(kwargs.get("title",""))
         ax.set_xlabel(kwargs.get("xlabel","x"))

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -1,0 +1,70 @@
+from matplotlib.transforms import (
+    Bbox, TransformedBbox, blended_transform_factory)
+from mpl_toolkits.axes_grid1.inset_locator import (
+    BboxPatch, BboxConnector, BboxConnectorPatch)
+
+
+def connect_bbox(bbox1, bbox2,
+                 loc1a, loc2a, loc1b, loc2b,
+                 prop_lines, prop_patches=None):
+    if prop_patches is None:
+        prop_patches = {
+            **prop_lines,
+            "alpha": prop_lines.get("alpha", 1) * 0.2,
+        }
+
+    c1 = BboxConnector(bbox1, bbox2, loc1=loc1a, loc2=loc2a, **prop_lines)
+    c1.set_clip_on(False)
+    c2 = BboxConnector(bbox1, bbox2, loc1=loc1b, loc2=loc2b, **prop_lines)
+    c2.set_clip_on(False)
+    bbox_patch1 = BboxPatch(bbox1, ec='k', fc="none", ls='--')
+    bbox_patch2 = BboxPatch(bbox2, ec='k', fc="none", ls='--')
+
+    p = BboxConnectorPatch(bbox1, bbox2,
+                           # loc1a=3, loc2a=2, loc1b=4, loc2b=1,
+                           loc1a=loc1a, loc2a=loc2a, loc1b=loc1b, loc2b=loc2b,
+                           **prop_patches)
+    p.set_clip_on(False)
+
+    return c1, c2, bbox_patch1, bbox_patch2, p
+
+
+def zoom_effect(ax1, ax2, xmin, xmax, **kwargs):
+    """
+    Connect *ax1* and *ax2*. The *xmin*-to-*xmax* range in both axes will
+    be marked.
+
+    Parameters
+    ----------
+    ax1
+        The main axes.
+    ax2
+        The zoomed axes.
+    xmin, xmax
+        The limits of the colored area in both plot axes.
+    **kwargs
+        Arguments passed to the patch constructor.
+    """
+
+    trans1 = blended_transform_factory(ax1.transData, ax1.transAxes)
+    trans2 = blended_transform_factory(ax2.transData, ax2.transAxes)
+
+    bbox = Bbox.from_extents(xmin, 0, xmax, 1)
+
+    mybbox1 = TransformedBbox(bbox, trans1)
+    mybbox2 = TransformedBbox(bbox, trans2)
+
+    prop_patches = {**kwargs, "ec": "none", "alpha": 0.2}
+
+    c1, c2, bbox_patch1, bbox_patch2, p = connect_bbox(
+        mybbox1, mybbox2,
+        loc1a=3, loc2a=2, loc1b=4, loc2b=1,
+        prop_lines=kwargs, prop_patches=prop_patches)
+
+    ax1.add_patch(bbox_patch1)
+    ax2.add_patch(bbox_patch2)
+    ax2.add_patch(c1)
+    ax2.add_patch(c2)
+    ax2.add_patch(p)
+
+    return c1, c2, bbox_patch1, bbox_patch2, p

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -79,13 +79,16 @@ class Simulator:
                          self.timeStep())
 
     def run(self):
-        times = self.times()
-        perf = np.zeros_like(times)
-        for it, t in enumerate(self.times()):
+        self._check_init()
+        perf = []
+        end_time = self.cpp_sim.endTime()
+        t = 0.
+        while t < end_time:
             tick  = timem.time()
             self.advance()
             tock = timem.time()
             perf[it] = tock-tick
+            t = self.cpp_sim.currenTime()
             print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, perf[it], np.sum(perf)))
 
         print("mean advance time = {}".format(np.mean(perf)))

--- a/src/amr/wrappers/integrator.h
+++ b/src/amr/wrappers/integrator.h
@@ -111,7 +111,7 @@ namespace amr
         }
 
 
-        void advance(double dt) { timeRefIntegrator_->advanceHierarchy(dt); }
+        double advance(double dt) { return timeRefIntegrator_->advanceHierarchy(dt); }
 
 
     protected:

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -16,7 +16,7 @@ public:
     virtual double endTime()                             = 0;
     virtual double currentTime()                         = 0;
     virtual double timeStep()                            = 0;
-    virtual void advance(double dt)                      = 0;
+    virtual double advance(double dt)                    = 0;
     virtual std::string to_str()                         = 0;
     virtual std::vector<int> const& domainBox() const    = 0;
     virtual std::vector<double> const& cellWidth() const = 0;
@@ -143,14 +143,15 @@ public:
     std::vector<double> const& cellWidth() const override { return hierarchy_->cellWidth(); }
     std::size_t interporder() const override { return interp_order; }
 
-    void advance(double dt) override
+    double advance(double dt) override
     {
         try
         {
             if (integrator_)
             {
-                integrator_->advance(dt);
+                auto dt_new = integrator_->advance(dt);
                 currentTime_ += dt;
+                return dt_new;
             }
             else
                 throw std::runtime_error("Error - no valid integrator in the simulator");


### PR DESCRIPTION
This adds functions to do

```python
    fig,axes = plt.subplots(nrows=3,figsize=(10,10))
    B = r.GetB(time)
    B.plot(qty="EM_B_y",levels=(0,),ax=axes[0], title="{:8.4f}".format(time),marker='+')
    B.plot(qty="EM_B_y",levels=(1,),ax=axes[1], marker='+')
    B.plot(qty="EM_B_y", levels=(2,),ax=axes[2], marker='+')
    
    for ax in axes:
        ax.set_ylim((-1.4, 1.4))
        ax.axhline(0,ls='--', color='k')
    
    xmin1,xmax1=B.patch_levels[1].level_range()
    axes[1].set_xlim((xmin1,xmax1))
    zoom_effect(axes[0],axes[1],xmin1,xmax1)

    xmin2,xmax2=B.patch_levels[2].level_range()
    axes[2].set_xlim((xmin2,xmax2))
    zoom_effect(axes[1],axes[2],xmin2,xmax2)   
 
```

which produces


![image](https://user-images.githubusercontent.com/3200931/96009178-a2629e80-0e40-11eb-9f64-d70cd2d284af.png)


