### PR TITLE
Simulation config and Python hierarchy updates

### DIFF
--- a/pyphare/pyphare/core/box.py
+++ b/pyphare/pyphare/core/box.py
@@ -18,7 +18,7 @@ class Box:
         self.upper = upper.astype(int)
 
     def dim(self):
-        return len(self.lower.shape)
+        return len(self.lower)
 
     def __mul__(self, box2):
         """
@@ -53,12 +53,6 @@ class Box:
     def __repr__(self):
         return self.__str__()
 
-    # only 0 or 1 are valid
-    def __getitem__(self, idx):
-        assert 0 <= idx <= 1
-        if idx == 0:
-            return self.lower
-        return self.upper
 
     def __contains__(self, item):
         """true if item is completely within self"""
@@ -75,7 +69,7 @@ class Box:
 
 
     def __eq__(self, other):
-        return (self.lower == other.lower).all() and (self.upper == other.upper).all()
+        return isinstance(other, Box) and (self.lower == other.lower).all() and (self.upper == other.upper).all()
 
 
 
@@ -115,11 +109,18 @@ def shift(box, offset):
 
 
 def grow(box, size):
-    if is_scalar(size):
-        assert box.dim() == 1 # possible overkill, here to block accidents
+    if is_scalar(size) and box.dim() > 1:
+        raise ValueError("box.py: grow must use a list for dimension > 1")
     if (np.asarray(size) < 0).any():
         raise ValueError("size must be >=0")
     return Box(box.lower - size, box.upper + size)
+
+def shrink(box, size):
+    if is_scalar(size) and box.dim() > 1:
+        raise ValueError("box.py: shrink must use a list for dimension > 1")
+    if (np.asarray(size) < 0).any():
+        raise ValueError("size must be >=0")
+    return Box(box.lower + size, box.upper - size)
 
 
 def remove(box, to_remove):

--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -55,7 +55,7 @@ class GridLayout(object):
         self.origin = listify(origin)
         self.dl = listify(dl)
         self.interp_order = interp_order
-
+        self.impl = "yee"
         self.directions = ['X','Y','Z']
 
         self.hybridQuantities = ['Bx','By','Bz',

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -108,6 +108,7 @@ def populateDict():
 
 
     add("simulation/AMR/max_nbr_levels", int(simulation.max_nbr_levels))
+    add("simulation/AMR/nesting_buffer", int(simulation.nesting_buffer))
     refinement_boxes = simulation.refinement_boxes
 
 
@@ -116,22 +117,23 @@ def populateDict():
         add("simulation/AMR/refinement/boxes/nbr_levels/", int(len(rb.keys())))
         for level,boxes in rb.items():
             level_path = "simulation/AMR/refinement/boxes/"+level+"/"
-            add(level_path + 'nbr_boxes/',int(len(boxes.keys())))
-            for box,cells in boxes.items():
-                lower = cells[0]
-                upper = cells[1]
-                box_lower_path_x = box + "/lower/x/"
-                box_upper_path_x = box + "/upper/x/"
+            add(level_path + 'nbr_boxes/',int(len(boxes)))
+            for box_i, box in enumerate(boxes):
+                box_id = "B" + str(box_i)
+                lower = box.lower
+                upper = box.upper
+                box_lower_path_x = box_id + "/lower/x/"
+                box_upper_path_x = box_id + "/upper/x/"
                 add(level_path + box_lower_path_x, int(lower[0]))
                 add(level_path + box_upper_path_x, int(upper[0]))
                 if len(lower)>=2:
-                    box_lower_path_y = box + "/lower/y/"
-                    box_upper_path_y = box + "/upper/y/"
+                    box_lower_path_y = box_id + "/lower/y/"
+                    box_upper_path_y = box_id + "/upper/y/"
                     add(level_path+box_lower_path_y, int(lower[1]))
                     add(level_path+box_upper_path_y, int(upper[1]))
                     if (len(lower)==3):
-                        box_lower_path_z = box + "/lower/z/"
-                        box_upper_path_z = box + "/upper/z/"
+                        box_lower_path_z = box_id + "/lower/z/"
+                        box_upper_path_z = box_id + "/upper/z/"
                         add(level_path+box_lower_path_z, int(lower[2]))
                         add(level_path+box_upper_path_z, int(upper[2]))
 

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -36,7 +36,7 @@ class FieldData(PatchData):
     defined on a grid.
     """
     def _mesh_coords(self, i):
-        return self.origin[i] - self._ghosts_nbr * self.dl[i] + np.arange(self.size[i]) * self.dl[i] + self.offset[i]
+        return self.origin[i] - self.ghosts_nbr * self.dl[i] + np.arange(self.size[i]) * self.dl[i] + self.offset[i]
 
     @property
     def x(self):
@@ -58,7 +58,7 @@ class FieldData(PatchData):
         self.dx = layout.dl[0] # dropped in 2d_py_init PR - use dl[0]
         self.dl = layout.dl
         self.dim = layout.box.dim()
-        self._ghosts_nbr = np.zeros(self.dim)
+        self.ghosts_nbr = np.zeros(self.dim)
 
         if field_name in layout.centering["X"]:
             directions = ["X", "Y", "Z"][:self.dim] # drop unused directions
@@ -75,9 +75,9 @@ class FieldData(PatchData):
             ValueError("centering not specified and cannot be inferred from field name")
 
         for i, centering in enumerate(centerings):
-            self._ghosts_nbr[i] = layout.nbrGhosts(layout.interp_order, centering)
+            self.ghosts_nbr[i] = layout.nbrGhosts(layout.interp_order, centering)
 
-        self.ghost_box = boxm.grow(layout.box, self._ghosts_nbr)
+        self.ghost_box = boxm.grow(layout.box, self.ghosts_nbr)
 
         self.size = np.zeros(self.dim, dtype=int)
         self.offset = np.zeros(self.dim)
@@ -106,12 +106,12 @@ class ParticleData(PatchData):
         self.dataset = data
         self.pop_name = pop_name
         if layout.interp_order == 1:
-            self._ghosts_nbr = [1] * layout.box.dim()
+            self.ghosts_nbr = [1] * layout.box.dim()
         elif layout.interp_order == 2 or layout.interp_order == 3:
-            self._ghosts_nbr = [2] * layout.box.dim()
+            self.ghosts_nbr = [2] * layout.box.dim()
         else:
             raise RuntimeError("invalid interpolation order {}".format(layout.interp_order))
-        self.ghost_box = boxm.grow(layout.box, self._ghosts_nbr)
+        self.ghost_box = boxm.grow(layout.box, self.ghosts_nbr)
 
 
 

--- a/pyphare/pyphare_tests/test_core/test_box.py
+++ b/pyphare/pyphare_tests/test_core/test_box.py
@@ -95,7 +95,7 @@ class BoxTesT(unittest.TestCase):
            )
     @unpack
     def test_grow(self, box, size, expected):
-        self.assertEqual(boxm.grow(box, size), expected)
+        self.assertEqual(boxm.grow(box, [size] * box.dim()), expected)
 
 
 
@@ -105,7 +105,7 @@ class BoxTesT(unittest.TestCase):
     )
     def test_grow_neg_size_raises(self, box):
         with self.assertRaises(ValueError):
-            boxm.grow(box, -1)
+            boxm.grow(box, [-1] * box.dim())
 
 
 

--- a/pyphare/pyphare_tests/test_pharesee/__init__.py
+++ b/pyphare/pyphare_tests/test_pharesee/__init__.py
@@ -1,0 +1,239 @@
+import numpy as np
+
+import pyphare.core.box as boxm
+from pyphare.core.box import Box
+from pyphare.core.phare_utilities import listify
+from pyphare.core.gridlayout import GridLayout, yee_element_is_primal
+
+from pyphare.pharesee.particles import Particles
+
+from pyphare.pharesee.hierarchy import FieldData
+from pyphare.pharesee.hierarchy import ParticleData
+from pyphare.pharesee.hierarchy import PatchHierarchy
+from pyphare.pharesee.hierarchy import Patch, PatchLevel
+
+
+def init(ghost_box, layout, L, qty, fn):
+
+    assert layout.impl == "yee"
+
+    ndim = ghost_box.dim()
+
+    dl, origin = layout.dl, layout.origin
+    xyz, directions = [], ["x", "y", "z"][: ndim]
+    for dimdex, direction in enumerate(directions):
+        primal = yee_element_is_primal(qty, direction)
+        nbrGhosts = layout.nbrGhosts(primal, layout.interp_order)
+        xyz.append(
+            origin[dimdex]
+            + np.arange(ghost_box.shape()[dimdex] + primal) * dl[dimdex]
+            - nbrGhosts * dl[dimdex]
+        )
+
+    if ndim > 1:
+        xx, yy = np.meshgrid(*xyz, indexing="ij")
+
+        if ndim == 2:
+            return fn(0, xx) * fn(1, yy)
+
+        raise ValueError("3d unsupported")
+
+    return fn(0, xyz[0])
+
+
+def Bx(ghost_box, layout, L):
+    return init(ghost_box, layout, L, "Bx", lambda i, v : np.sin(2 * np.pi / L[i] * v))
+
+
+def By(ghost_box, layout, L):
+    return init(ghost_box, layout, L, "By", lambda i, v : np.cos(2 * np.pi / L[i] * v))
+
+
+def Bz(ghost_box, layout, L):
+    return init(ghost_box, layout, L, "Bz", lambda i, v : np.sin(4 * np.pi / L[i] * v))
+
+
+def Ex(ghost_box, layout, L):
+    return init(ghost_box, layout, L, "Ex", lambda i, v : np.sin(2 * np.pi / L[i] * v))
+
+
+def Ey(ghost_box, layout, L):
+    return init(ghost_box, layout, L, "Ey", lambda i, v : np.cos(2 * np.pi / L[i] * v))
+
+
+def Ez(ghost_box, layout, L):
+    return init(ghost_box, layout, L, "Ez", lambda i, v : np.sin(4 * np.pi / L[i] * v))
+
+
+def build_refinementboxes(domain_box, **kwargs):
+
+    refinement_ratio = kwargs["refinement_ratio"]
+
+    boxes = {}
+    for ilvl, boxes_data in kwargs["refinement_boxes"].items():
+
+        level_number = int(ilvl.strip("L")) + 1
+
+        if level_number not in boxes:
+            boxes[level_number] = []
+
+        assert isinstance(boxes_data, (list, dict))
+
+        if isinstance(boxes_data, list):
+            for _, refinement_box in enumerate(boxes_data):
+                refined_box = boxm.refine(refinement_box, refinement_ratio)
+                boxes[level_number].append(refined_box)
+
+        else:
+            for boxname, lower_upper in boxes_data.items():
+                refinement_box = Box(lower_upper[0][0], lower_upper[1][0])
+                refined_box = boxm.refine(refinement_box, refinement_ratio)
+                boxes[level_number].append(refined_box)
+
+    # coarse level boxes are arbitrarily divided in 2 patches in the middle
+    middle_cell = np.round(domain_box.upper / 2)
+    lower_box = Box(0, middle_cell)
+    upper_box = Box(middle_cell + 1, domain_box.upper)
+    boxes[0] = [lower_box, upper_box]
+
+    return boxes
+
+
+def build_patch_datas(domain_box, boxes, **kwargs):
+    quantities = kwargs["quantities"]
+    origin = kwargs["origin"]
+    interp_order = kwargs["interp_order"]
+    domain_size = kwargs["domain_size"]
+    cell_width = kwargs["cell_width"]
+    refinement_ratio = kwargs["refinement_ratio"]
+
+    skip_particles = False
+    if "particles" in quantities:
+        del quantities[quantities.index("particles")]
+    else:
+        skip_particles = True
+
+    domain_layout = GridLayout(domain_box, origin, cell_width, interp_order)
+
+    coarse_particles = Particles(box=domain_box)
+
+    # copy domain particles and put them in ghost cells
+    particle_ghost_nbr = domain_layout.particleGhostNbr(interp_order)
+    box_extend = particle_ghost_nbr - 1
+
+    upper_slct_box = Box(domain_box.upper - box_extend, domain_box.upper)
+    lower_slct_box = Box(domain_box.lower, domain_box.lower + box_extend)
+
+    if not skip_particles:
+        coarse_particles = Particles(box=domain_box)
+        upper_cell_particles = coarse_particles.select(upper_slct_box)
+        lower_cell_particles = coarse_particles.select(lower_slct_box)
+
+        coarse_particles.add(upper_cell_particles.shift_icell(-domain_box.shape()))
+        coarse_particles.add(lower_cell_particles.shift_icell(domain_box.shape()))
+
+    patch_datas = {}
+
+    for ilvl, lvl_box in boxes.items():
+
+        lvl_cell_width = cell_width / (refinement_ratio ** ilvl)
+
+        if not skip_particles:
+            if ilvl == 0:
+                lvl_particles = coarse_particles
+            else:
+                level_domain_box = boxm.refine(domain_box, refinement_ratio)
+                lvl_ghost_domain_box = boxm.grow(level_domain_box, domain_layout.particleGhostNbr(interp_order))
+                lvl_particles = Particles(box = lvl_ghost_domain_box)
+
+        if ilvl not in patch_datas:
+            patch_datas[ilvl] = []
+
+        for box in lvl_box:
+
+            ghost_box = boxm.grow(box, 5)
+            origin = box.lower * lvl_cell_width
+            layout = GridLayout(box, origin, lvl_cell_width, interp_order)
+
+            datas = {qty: globals()[qty](ghost_box, layout, domain_size) for qty in quantities}
+
+            if not skip_particles:
+                datas["particles"] = lvl_particles.select(ghost_box)
+
+            boxed_patch_datas = {}
+            for qty_name, data in datas.items():
+                if qty_name == 'particles':
+                    pdata = ParticleData(layout, data, "pop_name")
+                else:
+                    pdata = FieldData(layout, qty_name, data)
+
+                boxed_patch_datas[qty_name] = pdata
+
+            patch_datas[ilvl].append(boxed_patch_datas)
+
+    return patch_datas
+
+
+def build_kwargs(**kwargs):
+
+    quantities = ["Bx", "By", "Bz", "Ex", "Ey", "Ez", "particles"]
+
+    if "simulation" in kwargs:
+        for k in kwargs:
+            if k != "simulation":
+                print("warning: 'simulation' given, {} discarded".format(k))
+
+        sim = kwargs["simulation"]
+        kwargs["nbr_cells"] = sim.cells
+        kwargs["origin"] = sim.origin
+        kwargs["interp_order"] = sim.interp_order
+        kwargs["domain_size"] = sim.simulation_domain()
+        kwargs["cell_width"] = sim.dl
+        kwargs["refinement_boxes"] = sim.refinement_boxes
+
+    kwargs["quantities"] = listify(kwargs.get("quantities", quantities))
+    kwargs["refinement_ratio"] = 2
+
+    return kwargs
+
+
+def build_hierarchy(**kwargs):
+    """accepted keywords:
+     - simulation : a simulation Object
+
+     or
+
+     - nbr_cells
+     - origin
+     - interp_order
+     - domain_size
+     - cell_width
+     - refinement_ratio
+     - refinement_boxes
+     """
+    kwargs = build_kwargs(**kwargs)
+
+    nbr_cells = kwargs["nbr_cells"]
+    origin = kwargs["origin"]
+    interp_order = kwargs["interp_order"]
+    domain_size = kwargs["domain_size"]
+    cell_width = kwargs["cell_width"]
+    refinement_ratio = kwargs["refinement_ratio"]
+
+    domain_box = boxm.Box(0, nbr_cells - 1)
+    boxes = build_refinementboxes(domain_box, **kwargs)
+    patch_datas = build_patch_datas(domain_box, boxes, **kwargs)
+
+    patches = {ilvl: [] for ilvl in list(patch_datas.keys())}
+    for ilvl, lvl_patch_datas in patch_datas.items():
+        for patch_datas in lvl_patch_datas:
+            patches[ilvl].append(Patch(patch_datas))
+
+    patch_levels = {}
+    for ilvl, lvl_patches in patches.items():
+        patch_levels[ilvl] = PatchLevel(ilvl, lvl_patches)
+
+    sorted_levels_numbers = sorted(patch_levels)
+    patch_levels = {ilvl: patch_levels[ilvl] for ilvl in sorted_levels_numbers}
+    return PatchHierarchy(patch_levels, domain_box, refinement_ratio)
+

--- a/src/amr/wrappers/hierarchy.h
+++ b/src/amr/wrappers/hierarchy.h
@@ -295,6 +295,9 @@ auto patchHierarchyDatabase(PHARE::initializer::PHAREDict& amr)
     auto maxLevelNumber = amr["max_nbr_levels"].template to<int>();
     hierDB->putInteger("max_levels", maxLevelNumber);
 
+    std::vector<int> nesting_buffer(maxLevelNumber, amr["nesting_buffer"].template to<int>());
+    hierDB->putIntegerVector("proper_nesting_buffer", nesting_buffer);
+
     auto ratioToCoarserDB = hierDB->putDatabase("ratio_to_coarser");
 
     int smallestPatchSize = 0, largestPatchSize = 0;

--- a/tests/amr/messengers/job.py.in
+++ b/tests/amr/messengers/job.py.in
@@ -15,7 +15,6 @@ ph.Simulation(
     boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
     cells=65,                  # integer or tuple length == dimension
     dl=1./65,                  # mesh size of the root level, float or tuple
-    max_nbr_levels=2,          # (default=1) max nbr of levels in the AMR hierarchy
     refinement_boxes = {"L0":{"B0":[(10,),(50,)]}}
 )
 

--- a/tests/amr/multiphysics_integrator/job.py.in
+++ b/tests/amr/multiphysics_integrator/job.py.in
@@ -13,7 +13,6 @@ ph.Simulation(
     boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
     cells=65,                  # integer or tuple length == dimension
     dl=1./65,                  # mesh size of the root level, float or tuple
-    max_nbr_levels=4,          # (default=1) max nbr of levels in the AMR hierarchy
     refinement_boxes = {
         "L0":{"B0":[(10,),(50,)]},
         "L1":{"B0":[(30,),(80,)]},

--- a/tests/functional/alfven_wave/alfven_wave1d.py
+++ b/tests/functional/alfven_wave/alfven_wave1d.py
@@ -30,7 +30,6 @@ def config():
         boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
         cells=40,                # integer or tuple length == dimension
         dl=0.3,                  # mesh size of the root level, float or tuple
-        max_nbr_levels=2,          # (default=1) max nbr of levels in the AMR hierarchy
         refinement_boxes={"L0": {"B0": [(10, ), (20, )]}},
         diag_options={"format": "phareh5", "options": {"dir": "phare_outputs","mode":"overwrite"}}
     )

--- a/tests/functional/td/td1d.py
+++ b/tests/functional/td/td1d.py
@@ -40,7 +40,6 @@ def config():
         boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
         cells=80,                # integer or tuple length == dimension
         dl=0.3,                  # mesh size of the root level, float or tuple
-        max_nbr_levels=3,          # (default=1) max nbr of levels in the AMR hierarchy
         refinement_boxes={"L0": {"B0": [(10, ), (40, )]},
                           "L1":{"B0":[(30,),(60,)]}},
         diag_options={"format": "phareh5", "options": {"dir": "phare_outputs","mode":"overwrite"}}

--- a/tests/initializer/job.py
+++ b/tests/initializer/job.py
@@ -16,7 +16,6 @@ Simulation(
     boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
     cells=65,                  # integer or tuple length == dimension
     dl=1./65,                  # mesh size of the root level, float or tuple
-    max_nbr_levels=2,          # (default=1) max nbr of levels in the AMR hierarchy
     refinement_boxes = {"L0":{"B0":[(10,),(50,)]}},
     diag_options = {"format":"phareh5", "options": {"dir": "phare_outputs","mode":"overwrite"}}
 )

--- a/tests/simulator/__init__.py
+++ b/tests/simulator/__init__.py
@@ -36,10 +36,10 @@ def basicSimulatorArgs(dim: int, interp: int, **kwargs):
         "boundary_types": boundary,
         "cells": cells,
         "dl": dl,
-        "max_nbr_levels": 2,
         "refinement_boxes": {"L0": {"B0": b0}},
         "refined_particle_nbr": valid_refined_particle_nbr[dim][interp][0],
         "diag_options": {},
+        "nesting_buffer": 0,
     }
     for k, v in kwargs.items():
         if k in args:

--- a/tests/simulator/diagnostics.py
+++ b/tests/simulator/diagnostics.py
@@ -77,7 +77,6 @@ simArgs = {
   "boundary_types":"periodic",
   "cells":40,
   "dl":0.3,
-  "max_nbr_levels":2,
   "diag_options": {"format": "phareh5", "options": {"dir": out, "mode":"overwrite", "fine_dump_lvl_max": 10}}
 }
 

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -10,6 +10,7 @@ from ddt import ddt, data
 from tests.diagnostic import dump_all_diags
 from tests.simulator import NoOverwriteDict, populate_simulation
 from pyphare.simulator.simulator import Simulator,startMPI
+from pyphare.core.box import Box
 
 out = "phare_outputs/valid/refinement_boxes/"
 diags = {"diag_options": {"format": "phareh5", "options": {"dir": out, "mode":"overwrite" }}}
@@ -17,6 +18,8 @@ diags = {"diag_options": {"format": "phareh5", "options": {"dir": out, "mode":"o
 
 @ddt
 class SimulatorRefineBoxInputs(unittest.TestCase):
+
+
     def __init__(self, *args, **kwargs):
         super(SimulatorRefineBoxInputs, self).__init__(*args, **kwargs)
         self.simulator = None
@@ -27,6 +30,7 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
         dic.update(diags.copy())
         dic.update({"diags_fn": lambda model: dump_all_diags(model.populations)})
         return dic
+
     """
       The first set of boxes "B0": [(10,), (14,)]
       Are configured to force there to be a single patch on L0
@@ -37,13 +41,42 @@ class SimulatorRefineBoxInputs(unittest.TestCase):
     valid1D = [
         dup({"cells":[65], "refinement_boxes": {"L0": {"B0": [(10,), (14,)]}}}),
         dup({"cells":[65], "refinement_boxes": {"L0": {"B0": [(5,), (55,)]}}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": {"B0": Box(5, 55)}}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 55)]}}),
+        dup({"cells":[65], "refinement_boxes": {  0 : [Box(5, 55)]}}),
+        dup({"cells":[65], "refinement_boxes": {  0 : [Box(0, 55)]}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 14), Box(15, 25)]}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(12, 48)], "L2": [Box(60, 64)]}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(12, 48)]}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(20, 30)]}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(11, 49)]}, "nesting_buffer": 1}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(10, 50)]}}),
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(15, 49)]}}),
+
+        dup({"cells":[65], "refinement_boxes": None, "smallest_patch_size": 20, "largest_patch_size": 20, "nesting_buffer": 10}),
+
     ]
 
     invalid1D = [
-        dup({"max_nbr_levels": 1, "refinement_boxes": {"L0": {"B0": [(10,), (50,)]}}}),
-        #dup({"cells": [55], "refinement_boxes": {"L0": {"B0": [(5,), (65,)]}}}),
+        # finer box outside lower
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 24)], "L1": [Box(9, 30)]}}),
+        # finer box outside upper
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 24)], "L1": [Box(15, 50)]}}),
+        # overlapping boxes
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 15), Box(15, 25)]}}),
+        # box.upper outside domain
+        dup({"cells": [55], "refinement_boxes": {"L0": {"B0": [(5,), (65,)]}}}),
+        # largest_patch_size > smallest_patch_size
         dup({"smallest_patch_size": 100, "largest_patch_size": 64,}),
+        # refined_particle_nbr doesn't exist
         dup({"refined_particle_nbr": 1}),
+        # L2 box incompatible with L1 box due to nesting buffer
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(11, 49)]}, "nesting_buffer": 2}),
+        # negative nesting buffer
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(11, 49)]}, "nesting_buffer": -1}),
+        # too large nesting buffer
+        dup({"cells":[65], "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(11, 49)]}, "nesting_buffer": 33}),
+        dup({"cells":[65], "refinement_boxes": None, "largest_patch_size": 20, "nesting_buffer": 46}),
     ]
 
     def tearDown(self):


### PR DESCRIPTION
- Update particle level ghost functions to support any quantity (eg. Fields) 
- Fixes and tests for periodic level ghost 
- Allow config of finer patch nesting buffer from python defaulted to 0.
- refactor "touch_domain_border" to "near_domain_border" for ghost box overlaps
- Refinebox config updates for simpler interface options
- Refinebox config validation updates to check that finer box is inside any coarser box, and that no fine boxes overlap

includes: https://github.com/PHAREHUB/PHARE/issues/362
