### PR TITLE
Refactor some tests to be only run under serial execution

### DIFF
--- a/tests/amr/data/field/coarsening/CMakeLists.txt
+++ b/tests/amr/data/field/coarsening/CMakeLists.txt
@@ -30,8 +30,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   phare_amr
   ${GTEST_LIBS})
 
+
 add_custom_command(TARGET ${PROJECT_NAME}
                    PRE_BUILD
                    COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}:${PHARE_PYTHONPATH}" ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_coarsen_field.py ${CMAKE_CURRENT_BINARY_DIR})
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/amr/data/field/overlap/CMakeLists.txt
+++ b/tests/amr/data/field/overlap/CMakeLists.txt
@@ -30,6 +30,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${SAMRAI_LIBRARIES})
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/data/field/refine/CMakeLists.txt
+++ b/tests/amr/data/field/refine/CMakeLists.txt
@@ -15,28 +15,35 @@ set(SOURCES_INC
   ${CMAKE_CURRENT_BINARY_DIR}/input_config.h
    )
 
-set(SOURCES_CPP
-  test_field_refinement_on_hierarchy.cpp
-  test_field_refine.cpp)
+function(_setup_amr_field_refine_test src_name)
 
-add_executable(${PROJECT_NAME} ${SOURCES_INC} ${SOURCES_CPP})
+  add_executable(${src_name} ${SOURCES_INC} ${src_name}.cpp)
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  ${GTEST_INCLUDE_DIRS}
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  target_include_directories(${src_name} PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    ${GTEST_INCLUDE_DIRS}
   )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
-  phare_amr
-  ${GTEST_LIBS})
+  target_link_libraries(${src_name} PRIVATE phare_amr ${GTEST_LIBS})
+
+  target_include_directories(${src_name} PRIVATE
+    $<BUILD_INTERFACE:${SAMRAI_INCLUDE_DIRS}>)
+
+  target_link_libraries(${src_name} PRIVATE ${SAMRAI_LIBRARIES})
+
+endfunction(_setup_amr_field_refine_test)
 
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-  $<BUILD_INTERFACE:${SAMRAI_INCLUDE_DIRS}>)
+function(_add_general_amr_field_refine_test src_name)
+  _setup_amr_field_refine_test(${src_name})
+  add_phare_test(${src_name} ${CMAKE_CURRENT_BINARY_DIR})
+endfunction(_add_general_amr_field_refine_test)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${SAMRAI_LIBRARIES})
+function(_add_serial_amr_field_refine_test src_name)
+  _setup_amr_field_refine_test(${src_name})
+  add_no_mpi_phare_test(${src_name} ${CMAKE_CURRENT_BINARY_DIR})
+endfunction(_add_serial_amr_field_refine_test)
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
-
+_add_general_amr_field_refine_test(test_field_refinement_on_hierarchy)
+_add_serial_amr_field_refine_test(test_field_refine)

--- a/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.cpp
+++ b/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.cpp
@@ -132,12 +132,6 @@ TYPED_TEST(ALinearFieldRefineTest, ConserveLinearFunction)
 
 
 
-
-INSTANTIATE_TEST_SUITE_P(WithRatioFrom2To10TestThat, ALinearFieldRefine1DO1,
-                         ::testing::Values(2, 3, 4, 5, 6, 7, 8, 9, 10));
-
-
-
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.cpp
+++ b/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.cpp
@@ -129,3 +129,30 @@ TYPED_TEST(ALinearFieldRefineTest, ConserveLinearFunction)
         }
     }
 }
+
+
+
+
+INSTANTIATE_TEST_SUITE_P(WithRatioFrom2To10TestThat, ALinearFieldRefine1DO1,
+                         ::testing::Values(2, 3, 4, 5, 6, 7, 8, 9, 10));
+
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    SAMRAI::tbox::SAMRAI_MPI::init(&argc, &argv);
+    SAMRAI::tbox::SAMRAIManager::initialize();
+    SAMRAI::tbox::SAMRAIManager::startup();
+
+
+    int testResult = RUN_ALL_TESTS();
+
+    // Finalize
+    SAMRAI::tbox::SAMRAIManager::shutdown();
+    SAMRAI::tbox::SAMRAIManager::finalize();
+    SAMRAI::tbox::SAMRAI_MPI::finalize();
+
+    return testResult;
+}

--- a/tests/amr/data/field/time_interpolate/CMakeLists.txt
+++ b/tests/amr/data/field/time_interpolate/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 
 

--- a/tests/amr/data/field/variable/CMakeLists.txt
+++ b/tests/amr/data/field/variable/CMakeLists.txt
@@ -23,6 +23,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${SAMRAI_LIBRARIES})
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/data/particles/copy/CMakeLists.txt
+++ b/tests/amr/data/particles/copy/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/data/particles/copy_overlap/CMakeLists.txt
+++ b/tests/amr/data/particles/copy_overlap/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 


### PR DESCRIPTION
https://github.com/PHAREHUB/PHARE/issues/358

not sure it's all the tests that could be "serialized" but it would probably make the mpi_tests quicker if it was merged as is
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated several test setup procedures to run without the need for MPI (Message Passing Interface), enhancing the flexibility and speed of test execution.
- **New Feature**
  - Introduced a Python script `test_coarsen_field.py` to be run before the build, improving the build process.
- **Refactor**
  - Implemented new functions for setting up and adding tests in the field refinement area, streamlining the test addition process.
- **Test**
  - Added two new tests, `test_field_refinement_on_hierarchy` and `test_field_refine`, to improve the robustness of the software.
- **Test**
  - Updated the test execution framework in `test_field_refinement_on_hierarchy.cpp` to use Google Test, enhancing the reliability and readability of test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->