### PR TITLE
Tagging

### DIFF
--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -69,7 +69,7 @@ class FieldData(PatchData):
                 assert len(centerings) == self.dim
             else:
                 if self.dim != 1:
-                    raise ValeuError("FieldData invalid dimenion for centering argument, expected list for dim > 1")
+                    raise ValueError("FieldData invalid dimenion for centering argument, expected list for dim > 1")
                 centerings = [kwargs["centering"]]
         else:
             ValueError("centering not specified and cannot be inferred from field name")
@@ -254,10 +254,12 @@ class PatchHierarchy:
             ax.set_xlim(kwargs["xlim"])
         if "ylim" in kwargs:
             ax.set_ylim(kwargs["ylim"])
-        ax.legend()
+
+        if kwargs.get("legend", None) is not None:
+            ax.legend()
 
         if "filename" in kwargs:
-            fig.savefig(filename)
+            fig.savefig(kwargs["filename"])
 
 
     def dist_plot(self, **kwargs):

--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -172,7 +172,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
   add_subdirectory(tests/amr/messengers)
   add_subdirectory(tests/amr/models)
   add_subdirectory(tests/amr/multiphysics_integrator)
-
+  add_subdirectory(tests/amr/tagging)
 
   add_subdirectory(tests/diagnostic)
 
@@ -181,6 +181,8 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
   add_subdirectory(tests/functional/alfven_wave)
   add_subdirectory(tests/functional/td)
+  add_subdirectory(tests/functional/tdtagged)
+
 
   add_subdirectory(pyphare/pyphare_tests/test_pharesee/)
   add_subdirectory(pyphare/pyphare_tests/pharein/)

--- a/src/amr/CMakeLists.txt
+++ b/src/amr/CMakeLists.txt
@@ -42,6 +42,11 @@ set( SOURCES_INC
      types/amr_types.h
      wrappers/hierarchy.h
      wrappers/integrator.h
+     tagging/tagger.h
+     tagging/tagger_factory.h
+     tagging/hybrid_tagger.h
+     tagging/hybrid_tagger_strategy.h
+     tagging/scaledavg_hybrid_tagger_strategy.h
    )
 set( SOURCES_CPP
      data/field/refine/linear_weighter.cpp

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -183,6 +183,7 @@ namespace amr
             interiorParticles_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             levelGhostParticlesOld_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             copyLevelGhostOldToPushable_(*level, model);
+
             // computeIonMoments_(*level, model);
             // levelGhostNew will be refined in next firstStep
         }
@@ -439,13 +440,16 @@ namespace amr
          * at its ghost nodes, this level will have its model EM field  and current at t=n+1 and
          * thanks to this methods, the t=n field will be in the messenger.
          */
-        void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level) override
+        void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                         double currentTime) override
         {
             auto& hybridModel = static_cast<HybridModel&>(model);
             for (auto& patch : level)
             {
                 auto dataOnPatch = resourcesManager_->setOnPatch(
                     *patch, hybridModel.state.electromag, hybridModel.state.J, EM_old_, Jold_);
+                resourcesManager_->setTime(EM_old_, *patch, currentTime);
+                resourcesManager_->setTime(Jold_, *patch, currentTime);
 
                 auto& EM = hybridModel.state.electromag;
                 auto& J  = hybridModel.state.J;

--- a/src/amr/messengers/hybrid_messenger.h
+++ b/src/amr/messengers/hybrid_messenger.h
@@ -172,9 +172,10 @@ namespace amr
         /**
          * @brief prepareStep see IMessenger::prepareStep
          */
-        void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level) override
+        void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                         double currentTime) override
         {
-            strat_->prepareStep(model, level);
+            strat_->prepareStep(model, level, currentTime);
         }
 
 

--- a/src/amr/messengers/hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_messenger_strategy.h
@@ -103,7 +103,9 @@ namespace amr
 
 
 
-        virtual void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level) = 0;
+        virtual void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                                 double currentTime)
+            = 0;
 
 
         virtual void fillRootGhosts(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,

--- a/src/amr/messengers/messenger.h
+++ b/src/amr/messengers/messenger.h
@@ -190,7 +190,9 @@ namespace amr
          * advanceLevel function. The method sets the Messenger in a state that is ready for the
          * solver to actually use it during advanceLevel.
          */
-        virtual void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level) = 0;
+        virtual void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                                 double currentTime)
+            = 0;
 
 
 

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.h
@@ -130,7 +130,10 @@ namespace amr
         void lastStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/) override {}
 
 
-        void prepareStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/) final {}
+        void prepareStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
+                         double currentTime) final
+        {
+        }
 
         void fillRootGhosts(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
                             double const /*initDataTime*/) final

--- a/src/amr/messengers/mhd_messenger.h
+++ b/src/amr/messengers/mhd_messenger.h
@@ -92,7 +92,10 @@ namespace amr
         void lastStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/) final {}
 
 
-        void prepareStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/) final {}
+        void prepareStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
+                         double /*currentTime*/) final
+        {
+        }
 
         void fillRootGhosts(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
                             double const /*initDataTime*/) final

--- a/src/amr/tagging/hybrid_tagger.h
+++ b/src/amr/tagging/hybrid_tagger.h
@@ -1,0 +1,72 @@
+
+#ifndef PHARE_HYBRID_TAGGER_H
+#define PHARE_HYBRID_TAGGER_H
+
+#include "tagger.h"
+#include "hybrid_tagger_strategy.h"
+#include "solver/physical_models/hybrid_model.h"
+#include "amr/types/amr_types.h"
+
+#include <SAMRAI/pdat/CellData.h>
+
+#include <memory>
+#include <utility>
+#include <stdexcept>
+
+
+
+
+namespace PHARE::amr
+{
+template<typename HybridModel>
+class HybridTagger : public Tagger
+{
+    using patch_t         = typename Tagger::patch_t;
+    using amr_t           = PHARE::amr::SAMRAI_Types;
+    using IPhysicalModel  = PHARE::solver::IPhysicalModel<amr_t>;
+    using gridlayout_type = typename HybridModel::gridlayout_type;
+
+
+public:
+    HybridTagger(std::unique_ptr<HybridTaggerStrategy<HybridModel>> strat)
+        : Tagger{"HybridTagger"}
+        , strat_{std::move(strat)}
+    {
+    }
+
+    void tag(IPhysicalModel& model, patch_t& patch, int tag_index) override;
+
+private:
+    std::unique_ptr<HybridTaggerStrategy<HybridModel>> strat_;
+};
+
+
+
+
+//-----------------------------------------------------------------------------
+//                           Definitions
+//-----------------------------------------------------------------------------
+
+
+
+
+template<typename HybridModel>
+void HybridTagger<HybridModel>::tag(PHARE::solver::IPhysicalModel<amr_t>& model, patch_t& patch,
+                                    int tag_index)
+{
+    if (strat_)
+    {
+        auto& hybridModel   = dynamic_cast<HybridModel&>(model);
+        auto layout         = PHARE::amr::layoutFromPatch<gridlayout_type>(patch);
+        auto modelIsOnPatch = hybridModel.setOnPatch(patch);
+        auto pd   = dynamic_cast<SAMRAI::pdat::CellData<int>*>(patch.getPatchData(tag_index).get());
+        auto tags = pd->getPointer();
+        strat_->tag(hybridModel, layout, tags);
+    }
+    else
+        throw std::runtime_error("invalid tagging strategy");
+}
+
+} // namespace PHARE::amr
+
+#endif

--- a/src/amr/tagging/hybrid_tagger_strategy.h
+++ b/src/amr/tagging/hybrid_tagger_strategy.h
@@ -1,0 +1,23 @@
+#ifndef HYBRID_TAGGER_STRATEGY_H
+#define HYBRID_TAGGER_STRATEGY_H
+
+namespace PHARE::amr
+{
+
+template<typename HybridModel>
+class HybridTaggerStrategy
+{
+    using gridlayout_type = typename HybridModel::gridlayout_type;
+
+public:
+    virtual void tag(HybridModel& model, gridlayout_type const& layout, int* tags) const = 0;
+    virtual ~HybridTaggerStrategy()                                                      = 0;
+};
+
+template<typename HybridModel>
+HybridTaggerStrategy<HybridModel>::~HybridTaggerStrategy()
+{
+}
+}
+
+#endif // HYBRID_TAGGER_STRATEGY_H

--- a/src/amr/tagging/scaledavg_hybrid_tagger_strategy.h
+++ b/src/amr/tagging/scaledavg_hybrid_tagger_strategy.h
@@ -1,0 +1,61 @@
+#ifndef SCALEDAVG_HYBRID_TAGGER_STRATEGY_H
+#define SCALEDAVG_HYBRID_TAGGER_STRATEGY_H
+
+#include "hybrid_tagger_strategy.h"
+#include "core/data/grid/gridlayoutdefs.h"
+#include "core/data/vecfield/vecfield_component.h"
+
+
+namespace PHARE::amr
+{
+template<typename HybridModel>
+class ScaledAvgHybridTaggerStrategy : public HybridTaggerStrategy<HybridModel>
+{
+    using gridlayout_type           = typename HybridModel::gridlayout_type;
+    static auto constexpr dimension = HybridModel::dimension;
+
+public:
+    void tag(HybridModel& model, gridlayout_type const& layout, int* tags) const override;
+};
+
+template<typename HybridModel>
+void ScaledAvgHybridTaggerStrategy<HybridModel>::tag(HybridModel& model,
+                                                     gridlayout_type const& layout, int* tags) const
+{
+    auto& Bx = model.state.electromag.B.getComponent(PHARE::core::Component::X);
+    auto& By = model.state.electromag.B.getComponent(PHARE::core::Component::Y);
+    auto& Bz = model.state.electromag.B.getComponent(PHARE::core::Component::Z);
+
+    auto start
+        = layout.physicalStartIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+    auto end = layout.physicalEndIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+
+    auto endCell     = layout.nbrCells()[0] - 1;
+    double threshold = 0.1;
+
+
+    if constexpr (dimension == 1)
+    {
+        for (auto iCell = 0u, ix = start; iCell <= endCell; ++ix, ++iCell)
+        {
+            auto Bxavg = (Bx(ix - 1) + Bx(ix) + Bx(ix + 1)) / 3.;
+            auto Byavg = (By(ix - 1) + By(ix) + By(ix + 1)) / 3.;
+            auto Bzavg = (Bz(ix - 1) + Bz(ix) + Bz(ix + 1)) / 3.;
+
+            auto diffx = std::abs(Bxavg - Bx(ix));
+            auto diffy = std::abs(Byavg - By(ix));
+            auto diffz = std::abs(Bzavg - Bz(ix));
+
+            auto max = std::max({diffx, diffy, diffz});
+            if (max > threshold)
+            {
+                tags[iCell] = 1;
+            }
+            else
+                tags[iCell] = 0;
+        }
+    }
+}
+} // namespace PHARE::amr
+
+#endif // SCALEDAVG_HYBRID_TAGGER_STRATEGY_H

--- a/src/amr/tagging/tagger.h
+++ b/src/amr/tagging/tagger.h
@@ -1,0 +1,33 @@
+
+#ifndef PHARE_TAGGER_H
+#define PHARE_TAGGER_H
+
+#include "physical_models/physical_model.h"
+#include "amr/types/amr_types.h"
+
+#include <memory>
+
+namespace PHARE::amr
+{
+class Tagger
+{
+protected:
+    using patch_t = PHARE::amr::SAMRAI_Types::patch_t;
+    using amr_t   = PHARE::amr::SAMRAI_Types;
+    std::string name_;
+
+public:
+    Tagger(std::string name)
+        : name_{name}
+    {
+    }
+    std::string name() { return name_; }
+    virtual void tag(PHARE::solver::IPhysicalModel<amr_t>& model, patch_t& patch, int tag_index)
+        = 0;
+    virtual ~Tagger(){};
+};
+
+
+} // namespace PHARE::amr
+
+#endif

--- a/src/amr/tagging/tagger_factory.h
+++ b/src/amr/tagging/tagger_factory.h
@@ -1,0 +1,42 @@
+
+#ifndef PHARE_TAGGER_FACTORY_H
+#define PHARE_TAGGER_FACTORY_H
+
+#include <string>
+#include <memory>
+
+#include "tagger.h"
+#include "hybrid_tagger.h"
+#include "hybrid_tagger_strategy.h"
+#include "scaledavg_hybrid_tagger_strategy.h"
+
+namespace PHARE::amr
+{
+template<typename PHARE_T>
+class TaggerFactory
+{
+public:
+    TaggerFactory() = delete;
+    static std::unique_ptr<Tagger> make(std::string modelName, std::string methodName);
+};
+
+template<typename PHARE_T>
+std::unique_ptr<Tagger> TaggerFactory<PHARE_T>::make(std::string modelName, std::string methodName)
+{
+    if (modelName == "HybridModel")
+    {
+        using HybridModel = typename PHARE_T::HybridModel_t;
+        using HT          = HybridTagger<HybridModel>;
+        using HTS         = ScaledAvgHybridTaggerStrategy<HybridModel>;
+        return std::make_unique<HT>(std::make_unique<HTS>());
+    }
+    return nullptr;
+}
+
+
+} // namespace PHARE::amr
+
+
+
+
+#endif

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -7,6 +7,8 @@
 #include "phare_core.h"
 #include "phare_types.h"
 
+#include "amr/tagging/tagger_factory.h"
+#include <chrono>
 
 
 namespace PHARE
@@ -152,9 +154,15 @@ Simulator<_dimension, _interp_order, _nbRefinedPart>::Simulator(
         // since for now it is the only model available
         // same for the solver
         multiphysInteg_->registerModel(0, maxLevelNumber_ - 1, hybridModel_);
+
         multiphysInteg_->registerAndInitSolver(
             0, maxLevelNumber_ - 1, std::make_unique<SolverPPC>(dict["simulation"]["algo"]));
+
         multiphysInteg_->registerAndSetupMessengers(messengerFactory_);
+
+        // hard coded for now, should get some params later from the dict
+        auto hybridTagger_ = amr::TaggerFactory<PHARETypes>::make("HybridModel", "scaledAvg");
+        multiphysInteg_->registerTagger(0, maxLevelNumber_ - 1, std::move(hybridTagger_));
 
 
         auto startTime = 0.; // TODO make it runtime

--- a/src/solver/level_initializer/hybrid_level_initializer.h
+++ b/src/solver/level_initializer/hybrid_level_initializer.h
@@ -69,7 +69,7 @@ namespace solver
                 else
                 {
                     messenger.initLevel(model, level, initDataTime);
-                    messenger.prepareStep(model, level);
+                    messenger.prepareStep(model, level, initDataTime);
                 }
             }
 

--- a/src/solver/physical_models/hybrid_model.h
+++ b/src/solver/physical_models/hybrid_model.h
@@ -13,157 +13,172 @@
 #include "amr/resources_manager/resources_manager.h"
 #include "amr/messengers/hybrid_messenger_info.h"
 
-namespace PHARE
+namespace PHARE::solver
 {
-namespace solver
+/**
+ * @brief The HybridModel class is a concrete implementation of a IPhysicalModel. The class
+ * holds a HybridState and a ResourcesManager.
+ */
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+class HybridModel : public IPhysicalModel<AMR_Types>
 {
+public:
+    using type_list = PHARE::core::type_list<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>;
+    using Interface = IPhysicalModel<AMR_Types>;
+    using amr_types = AMR_Types;
+    using patch_t   = typename AMR_Types::patch_t;
+    using level_t   = typename AMR_Types::level_t;
+    static const std::string model_name;
+    using gridlayout_type           = GridLayoutT;
+    using electromag_type           = Electromag;
+    using vecfield_type             = typename Electromag::vecfield_type;
+    using field_type                = typename vecfield_type::field_type;
+    using ions_type                 = Ions;
+    using particle_array_type       = typename Ions::particle_array_type;
+    using resources_manager_type    = amr::ResourcesManager<gridlayout_type>;
+    static constexpr auto dimension = GridLayoutT::dimension;
+    using ParticleInitializerFactory
+        = core::ParticleInitializerFactory<particle_array_type, gridlayout_type>;
+
+
+    core::HybridState<Electromag, Ions, Electrons> state;
+    std::shared_ptr<resources_manager_type> resourcesManager;
+
+
+    virtual void initialize(level_t& level) override;
+
+
     /**
-     * @brief The HybridModel class is a concrete implementation of a IPhysicalModel. The class
-     * holds a HybridState and a ResourcesManager.
+     * @brief allocate uses the ResourcesManager to allocate HybridState physical quantities on
+     * the given Patch at the given allocateTime
      */
-    template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
-             typename AMR_Types>
-    class HybridModel : public IPhysicalModel<AMR_Types>
+    virtual void allocate(patch_t& patch, double const allocateTime) override
     {
-    public:
-        using type_list
-            = PHARE::core::type_list<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>;
-        using Interface = IPhysicalModel<AMR_Types>;
-        using amr_types = AMR_Types;
-        using patch_t   = typename AMR_Types::patch_t;
-        using level_t   = typename AMR_Types::level_t;
-        static const std::string model_name;
-        using gridlayout_type           = GridLayoutT;
-        using electromag_type           = Electromag;
-        using vecfield_type             = typename Electromag::vecfield_type;
-        using field_type                = typename vecfield_type::field_type;
-        using ions_type                 = Ions;
-        using particle_array_type       = typename Ions::particle_array_type;
-        using resources_manager_type    = amr::ResourcesManager<gridlayout_type>;
-        static constexpr auto dimension = GridLayoutT::dimension;
-        using ParticleInitializerFactory
-            = core::ParticleInitializerFactory<particle_array_type, gridlayout_type>;
-
-        //! Physical quantities associated with hybrid equations
-        core::HybridState<Electromag, Ions, Electrons> state;
-
-        //! ResourcesManager used for interacting with SAMRAI databases, patchdata etc.
-        std::shared_ptr<resources_manager_type> resourcesManager;
+        resourcesManager->allocate(state, patch, allocateTime);
+    }
 
 
-
-        HybridModel(PHARE::initializer::PHAREDict dict,
-                    std::shared_ptr<resources_manager_type> const& _resourcesManager)
-            : IPhysicalModel<AMR_Types>{model_name}
-            , state{dict}
-            , resourcesManager{std::move(_resourcesManager)}
-        {
-        }
+    /**
+     * @brief fillMessengerInfo describes which variables of the model are to be initialized or
+     * filled at ghost nodes.
+     */
+    virtual void fillMessengerInfo(std::unique_ptr<amr::IMessengerInfo> const& info) const override;
 
 
-        virtual void initialize(level_t& level) override
-        {
-            for (auto& patch : level)
-            {
-                // first initialize the ions
-                auto layout = amr::layoutFromPatch<gridlayout_type>(*patch);
-                auto& ions  = state.ions;
-                auto _ = this->resourcesManager->setOnPatch(*patch, state.electromag, state.ions);
-
-                for (auto& pop : ions)
-                {
-                    auto info                = pop.particleInitializerInfo();
-                    auto particleInitializer = ParticleInitializerFactory::create(info);
-                    particleInitializer->loadParticles(pop.domainParticles(), layout);
-                }
-
-                state.electromag.initialize(layout);
-            }
-        }
+    auto setOnPatch(patch_t& patch) { return resourcesManager->setOnPatch(patch, *this); }
 
 
-
-        /**
-         * @brief allocate uses the ResourcesManager to allocate HybridState physical quantities on
-         * the given Patch at the given allocateTime
-         */
-        virtual void allocate(patch_t& patch, double const allocateTime) override
-        {
-            resourcesManager->allocate(state, patch, allocateTime);
-        }
-
-
-        /**
-         * @brief fillMessengerInfo describes which variables of the model are to be initialized or
-         * filled at ghost nodes.
-         */
-        virtual void
-        fillMessengerInfo(std::unique_ptr<amr::IMessengerInfo> const& info) const override
-        {
-            auto& modelInfo = dynamic_cast<amr::HybridMessengerInfo&>(*info);
-
-            modelInfo.modelMagnetic        = amr::VecFieldDescriptor{state.electromag.B};
-            modelInfo.modelElectric        = amr::VecFieldDescriptor{state.electromag.E};
-            modelInfo.modelIonDensity      = state.ions.densityName();
-            modelInfo.modelIonBulkVelocity = amr::VecFieldDescriptor{state.ions.velocity()};
-            modelInfo.modelCurrent         = amr::VecFieldDescriptor{state.J};
-
-            modelInfo.initElectric.emplace_back(state.electromag.E);
-            modelInfo.initMagnetic.emplace_back(state.electromag.B);
-
-            modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
-            modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
-            modelInfo.ghostCurrent.push_back(state.J);
-
-
-            auto transform_ = [](auto& ions, auto& inserter) {
-                std::transform(std::begin(ions), std::end(ions), std::back_inserter(inserter),
-                               [](auto const& pop) { return pop.name(); });
-            };
-            transform_(state.ions, modelInfo.interiorParticles);
-            transform_(state.ions, modelInfo.levelGhostParticlesOld);
-            transform_(state.ions, modelInfo.levelGhostParticlesNew);
-            transform_(state.ions, modelInfo.patchGhostParticles);
-        }
-
-        virtual ~HybridModel() override {}
-
-        //-------------------------------------------------------------------------
-        //                  start the ResourcesUser interface
-        //-------------------------------------------------------------------------
-
-        bool isUsable() const { return state.isUsable(); }
-
-        bool isSettable() const { return state.isSettable(); }
-
-        auto getCompileTimeResourcesUserList() const { return std::forward_as_tuple(state); }
-
-        auto getCompileTimeResourcesUserList() { return std::forward_as_tuple(state); }
-
-        //-------------------------------------------------------------------------
-        //                  ends the ResourcesUser interface
-        //-------------------------------------------------------------------------
-    };
-
-    template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
-             typename AMR_Types>
-    const std::string HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::model_name
-        = "HybridModel";
-
-    template<typename... Args>
-    HybridModel<Args...> hybrid_model_from_type_list(core::type_list<Args...>);
-
-    template<typename TypeList>
-    struct type_list_to_hybrid_model
+    HybridModel(PHARE::initializer::PHAREDict dict,
+                std::shared_ptr<resources_manager_type> const& _resourcesManager)
+        : IPhysicalModel<AMR_Types>{model_name}
+        , state{dict}
+        , resourcesManager{std::move(_resourcesManager)}
     {
-        using type = decltype(hybrid_model_from_type_list(std::declval<TypeList>()));
+    }
+
+
+    virtual ~HybridModel() override {}
+
+    //-------------------------------------------------------------------------
+    //                  start the ResourcesUser interface
+    //-------------------------------------------------------------------------
+
+    bool isUsable() const { return state.isUsable(); }
+
+    bool isSettable() const { return state.isSettable(); }
+
+    auto getCompileTimeResourcesUserList() const { return std::forward_as_tuple(state); }
+
+    auto getCompileTimeResourcesUserList() { return std::forward_as_tuple(state); }
+
+    //-------------------------------------------------------------------------
+    //                  ends the ResourcesUser interface
+    //-------------------------------------------------------------------------
+};
+
+
+
+
+//-------------------------------------------------------------------------
+//                             definitions
+//-------------------------------------------------------------------------
+
+
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::initialize(level_t& level)
+{
+    for (auto& patch : level)
+    {
+        // first initialize the ions
+        auto layout = amr::layoutFromPatch<gridlayout_type>(*patch);
+        auto& ions  = state.ions;
+        auto _      = this->resourcesManager->setOnPatch(*patch, state.electromag, state.ions);
+
+        for (auto& pop : ions)
+        {
+            auto info                = pop.particleInitializerInfo();
+            auto particleInitializer = ParticleInitializerFactory::create(info);
+            particleInitializer->loadParticles(pop.domainParticles(), layout);
+        }
+
+        state.electromag.initialize(layout);
+    }
+}
+
+
+
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::fillMessengerInfo(
+    std::unique_ptr<amr::IMessengerInfo> const& info) const
+{
+    auto& modelInfo = dynamic_cast<amr::HybridMessengerInfo&>(*info);
+
+    modelInfo.modelMagnetic        = amr::VecFieldDescriptor{state.electromag.B};
+    modelInfo.modelElectric        = amr::VecFieldDescriptor{state.electromag.E};
+    modelInfo.modelIonDensity      = state.ions.densityName();
+    modelInfo.modelIonBulkVelocity = amr::VecFieldDescriptor{state.ions.velocity()};
+    modelInfo.modelCurrent         = amr::VecFieldDescriptor{state.J};
+
+    modelInfo.initElectric.emplace_back(state.electromag.E);
+    modelInfo.initMagnetic.emplace_back(state.electromag.B);
+
+    modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
+    modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
+    modelInfo.ghostCurrent.push_back(state.J);
+
+
+    auto transform_ = [](auto& ions, auto& inserter) {
+        std::transform(std::begin(ions), std::end(ions), std::back_inserter(inserter),
+                       [](auto const& pop) { return pop.name(); });
     };
+    transform_(state.ions, modelInfo.interiorParticles);
+    transform_(state.ions, modelInfo.levelGhostParticlesOld);
+    transform_(state.ions, modelInfo.levelGhostParticlesNew);
+    transform_(state.ions, modelInfo.patchGhostParticles);
+}
 
-    template<typename TypeList>
-    using type_list_to_hybrid_model_t = typename type_list_to_hybrid_model<TypeList>::type;
 
-} // namespace solver
 
-} // namespace PHARE
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+const std::string HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::model_name
+    = "HybridModel";
+
+template<typename... Args>
+HybridModel<Args...> hybrid_model_from_type_list(core::type_list<Args...>);
+
+template<typename TypeList>
+struct type_list_to_hybrid_model
+{
+    using type = decltype(hybrid_model_from_type_list(std::declval<TypeList>()));
+};
+
+template<typename TypeList>
+using type_list_to_hybrid_model_t = typename type_list_to_hybrid_model<TypeList>::type;
+
+} // namespace PHARE::solver
 
 #endif

--- a/src/solver/physical_models/mhd_model.h
+++ b/src/solver/physical_models/mhd_model.h
@@ -55,6 +55,9 @@ namespace solver
         {
         }
 
+        auto setOnPatch(patch_t& patch) { return resourcesManager->setOnPatch(patch, *this); }
+
+
         virtual ~MHDModel() override = default;
 
         core::MHDState<VecFieldT> state;

--- a/tests/amr/messengers/test_messengers.cpp
+++ b/tests/amr/messengers/test_messengers.cpp
@@ -519,7 +519,7 @@ void AfullHybridBasicHierarchy<dimension, nbRefinePart>::fillsRefinedLevelFieldG
 
 
     // this prepareStep copies the current model EM into messenger EM
-    messenger->prepareStep(*hybridModel, *level0);
+    messenger->prepareStep(*hybridModel, *level0, 0);
 
 
     // here we set the level 0 at t=1, this simulates the advanceLevel

--- a/tests/amr/tagging/CMakeLists.txt
+++ b/tests/amr/tagging/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(test-tagging)
+
+
+
+set(SOURCES_CPP
+  test_tagging.cpp
+   )
+
+add_executable(${PROJECT_NAME} ${SOURCES_INC} ${SOURCES_CPP})
+
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  ${GTEST_INCLUDE_DIRS}
+  )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  phare_amr
+  phare_solver
+  ${GTEST_LIBS})
+
+
+add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+
+

--- a/tests/amr/tagging/test_tagging.cpp
+++ b/tests/amr/tagging/test_tagging.cpp
@@ -1,0 +1,221 @@
+
+
+#include "phare/phare.h"
+#include "amr/tagging/tagger.h"
+#include "amr/tagging/tagger_factory.h"
+#include "amr/resources_manager/resources_manager.h"
+
+#include "core/data/ndarray/ndarray_vector.h"
+#include "core/models/hybrid_state.h"
+#include "core/utilities/span.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace PHARE::amr;
+
+
+
+
+TEST(test_tagger, fromFactory)
+{
+    using phare_types = PHARE::PHARE_Types<1, 1, 2>;
+    auto hybridTagger = TaggerFactory<phare_types>::make("HybridModel", "scaledAvg");
+    EXPECT_TRUE(hybridTagger != nullptr);
+
+    auto badTagger = TaggerFactory<phare_types>::make("invalidModel", "scaledAvg");
+    EXPECT_TRUE(badTagger == nullptr);
+}
+
+
+
+using Param   = std::vector<double> const;
+using RetType = std::shared_ptr<PHARE::core::Span<double>>;
+
+RetType step(Param& x)
+{
+    std::vector<double> values(x.size());
+    std::transform(std::begin(x), std::end(x), std::begin(values),
+                   [](auto xx) { return std::tanh((xx - 0.52) / 0.05); });
+    return std::make_shared<PHARE::core::VectorSpan<double>>(std::move(values));
+}
+
+
+using InitFunctionT = PHARE::initializer::InitFunction<1>;
+
+PHARE::initializer::PHAREDict createDict()
+{
+    PHARE::initializer::PHAREDict dict;
+    dict["ions"]["nbrPopulations"] = int{2};
+    dict["ions"]["pop0"]["name"]   = std::string{"protons"};
+    dict["ions"]["pop0"]["mass"]   = 1.;
+    dict["ions"]["pop0"]["ParticleInitializer"]["name"]
+        = std::string{"MaxwellianParticleInitializer"};
+    dict["ions"]["pop0"]["ParticleInitializer"]["density"] = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = int{100};
+    dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
+    dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
+
+    dict["ions"]["pop1"]["name"] = std::string{"alpha"};
+    dict["ions"]["pop1"]["mass"] = 1.;
+    dict["ions"]["pop1"]["ParticleInitializer"]["name"]
+        = std::string{"MaxwellianParticleInitializer"};
+    dict["ions"]["pop1"]["ParticleInitializer"]["density"] = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = int{100};
+    dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;
+    dict["ions"]["pop1"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
+
+    dict["electromag"]["name"]             = std::string{"EM"};
+    dict["electromag"]["electric"]["name"] = std::string{"E"};
+    dict["electromag"]["magnetic"]["name"] = std::string{"B"};
+
+    dict["electromag"]["magnetic"]["initializer"]["x_component"] = static_cast<InitFunctionT>(step);
+    dict["electromag"]["magnetic"]["initializer"]["y_component"] = static_cast<InitFunctionT>(step);
+    dict["electromag"]["magnetic"]["initializer"]["z_component"] = static_cast<InitFunctionT>(step);
+
+    dict["electrons"]["pressure_closure"]["name"] = std::string{"isothermal"};
+    dict["electrons"]["pressure_closure"]["Te"]   = 0.12;
+
+    return dict;
+}
+
+
+
+
+struct TestTagger : public ::testing::Test
+{
+    static constexpr auto dim            = 1;
+    static constexpr auto interp_order   = 1;
+    static constexpr auto refinedPartNbr = 2;
+
+    using phare_types = PHARE::PHARE_Types<dim, interp_order, refinedPartNbr>;
+    using Electromag  = typename phare_types::Electromag_t;
+    using Ions        = typename phare_types::Ions_t;
+    using Electrons   = typename phare_types::Electrons_t;
+    using Field       = typename phare_types::Field_t;
+    using GridLayoutT = GridLayout<GridLayoutImplYee<dim, interp_order>>;
+
+    struct SinglePatchHybridModel
+    {
+        using gridlayout_type           = GridLayout<GridLayoutImplYee<dim, interp_order>>;
+        static auto constexpr dimension = dim;
+        HybridState<Electromag, Ions, Electrons> state;
+    };
+
+
+    GridLayoutT layout;
+    Field Bx, By, Bz;
+    Field Ex, Ey, Ez;
+    SinglePatchHybridModel model;
+    std::vector<int> tags;
+
+    TestTagger()
+        : layout{{0.05}, {20}, {0.}}
+        , Bx{"Bx", HybridQuantity::Scalar::Bx, layout.allocSize(HybridQuantity::Scalar::Bx)}
+        , By{"By", HybridQuantity::Scalar::By, layout.allocSize(HybridQuantity::Scalar::By)}
+        , Bz{"Bz", HybridQuantity::Scalar::Bz, layout.allocSize(HybridQuantity::Scalar::Bz)}
+        , Ex{"Ex", HybridQuantity::Scalar::Ex, layout.allocSize(HybridQuantity::Scalar::Ex)}
+        , Ey{"Ey", HybridQuantity::Scalar::Ey, layout.allocSize(HybridQuantity::Scalar::Ey)}
+        , Ez{"Ez", HybridQuantity::Scalar::Ez, layout.allocSize(HybridQuantity::Scalar::Ez)}
+        , model{createDict()}
+        , tags(20 + layout.nbrGhosts(PHARE::core::QtyCentering::dual))
+    {
+        model.state.electromag.E.setBuffer("EM_E_x", &Ex);
+        model.state.electromag.E.setBuffer("EM_E_y", &Ey);
+        model.state.electromag.E.setBuffer("EM_E_z", &Ez);
+        model.state.electromag.B.setBuffer("EM_B_x", &Bx);
+        model.state.electromag.B.setBuffer("EM_B_y", &By);
+        model.state.electromag.B.setBuffer("EM_B_z", &Bz);
+        model.state.electromag.initialize(layout);
+    }
+};
+
+
+TEST_F(TestTagger, scaledAvg)
+{
+    auto strat = ScaledAvgHybridTaggerStrategy<SinglePatchHybridModel>();
+    strat.tag(model, layout, tags.data());
+    {
+        auto start
+            = layout.physicalStartIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+        auto end
+            = layout.physicalEndIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+
+        auto endCell     = layout.nbrCells()[0] - 1;
+        double threshold = 0.1;
+
+
+        for (auto iCell = 0u, ix = start; iCell <= endCell; ++ix, ++iCell)
+        {
+            auto Bxavg = (Bx(ix - 1) + Bx(ix) + Bx(ix + 1)) / 3.;
+            auto Byavg = (By(ix - 1) + By(ix) + By(ix + 1)) / 3.;
+            auto Bzavg = (Bz(ix - 1) + Bz(ix) + Bz(ix + 1)) / 3.;
+
+            auto diffx = std::abs(Bxavg - Bx(ix));
+            auto diffy = std::abs(Byavg - By(ix));
+            auto diffz = std::abs(Bzavg - Bz(ix));
+
+            auto max = std::max({diffx, diffy, diffz});
+            if (max > threshold)
+            {
+                tags[iCell] = 1;
+            }
+            else
+                tags[iCell] = 0;
+        }
+    }
+}
+
+
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    int testResult = RUN_ALL_TESTS();
+    return testResult;
+}

--- a/tests/core/data/maxwellian_particle_initializer/test_maxwellian_particle_initializer.cpp
+++ b/tests/core/data/maxwellian_particle_initializer/test_maxwellian_particle_initializer.cpp
@@ -40,7 +40,7 @@ public:
 
     GridLayoutT layout;
     ParticleArrayT particles;
-    std::uint32_t nbrParticlesPerCell{1000};
+    std::uint32_t nbrParticlesPerCell{10000};
     std::unique_ptr<MaxwellianParticleInitializer<ParticleArrayT, GridLayoutT>> initializer;
 };
 
@@ -68,6 +68,8 @@ TEST_F(AMaxwellianParticleInitializer1D, loadsParticlesInTheDomain)
         auto pos       = positionAsPoint(particle, layout);
         auto endDomain = layout.origin()[0] + layout.nbrCells()[0] * layout.meshSize()[0];
 
+        if (!((pos[0] > 0.) and (pos[0] < endDomain)))
+            std::cout << "position : " << pos[0] << " not in domain (0," << endDomain << "\n";
         EXPECT_TRUE(pos[0] > 0. && pos[0] < endDomain);
         i++;
     }

--- a/tests/functional/tdtagged/CMakeLists.txt
+++ b/tests/functional/tdtagged/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(test-tdtagged)
+
+if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  file(GLOB PYFILES "*.py")
+  file(COPY ${PYFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+if(HighFive)
+
+  ## These test use dump diagnostics so require HighFive!
+phare_python3_exec(9 test-td-tagged td1dtagged.py ${CMAKE_CURRENT_BINARY_DIR})
+endif()

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -35,10 +35,10 @@ def config():
     Simulation(
         smallest_patch_size=10,
         largest_patch_size=20,
-        time_step_nbr=200,        # number of time steps (not specified if time_step and final_time provided)
-        final_time=2.5,             # simulation final time (not specified if time_step and time_step_nbr provided)
+        time_step_nbr=100,        # number of time steps (not specified if time_step and final_time provided)
+        final_time=25,             # simulation final time (not specified if time_step and time_step_nbr provided)
         boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
-        cells=80,                # integer or tuple length == dimension
+        cells=500,                # integer or tuple length == dimension
         dl=1,                  # mesh size of the root level, float or tuple
         max_nbr_levels=3,          # (default=1) max nbr of levels in the AMR hierarchy
         nesting_buffer=2,
@@ -111,7 +111,7 @@ def config():
 
     MaxwellianFluidModel(
         bx=bx, by=by, bz=bz,
-        protons={"charge": 1, "density": density, **vvv, "init": {"seed": 1337}}
+        protons={"charge": 1, "density": density, **vvv}
     )
 
     ElectronModel(closure="isothermal", Te=0.12)
@@ -120,7 +120,7 @@ def config():
 
     sim = ph.global_vars.sim
 
-    timestamps = np.arange(0, sim.final_time +sim.time_step, 5*sim.time_step)
+    timestamps = np.arange(0, sim.final_time +sim.time_step, sim.time_step)
 
 
 

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+from pybindlibs import cpp
+
+import pyphare.pharein as ph
+from pyphare.pharein import Simulation
+from pyphare.pharein import MaxwellianFluidModel
+from pyphare.pharein import ElectromagDiagnostics,FluidDiagnostics
+from pyphare.pharein import ElectronModel
+from pyphare.simulator.simulator import Simulator
+from pyphare.pharein import global_vars as gv
+import numpy as np
+
+from pyphare.pharesee.hierarchy import hierarchy_from
+
+
+import matplotlib.pyplot as plt
+
+
+import matplotlib as mpl
+import shutil
+import os
+import time
+mpl.use('Agg')
+
+
+
+
+def config():
+    """ Configure the simulation
+
+    This function defines the Simulation object,
+    user initialization model and diagnostics.
+    """
+    Simulation(
+        smallest_patch_size=10,
+        largest_patch_size=20,
+        time_step_nbr=200,        # number of time steps (not specified if time_step and final_time provided)
+        final_time=2.5,             # simulation final time (not specified if time_step and time_step_nbr provided)
+        boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
+        cells=80,                # integer or tuple length == dimension
+        dl=1,                  # mesh size of the root level, float or tuple
+        max_nbr_levels=3,          # (default=1) max nbr of levels in the AMR hierarchy
+        nesting_buffer=2,
+        refinement = "tagging",
+        diag_options={"format": "phareh5", "options": {"dir": "phare_outputs","mode":"overwrite"}}
+    )
+
+
+    def density(x):
+        return 1.
+
+
+    def S(x,x0,l):
+        return 0.5*(1+np.tanh((x-x0)/l))
+
+
+    def bx(x):
+        return 0.
+
+
+    def by(x):
+        from pyphare.pharein.global_vars import sim
+        L = sim.simulation_domain()[0]
+        v1=-1
+        v2=1.
+        return v1 + (v2-v1)*(S(x,L*0.25,1) -S(x, L*0.75, 1))
+
+
+    def bz(x):
+        return 0.5
+
+
+    def b2(x):
+        return bx(x)**2 + by(x)**2 + bz(x)**2
+
+
+    def T(x):
+        K = 1
+        return 1/density(x)*(K - b2(x)*0.5)
+
+
+    def vx(x):
+        return 0.
+
+
+    def vy(x):
+        return 0.
+
+
+    def vz(x):
+        return 0.
+
+
+    def vthx(x):
+        return T(x)
+
+
+    def vthy(x):
+        return T(x)
+
+
+    def vthz(x):
+        return T(x)
+
+
+    vvv = {
+        "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
+        "vthx": vthx, "vthy": vthy, "vthz": vthz
+    }
+
+    MaxwellianFluidModel(
+        bx=bx, by=by, bz=bz,
+        protons={"charge": 1, "density": density, **vvv, "init": {"seed": 1337}}
+    )
+
+    ElectronModel(closure="isothermal", Te=0.12)
+
+
+
+    sim = ph.global_vars.sim
+
+    timestamps = np.arange(0, sim.final_time +sim.time_step, 5*sim.time_step)
+
+
+
+    for quantity in ["E", "B"]:
+        ElectromagDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+        )
+
+
+    for quantity in ["density", "bulkVelocity"]:
+        FluidDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+            )
+
+
+
+
+def plot(bhier):
+    times = np.sort(np.asarray(list(bhier.time_hier.keys())))
+
+    components  =("B_y", "B_z")
+    ylims = ((-1.25, 1.25),(0.,1.0))
+
+    for component,ylim in zip(components,ylims):
+        for it,t in enumerate(times):
+            fig,ax = plt.subplots(figsize=(10,6))
+            for il,level in bhier.levels(t).items():
+                patches = level.patches
+                if il == 0:
+                    marker="+"
+                    alpha=1
+                    ls='-'
+                else:
+                    marker='o'
+                    alpha=0.4
+                    ls='none'
+
+                for ip, patch in enumerate(patches):
+                    val   = patch.patch_datas["EM_"+component].dataset[:]
+                    x_val = patch.patch_datas["EM_"+component].x
+                    label="${}$ level {} patch {}".format(component,il,ip)
+                    ax.plot(x_val, val, label=label,
+                            marker=marker, alpha=alpha, ls=ls)
+                    ax.set_ylim(ylim)
+
+            ax.legend(ncol=4)
+            ax.set_title("t = {:05.2f}".format(t))
+            fig.savefig("{}_{:04d}.png".format(component,it))
+            plt.close(fig)
+
+
+
+def main():
+    config()
+    simulator = Simulator(gv.sim)
+    simulator.initialize()
+    simulator.run()
+
+
+    if cpp.mpi_rank() == 0:
+        b = hierarchy_from(h5_filename="phare_outputs/EM_B.h5")
+        plot(b)
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
#9 

Add Tagger for automatic refinement
`MultiphysicsIntegrator`  uses the Tagger, which is abstract and actually depends on which model is being solved at current level.
There are therefore concrete taggers, per model. Each concrete Tagger can then have multiple tagging strategies. Only 1 is now coded. (Other attempts may come later, and also may be taken from user supplied python tagging methods.)

Bug fixes

- first bug fix concerns EM_old and Jold in the hybridMessenger. These quantities are supposed to store the current state of those model variables at time n before the level advances to time n+1. They are then used by next finer level to get ghosts at subcycle times which are per definition between coarse steps n and n+1. before this PR, the "old" quantities had their patchdata timestamp fixed at the creation of the level but never updated afterwards. The current PR thus sets their timestamps in `prepareStep`, i.e. before every advance().

- fix bug concerning regriding: Regriding means taking a level out of the hierarchy and replacing it by a new one. This action invalidates all the schedules stored in the RefinerPool that deal with the level being replaced. This PR now re-create schedules for the level that's being regrided and the next finer as well. This is important because SAMRAI typically will do things in the following order:

- for a hierarchy with 2 levels:
- tag level 1
- create level 2 
- regrid level 1

thus at the time L2 is created, its schedules are made with the L1 taht is about to be taken out of the hierarchy. This PR now re-makes these schedules when regriding L1.

- the PR also adds particles to the maxwellian initializer test as well as prints, in an attempt to know more about latest (random?) failures observed of this tests...


tagging : 
The concrete tagging strategy that is implemented tags a cell (==1) when the local 3 points average of the magnetic field differs from the current value from more than 10%. It's a first attempt that seems to give consistent results in tha tdtagged functional test but will need further attention in upcoming PRs.



Notes : 
- The concrete tagging strategy ignores what samrai stuff is, and probably could be moved to a core lib section. That should be considered later as this matter possibly also concern other components.



