### PR TITLE
Add shock intial condition in functional tests

### DIFF
--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -15,21 +15,23 @@ yee_centering = {
         'Ex':'dual', 'Ey':'primal', 'Ez':'primal',
         'Jx':'dual', 'Jy':'primal', 'Jz':'primal',
         'rho':'primal', 'Vx':'primal','Vy':'primal',
-        'Vz':'primal','P':'primal'
+        "Fx":"primal","Fy":"primal","Fz":"primal",
+        'Vz':'primal','P':'primal', "Fx":"primal","Fy":"primal","Fz":"primal"
     },
     'y' : {
         'Bx':'dual', 'By':'primal', 'Bz':'dual',
         'Ex':'primal', 'Ey':'dual', 'Ez':'primal',
         'Jx':'primal', 'Jy':'dual', 'Jz':'primal',
         'rho':'primal', 'Vx':'primal','Vy':'primal',
-        'Vz':'primal','P':'primal'
+        'Vz':'primal','P':'primal', "Fx":"primal","Fy":"primal","Fz":"primal"
     },
     'z' : {
         'Bx':'dual', 'By':'dual', 'Bz':'primal',
         'Ex':'primal', 'Ey':'primal', 'Ez':'dual',
         'Jx':'primal', 'Jy':'primal', 'Jz':'dual',
         'rho':'primal', 'Vx':'primal','Vy':'primal',
-        'Vz':'primal', 'P':'primal'
+        "Fx":"primal","Fy":"primal","Fz":"primal",
+        'Vz':'primal', 'P':'primal', "Fx":"primal","Fy":"primal","Fz":"primal"
     }
 }
 yee_centering_lower = {
@@ -71,7 +73,7 @@ class GridLayout(object):
                                  'Ex','Ey','Ez',
                                  'Jx','Jy','Jz',
                                  'rho','Vx','Vy',
-                                 'Vz','P']
+                                 'Vz','P', 'Fx', 'Fy', 'Fz']
 
 
         self.yeeCentering = YeeCentering()

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -525,7 +525,7 @@ class Simulation(object):
         self.electrons = None
 
         # hard coded in C++ MultiPhysicsIntegrator::getMaxFinerLevelDt
-        self.nSubcycles = 10
+        self.nSubcycles = 4
         self.stepDiff = 1/self.nSubcycles
 
         levelNumbers = list(range(self.max_nbr_levels))

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -96,8 +96,6 @@ class Simulator:
         print("mean advance time = {}".format(np.mean(perf)))
         print("total advance time = {}".format(np.sum(perf)))
 
-        print(perf)
-
 
 
     def _auto_dump(self):

--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -172,7 +172,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
   add_subdirectory(tests/amr/messengers)
   add_subdirectory(tests/amr/models)
   add_subdirectory(tests/amr/multiphysics_integrator)
-
+  add_subdirectory(tests/amr/tagging)
 
   add_subdirectory(tests/diagnostic)
 
@@ -181,6 +181,9 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
   add_subdirectory(tests/functional/alfven_wave)
   add_subdirectory(tests/functional/td)
+  add_subdirectory(tests/functional/translation)
+  add_subdirectory(tests/functional/tdtagged)
+  add_subdirectory(tests/functional/shock)
 
   add_subdirectory(pyphare/pyphare_tests/test_pharesee/)
   add_subdirectory(pyphare/pyphare_tests/pharein/)

--- a/src/amr/CMakeLists.txt
+++ b/src/amr/CMakeLists.txt
@@ -42,6 +42,11 @@ set( SOURCES_INC
      types/amr_types.h
      wrappers/hierarchy.h
      wrappers/integrator.h
+     tagging/tagger.h
+     tagging/tagger_factory.h
+     tagging/hybrid_tagger.h
+     tagging/hybrid_tagger_strategy.h
+     tagging/default_hybrid_tagger_strategy.h
    )
 set( SOURCES_CPP
      data/field/refine/linear_weighter.cpp

--- a/src/amr/tagging/default_hybrid_tagger_strategy.h
+++ b/src/amr/tagging/default_hybrid_tagger_strategy.h
@@ -1,0 +1,79 @@
+#ifndef DEFAULT_HYBRID_TAGGER_STRATEGY_H
+#define DEFAULT_HYBRID_TAGGER_STRATEGY_H
+
+#include "hybrid_tagger_strategy.h"
+#include "core/data/grid/gridlayoutdefs.h"
+#include "core/data/vecfield/vecfield_component.h"
+
+
+namespace PHARE::amr
+{
+template<typename HybridModel>
+class DefaultHybridTaggerStrategy : public HybridTaggerStrategy<HybridModel>
+{
+    using gridlayout_type           = typename HybridModel::gridlayout_type;
+    static auto constexpr dimension = HybridModel::dimension;
+
+public:
+    void tag(HybridModel& model, gridlayout_type const& layout, int* tags) const override;
+};
+
+template<typename HybridModel>
+void DefaultHybridTaggerStrategy<HybridModel>::tag(HybridModel& model,
+                                                   gridlayout_type const& layout, int* tags) const
+{
+    auto& Bx = model.state.electromag.B.getComponent(PHARE::core::Component::X);
+    auto& By = model.state.electromag.B.getComponent(PHARE::core::Component::Y);
+    auto& Bz = model.state.electromag.B.getComponent(PHARE::core::Component::Z);
+
+    auto& N = model.state.ions.density();
+
+    // we loop on cell indexes for all qties regardless of their centering
+    auto start
+        = layout.physicalStartIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+    auto end = layout.physicalEndIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+
+    auto endCell     = layout.nbrCells()[0] - 1;
+    double threshold = 0.05;
+    int idx          = 4;
+    double epsilon   = 0.1;
+
+
+    if constexpr (dimension == 1)
+    {
+        for (auto iCell = 0u, ix = start; iCell <= endCell; ++ix, ++iCell)
+        {
+            auto Byavgm2 = 0.2 * (By(ix - 4) + By(ix - 3) + By(ix - 2) + By(ix - 1) + By(ix));
+            auto Byavgm1 = 0.2 * (By(ix - 3) + By(ix - 2) + By(ix - 1) + By(ix) + By(ix + 1));
+            auto Byavg   = 0.2 * (By(ix - 2) + By(ix - 1) + By(ix) + By(ix + 1) + By(ix + 2));
+            auto Byavgp1 = 0.2 * (By(ix - 1) + By(ix) + By(ix + 1) + By(ix + 2) + By(ix + 3));
+            auto Byavgp2 = 0.2 * (By(ix) + By(ix + 1) + By(ix + 2) + By(ix + 3) + By(ix + 4));
+
+            auto Bzavgm2 = 0.2 * (Bz(ix - 4) + Bz(ix - 3) + Bz(ix - 2) + Bz(ix - 1) + Bz(ix));
+            auto Bzavgm1 = 0.2 * (Bz(ix - 3) + Bz(ix - 2) + Bz(ix - 1) + Bz(ix) + Bz(ix + 1));
+            auto Bzavg   = 0.2 * (Bz(ix - 2) + Bz(ix - 1) + Bz(ix) + Bz(ix + 1) + Bz(ix + 2));
+            auto Bzavgp1 = 0.2 * (Bz(ix - 1) + Bz(ix) + Bz(ix + 1) + Bz(ix + 2) + Bz(ix + 3));
+            auto Bzavgp2 = 0.2 * (Bz(ix) + Bz(ix + 1) + Bz(ix + 2) + Bz(ix + 3) + Bz(ix + 4));
+
+            auto Navgp1 = 0.2 * (N(ix - 1) + N(ix) + N(ix + 1) + N(ix + 2) + N(ix + 3));
+            auto Navg   = 0.2 * (N(ix - 2) + N(ix - 1) + N(ix) + N(ix + 1) + N(ix + 2));
+
+            auto criter_by = std::abs(Byavgp1 - Byavg) / (1 + std::abs(Byavg));
+            auto criter_bz = std::abs(Bzavgp1 - Bzavg) / (1 + std::abs(Bzavg));
+            auto criter_b  = std::sqrt(criter_by * criter_by + criter_bz * criter_bz);
+            auto criter_n  = std::abs(Navgp1 - Navg) / (1 + std::abs(Navg));
+
+            auto criter = std::max(criter_b, criter_n);
+
+            if (criter > threshold)
+            {
+                tags[iCell] = 1;
+            }
+            else
+                tags[iCell] = 0;
+        }
+    }
+}
+} // namespace PHARE::amr
+
+#endif // LOHNER_HYBRID_TAGGER_STRATEGY_H

--- a/src/amr/tagging/hybrid_tagger.h
+++ b/src/amr/tagging/hybrid_tagger.h
@@ -1,0 +1,72 @@
+
+#ifndef PHARE_HYBRID_TAGGER_H
+#define PHARE_HYBRID_TAGGER_H
+
+#include "tagger.h"
+#include "hybrid_tagger_strategy.h"
+#include "solver/physical_models/hybrid_model.h"
+#include "amr/types/amr_types.h"
+
+#include <SAMRAI/pdat/CellData.h>
+
+#include <memory>
+#include <utility>
+#include <stdexcept>
+
+
+
+
+namespace PHARE::amr
+{
+template<typename HybridModel>
+class HybridTagger : public Tagger
+{
+    using patch_t         = typename Tagger::patch_t;
+    using amr_t           = PHARE::amr::SAMRAI_Types;
+    using IPhysicalModel  = PHARE::solver::IPhysicalModel<amr_t>;
+    using gridlayout_type = typename HybridModel::gridlayout_type;
+
+
+public:
+    HybridTagger(std::unique_ptr<HybridTaggerStrategy<HybridModel>> strat)
+        : Tagger{"HybridTagger"}
+        , strat_{std::move(strat)}
+    {
+    }
+
+    void tag(IPhysicalModel& model, patch_t& patch, int tag_index) override;
+
+private:
+    std::unique_ptr<HybridTaggerStrategy<HybridModel>> strat_;
+};
+
+
+
+
+//-----------------------------------------------------------------------------
+//                           Definitions
+//-----------------------------------------------------------------------------
+
+
+
+
+template<typename HybridModel>
+void HybridTagger<HybridModel>::tag(PHARE::solver::IPhysicalModel<amr_t>& model, patch_t& patch,
+                                    int tag_index)
+{
+    if (strat_)
+    {
+        auto& hybridModel   = dynamic_cast<HybridModel&>(model);
+        auto layout         = PHARE::amr::layoutFromPatch<gridlayout_type>(patch);
+        auto modelIsOnPatch = hybridModel.setOnPatch(patch);
+        auto pd   = dynamic_cast<SAMRAI::pdat::CellData<int>*>(patch.getPatchData(tag_index).get());
+        auto tags = pd->getPointer();
+        strat_->tag(hybridModel, layout, tags);
+    }
+    else
+        throw std::runtime_error("invalid tagging strategy");
+}
+
+} // namespace PHARE::amr
+
+#endif

--- a/src/amr/tagging/hybrid_tagger_strategy.h
+++ b/src/amr/tagging/hybrid_tagger_strategy.h
@@ -1,0 +1,23 @@
+#ifndef HYBRID_TAGGER_STRATEGY_H
+#define HYBRID_TAGGER_STRATEGY_H
+
+namespace PHARE::amr
+{
+
+template<typename HybridModel>
+class HybridTaggerStrategy
+{
+    using gridlayout_type = typename HybridModel::gridlayout_type;
+
+public:
+    virtual void tag(HybridModel& model, gridlayout_type const& layout, int* tags) const = 0;
+    virtual ~HybridTaggerStrategy()                                                      = 0;
+};
+
+template<typename HybridModel>
+HybridTaggerStrategy<HybridModel>::~HybridTaggerStrategy()
+{
+}
+}
+
+#endif // HYBRID_TAGGER_STRATEGY_H

--- a/src/amr/tagging/tagger.h
+++ b/src/amr/tagging/tagger.h
@@ -1,0 +1,33 @@
+
+#ifndef PHARE_TAGGER_H
+#define PHARE_TAGGER_H
+
+#include "physical_models/physical_model.h"
+#include "amr/types/amr_types.h"
+
+#include <memory>
+
+namespace PHARE::amr
+{
+class Tagger
+{
+protected:
+    using patch_t = PHARE::amr::SAMRAI_Types::patch_t;
+    using amr_t   = PHARE::amr::SAMRAI_Types;
+    std::string name_;
+
+public:
+    Tagger(std::string name)
+        : name_{name}
+    {
+    }
+    std::string name() { return name_; }
+    virtual void tag(PHARE::solver::IPhysicalModel<amr_t>& model, patch_t& patch, int tag_index)
+        = 0;
+    virtual ~Tagger(){};
+};
+
+
+} // namespace PHARE::amr
+
+#endif

--- a/src/amr/tagging/tagger_factory.h
+++ b/src/amr/tagging/tagger_factory.h
@@ -1,0 +1,46 @@
+
+#ifndef PHARE_TAGGER_FACTORY_H
+#define PHARE_TAGGER_FACTORY_H
+
+#include <string>
+#include <memory>
+
+#include "tagger.h"
+#include "hybrid_tagger.h"
+#include "hybrid_tagger_strategy.h"
+#include "default_hybrid_tagger_strategy.h"
+
+namespace PHARE::amr
+{
+template<typename PHARE_T>
+class TaggerFactory
+{
+public:
+    TaggerFactory() = delete;
+    static std::unique_ptr<Tagger> make(std::string modelName, std::string methodName);
+};
+
+template<typename PHARE_T>
+std::unique_ptr<Tagger> TaggerFactory<PHARE_T>::make(std::string modelName, std::string methodName)
+{
+    if (modelName == "HybridModel")
+    {
+        using HybridModel = typename PHARE_T::HybridModel_t;
+        using HT          = HybridTagger<HybridModel>;
+
+        if (methodName == "default")
+        {
+            using HTS = DefaultHybridTaggerStrategy<HybridModel>;
+            return std::make_unique<HT>(std::make_unique<HTS>());
+        }
+    }
+    return nullptr;
+}
+
+
+} // namespace PHARE::amr
+
+
+
+
+#endif

--- a/src/core/numerics/ohm/ohm.h
+++ b/src/core/numerics/ohm/ohm.h
@@ -270,7 +270,7 @@ namespace core
         auto hyperresistive_(VecField const& J, MeshIndex<VecField::dimension> index,
                              ComponentTag) const
         {
-            auto const nu = 0.001; // TODO : nu should comme from input file
+            auto const nu = 0.01; // TODO : nu should comme from input file
 
             if constexpr (ComponentTag::component == Component::X)
             {
@@ -312,9 +312,9 @@ namespace core
             for (auto ix = ix0; ix <= ix1; ++ix)
             {
                 Ex(ix) = ideal1D_(Ve, B, {ix}, ComponentTag<Component::X>{})
-                         + pressure_(n, Pe, {ix}, ComponentTag<Component::X>{})
-                         + resistive_(J, {ix}, ComponentTag<Component::X>{})
-                         + hyperresistive_(J, {ix}, ComponentTag<Component::X>{});
+                         + 0 * pressure_(n, Pe, {ix}, ComponentTag<Component::X>{})
+                         + 0 * resistive_(J, {ix}, ComponentTag<Component::X>{})
+                         + 1 * hyperresistive_(J, {ix}, ComponentTag<Component::X>{});
             }
 
             ix0 = this->layout_->physicalStartIndex(Ey, Direction::X);
@@ -323,9 +323,9 @@ namespace core
             for (auto ix = ix0; ix <= ix1; ++ix)
             {
                 Ey(ix) = ideal1D_(Ve, B, {ix}, ComponentTag<Component::Y>{})
-                         + pressure_(n, Pe, {ix}, ComponentTag<Component::Y>{})
-                         + resistive_(J, {ix}, ComponentTag<Component::Y>{})
-                         + hyperresistive_(J, {ix}, ComponentTag<Component::Y>{});
+                         + 0 * pressure_(n, Pe, {ix}, ComponentTag<Component::Y>{})
+                         + 0 * resistive_(J, {ix}, ComponentTag<Component::Y>{})
+                         + 1 * hyperresistive_(J, {ix}, ComponentTag<Component::Y>{});
             }
 
             ix0 = this->layout_->physicalStartIndex(Ez, Direction::X);
@@ -334,9 +334,9 @@ namespace core
             for (auto ix = ix0; ix <= ix1; ++ix)
             {
                 Ez(ix) = ideal1D_(Ve, B, {ix}, ComponentTag<Component::Z>{})
-                         + pressure_(n, Pe, {ix}, ComponentTag<Component::Z>{})
-                         + resistive_(J, {ix}, ComponentTag<Component::Z>{})
-                         + hyperresistive_(J, {ix}, ComponentTag<Component::Z>{});
+                         + 0 * pressure_(n, Pe, {ix}, ComponentTag<Component::Z>{})
+                         + 0 * resistive_(J, {ix}, ComponentTag<Component::Z>{})
+                         + 1 * hyperresistive_(J, {ix}, ComponentTag<Component::Z>{});
             }
         }
 

--- a/src/core/numerics/pusher/boris.h
+++ b/src/core/numerics/pusher/boris.h
@@ -121,7 +121,11 @@ namespace core
                 float delta
                     = partIn.delta[iDim] + static_cast<float>(halfDtOverDl_[iDim] * partIn.v[iDim]);
 
-                float iCell         = std::floor(delta);
+                float iCell = std::floor(delta);
+                if (std::abs(delta) > 2)
+                {
+                    throw std::runtime_error("Error, particle moves more than 1 cell, delta >2");
+                }
                 partOut.delta[iDim] = delta - iCell;
                 partOut.iCell[iDim] = static_cast<int>(iCell + partIn.iCell[iDim]);
             }

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -7,6 +7,8 @@
 #include "phare_core.h"
 #include "phare_types.h"
 
+#include "amr/tagging/tagger_factory.h"
+#include <chrono>
 
 
 namespace PHARE
@@ -153,9 +155,15 @@ Simulator<_dimension, _interp_order, _nbRefinedPart>::Simulator(
         // since for now it is the only model available
         // same for the solver
         multiphysInteg_->registerModel(0, maxLevelNumber_ - 1, hybridModel_);
+
         multiphysInteg_->registerAndInitSolver(
             0, maxLevelNumber_ - 1, std::make_unique<SolverPPC>(dict["simulation"]["algo"]));
+
         multiphysInteg_->registerAndSetupMessengers(messengerFactory_);
+
+        // hard coded for now, should get some params later from the dict
+        auto hybridTagger_ = amr::TaggerFactory<PHARETypes>::make("HybridModel", "default");
+        multiphysInteg_->registerTagger(0, maxLevelNumber_ - 1, std::move(hybridTagger_));
 
 
         auto startTime = 0.; // TODO make it runtime

--- a/src/solver/physical_models/hybrid_model.h
+++ b/src/solver/physical_models/hybrid_model.h
@@ -13,157 +13,172 @@
 #include "amr/resources_manager/resources_manager.h"
 #include "amr/messengers/hybrid_messenger_info.h"
 
-namespace PHARE
+namespace PHARE::solver
 {
-namespace solver
+/**
+ * @brief The HybridModel class is a concrete implementation of a IPhysicalModel. The class
+ * holds a HybridState and a ResourcesManager.
+ */
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+class HybridModel : public IPhysicalModel<AMR_Types>
 {
+public:
+    using type_list = PHARE::core::type_list<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>;
+    using Interface = IPhysicalModel<AMR_Types>;
+    using amr_types = AMR_Types;
+    using patch_t   = typename AMR_Types::patch_t;
+    using level_t   = typename AMR_Types::level_t;
+    static const std::string model_name;
+    using gridlayout_type           = GridLayoutT;
+    using electromag_type           = Electromag;
+    using vecfield_type             = typename Electromag::vecfield_type;
+    using field_type                = typename vecfield_type::field_type;
+    using ions_type                 = Ions;
+    using particle_array_type       = typename Ions::particle_array_type;
+    using resources_manager_type    = amr::ResourcesManager<gridlayout_type>;
+    static constexpr auto dimension = GridLayoutT::dimension;
+    using ParticleInitializerFactory
+        = core::ParticleInitializerFactory<particle_array_type, gridlayout_type>;
+
+
+    core::HybridState<Electromag, Ions, Electrons> state;
+    std::shared_ptr<resources_manager_type> resourcesManager;
+
+
+    virtual void initialize(level_t& level) override;
+
+
     /**
-     * @brief The HybridModel class is a concrete implementation of a IPhysicalModel. The class
-     * holds a HybridState and a ResourcesManager.
+     * @brief allocate uses the ResourcesManager to allocate HybridState physical quantities on
+     * the given Patch at the given allocateTime
      */
-    template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
-             typename AMR_Types>
-    class HybridModel : public IPhysicalModel<AMR_Types>
+    virtual void allocate(patch_t& patch, double const allocateTime) override
     {
-    public:
-        using type_list
-            = PHARE::core::type_list<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>;
-        using Interface = IPhysicalModel<AMR_Types>;
-        using amr_types = AMR_Types;
-        using patch_t   = typename AMR_Types::patch_t;
-        using level_t   = typename AMR_Types::level_t;
-        static const std::string model_name;
-        using gridlayout_type           = GridLayoutT;
-        using electromag_type           = Electromag;
-        using vecfield_type             = typename Electromag::vecfield_type;
-        using field_type                = typename vecfield_type::field_type;
-        using ions_type                 = Ions;
-        using particle_array_type       = typename Ions::particle_array_type;
-        using resources_manager_type    = amr::ResourcesManager<gridlayout_type>;
-        static constexpr auto dimension = GridLayoutT::dimension;
-        using ParticleInitializerFactory
-            = core::ParticleInitializerFactory<particle_array_type, gridlayout_type>;
-
-        //! Physical quantities associated with hybrid equations
-        core::HybridState<Electromag, Ions, Electrons> state;
-
-        //! ResourcesManager used for interacting with SAMRAI databases, patchdata etc.
-        std::shared_ptr<resources_manager_type> resourcesManager;
+        resourcesManager->allocate(state, patch, allocateTime);
+    }
 
 
-
-        HybridModel(PHARE::initializer::PHAREDict dict,
-                    std::shared_ptr<resources_manager_type> const& _resourcesManager)
-            : IPhysicalModel<AMR_Types>{model_name}
-            , state{dict}
-            , resourcesManager{std::move(_resourcesManager)}
-        {
-        }
+    /**
+     * @brief fillMessengerInfo describes which variables of the model are to be initialized or
+     * filled at ghost nodes.
+     */
+    virtual void fillMessengerInfo(std::unique_ptr<amr::IMessengerInfo> const& info) const override;
 
 
-        virtual void initialize(level_t& level) override
-        {
-            for (auto& patch : level)
-            {
-                // first initialize the ions
-                auto layout = amr::layoutFromPatch<gridlayout_type>(*patch);
-                auto& ions  = state.ions;
-                auto _ = this->resourcesManager->setOnPatch(*patch, state.electromag, state.ions);
-
-                for (auto& pop : ions)
-                {
-                    auto info                = pop.particleInitializerInfo();
-                    auto particleInitializer = ParticleInitializerFactory::create(info);
-                    particleInitializer->loadParticles(pop.domainParticles(), layout);
-                }
-
-                state.electromag.initialize(layout);
-            }
-        }
+    auto setOnPatch(patch_t& patch) { return resourcesManager->setOnPatch(patch, *this); }
 
 
-
-        /**
-         * @brief allocate uses the ResourcesManager to allocate HybridState physical quantities on
-         * the given Patch at the given allocateTime
-         */
-        virtual void allocate(patch_t& patch, double const allocateTime) override
-        {
-            resourcesManager->allocate(state, patch, allocateTime);
-        }
-
-
-        /**
-         * @brief fillMessengerInfo describes which variables of the model are to be initialized or
-         * filled at ghost nodes.
-         */
-        virtual void
-        fillMessengerInfo(std::unique_ptr<amr::IMessengerInfo> const& info) const override
-        {
-            auto& modelInfo = dynamic_cast<amr::HybridMessengerInfo&>(*info);
-
-            modelInfo.modelMagnetic        = amr::VecFieldDescriptor{state.electromag.B};
-            modelInfo.modelElectric        = amr::VecFieldDescriptor{state.electromag.E};
-            modelInfo.modelIonDensity      = state.ions.densityName();
-            modelInfo.modelIonBulkVelocity = amr::VecFieldDescriptor{state.ions.velocity()};
-            modelInfo.modelCurrent         = amr::VecFieldDescriptor{state.J};
-
-            modelInfo.initElectric.emplace_back(state.electromag.E);
-            modelInfo.initMagnetic.emplace_back(state.electromag.B);
-
-            modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
-            modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
-            modelInfo.ghostCurrent.push_back(state.J);
-
-
-            auto transform_ = [](auto& ions, auto& inserter) {
-                std::transform(std::begin(ions), std::end(ions), std::back_inserter(inserter),
-                               [](auto const& pop) { return pop.name(); });
-            };
-            transform_(state.ions, modelInfo.interiorParticles);
-            transform_(state.ions, modelInfo.levelGhostParticlesOld);
-            transform_(state.ions, modelInfo.levelGhostParticlesNew);
-            transform_(state.ions, modelInfo.patchGhostParticles);
-        }
-
-        virtual ~HybridModel() override {}
-
-        //-------------------------------------------------------------------------
-        //                  start the ResourcesUser interface
-        //-------------------------------------------------------------------------
-
-        bool isUsable() const { return state.isUsable(); }
-
-        bool isSettable() const { return state.isSettable(); }
-
-        auto getCompileTimeResourcesUserList() const { return std::forward_as_tuple(state); }
-
-        auto getCompileTimeResourcesUserList() { return std::forward_as_tuple(state); }
-
-        //-------------------------------------------------------------------------
-        //                  ends the ResourcesUser interface
-        //-------------------------------------------------------------------------
-    };
-
-    template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
-             typename AMR_Types>
-    const std::string HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::model_name
-        = "HybridModel";
-
-    template<typename... Args>
-    HybridModel<Args...> hybrid_model_from_type_list(core::type_list<Args...>);
-
-    template<typename TypeList>
-    struct type_list_to_hybrid_model
+    HybridModel(PHARE::initializer::PHAREDict dict,
+                std::shared_ptr<resources_manager_type> const& _resourcesManager)
+        : IPhysicalModel<AMR_Types>{model_name}
+        , state{dict}
+        , resourcesManager{std::move(_resourcesManager)}
     {
-        using type = decltype(hybrid_model_from_type_list(std::declval<TypeList>()));
+    }
+
+
+    virtual ~HybridModel() override {}
+
+    //-------------------------------------------------------------------------
+    //                  start the ResourcesUser interface
+    //-------------------------------------------------------------------------
+
+    bool isUsable() const { return state.isUsable(); }
+
+    bool isSettable() const { return state.isSettable(); }
+
+    auto getCompileTimeResourcesUserList() const { return std::forward_as_tuple(state); }
+
+    auto getCompileTimeResourcesUserList() { return std::forward_as_tuple(state); }
+
+    //-------------------------------------------------------------------------
+    //                  ends the ResourcesUser interface
+    //-------------------------------------------------------------------------
+};
+
+
+
+
+//-------------------------------------------------------------------------
+//                             definitions
+//-------------------------------------------------------------------------
+
+
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::initialize(level_t& level)
+{
+    for (auto& patch : level)
+    {
+        // first initialize the ions
+        auto layout = amr::layoutFromPatch<gridlayout_type>(*patch);
+        auto& ions  = state.ions;
+        auto _      = this->resourcesManager->setOnPatch(*patch, state.electromag, state.ions);
+
+        for (auto& pop : ions)
+        {
+            auto info                = pop.particleInitializerInfo();
+            auto particleInitializer = ParticleInitializerFactory::create(info);
+            particleInitializer->loadParticles(pop.domainParticles(), layout);
+        }
+
+        state.electromag.initialize(layout);
+    }
+}
+
+
+
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::fillMessengerInfo(
+    std::unique_ptr<amr::IMessengerInfo> const& info) const
+{
+    auto& modelInfo = dynamic_cast<amr::HybridMessengerInfo&>(*info);
+
+    modelInfo.modelMagnetic        = amr::VecFieldDescriptor{state.electromag.B};
+    modelInfo.modelElectric        = amr::VecFieldDescriptor{state.electromag.E};
+    modelInfo.modelIonDensity      = state.ions.densityName();
+    modelInfo.modelIonBulkVelocity = amr::VecFieldDescriptor{state.ions.velocity()};
+    modelInfo.modelCurrent         = amr::VecFieldDescriptor{state.J};
+
+    modelInfo.initElectric.emplace_back(state.electromag.E);
+    modelInfo.initMagnetic.emplace_back(state.electromag.B);
+
+    modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
+    modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
+    modelInfo.ghostCurrent.push_back(state.J);
+
+
+    auto transform_ = [](auto& ions, auto& inserter) {
+        std::transform(std::begin(ions), std::end(ions), std::back_inserter(inserter),
+                       [](auto const& pop) { return pop.name(); });
     };
+    transform_(state.ions, modelInfo.interiorParticles);
+    transform_(state.ions, modelInfo.levelGhostParticlesOld);
+    transform_(state.ions, modelInfo.levelGhostParticlesNew);
+    transform_(state.ions, modelInfo.patchGhostParticles);
+}
 
-    template<typename TypeList>
-    using type_list_to_hybrid_model_t = typename type_list_to_hybrid_model<TypeList>::type;
 
-} // namespace solver
 
-} // namespace PHARE
+template<typename GridLayoutT, typename Electromag, typename Ions, typename Electrons,
+         typename AMR_Types>
+const std::string HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::model_name
+    = "HybridModel";
+
+template<typename... Args>
+HybridModel<Args...> hybrid_model_from_type_list(core::type_list<Args...>);
+
+template<typename TypeList>
+struct type_list_to_hybrid_model
+{
+    using type = decltype(hybrid_model_from_type_list(std::declval<TypeList>()));
+};
+
+template<typename TypeList>
+using type_list_to_hybrid_model_t = typename type_list_to_hybrid_model<TypeList>::type;
+
+} // namespace PHARE::solver
 
 #endif

--- a/src/solver/physical_models/mhd_model.h
+++ b/src/solver/physical_models/mhd_model.h
@@ -55,6 +55,9 @@ namespace solver
         {
         }
 
+        auto setOnPatch(patch_t& patch) { return resourcesManager->setOnPatch(patch, *this); }
+
+
         virtual ~MHDModel() override = default;
 
         core::MHDState<VecFieldT> state;

--- a/src/solver/solvers/solver_ppc.h
+++ b/src/solver/solvers/solver_ppc.h
@@ -470,14 +470,15 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, Ions& ions,
             nbrLevelGhostOldParticles += pop.levelGhostParticlesOld().size();
             nbrLevelGhostParticles += pop.levelGhostParticles().size();
             nbrPatchGhostParticles += pop.patchGhostParticles().size();
+
+            if (nbrLevelGhostOldParticles < nbrLevelGhostParticles
+                and nbrLevelGhostOldParticles > 0)
+                throw std::runtime_error("Error - there are less old level ghost particles ("
+                                         + std::to_string(nbrLevelGhostOldParticles)
+                                         + ") than pushable ("
+                                         + std::to_string(nbrLevelGhostParticles) + ")");
         }
     }
-    std::cout << "level = " << level.getLevelNumber() << std::setprecision(6)
-              << " t = " << currentTime << ";  nbrDomParticles = " << nbrDomainParticles
-              << "; LevelGhostNew = " << nbrLevelGhostNewParticles
-              << "; LevelGhostOld = " << nbrLevelGhostOldParticles
-              << "; LevelGhost = " << nbrLevelGhostParticles
-              << "; patchGhost = " << nbrPatchGhostParticles << "\n";
 
 
 

--- a/tests/amr/tagging/CMakeLists.txt
+++ b/tests/amr/tagging/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(test-tagging)
+
+
+
+set(SOURCES_CPP
+  test_tagging.cpp
+   )
+
+add_executable(${PROJECT_NAME} ${SOURCES_INC} ${SOURCES_CPP})
+
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  ${GTEST_INCLUDE_DIRS}
+  )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  phare_amr
+  phare_solver
+  ${GTEST_LIBS})
+
+
+add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+
+

--- a/tests/amr/tagging/test_tagging.cpp
+++ b/tests/amr/tagging/test_tagging.cpp
@@ -1,0 +1,222 @@
+
+
+#include "phare/phare.h"
+#include "amr/tagging/tagger.h"
+#include "amr/tagging/tagger_factory.h"
+#include "amr/resources_manager/resources_manager.h"
+
+#include "core/data/ndarray/ndarray_vector.h"
+#include "core/models/hybrid_state.h"
+#include "core/utilities/span.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace PHARE::amr;
+
+
+
+
+TEST(test_tagger, fromFactory)
+{
+    using phare_types = PHARE::PHARE_Types<1, 1, 2>;
+    auto hybridTagger = TaggerFactory<phare_types>::make("HybridModel", "default");
+    EXPECT_TRUE(hybridTagger != nullptr);
+
+    auto badTagger = TaggerFactory<phare_types>::make("invalidModel", "invalidStrat");
+    EXPECT_TRUE(badTagger == nullptr);
+}
+
+
+
+using Param   = std::vector<double> const;
+using RetType = std::shared_ptr<PHARE::core::Span<double>>;
+
+RetType step(Param& x)
+{
+    std::vector<double> values(x.size());
+    std::transform(std::begin(x), std::end(x), std::begin(values),
+                   [](auto xx) { return std::tanh((xx - 0.52) / 0.05); });
+    return std::make_shared<PHARE::core::VectorSpan<double>>(std::move(values));
+}
+
+
+using InitFunctionT = PHARE::initializer::InitFunction<1>;
+
+PHARE::initializer::PHAREDict createDict()
+{
+    PHARE::initializer::PHAREDict dict;
+    dict["ions"]["nbrPopulations"] = int{2};
+    dict["ions"]["pop0"]["name"]   = std::string{"protons"};
+    dict["ions"]["pop0"]["mass"]   = 1.;
+    dict["ions"]["pop0"]["ParticleInitializer"]["name"]
+        = std::string{"MaxwellianParticleInitializer"};
+    dict["ions"]["pop0"]["ParticleInitializer"]["density"] = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+
+    dict["ions"]["pop0"]["ParticleInitializer"]["nbrPartPerCell"] = int{100};
+    dict["ions"]["pop0"]["ParticleInitializer"]["charge"]         = -1.;
+    dict["ions"]["pop0"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
+
+    dict["ions"]["pop1"]["name"] = std::string{"alpha"};
+    dict["ions"]["pop1"]["mass"] = 1.;
+    dict["ions"]["pop1"]["ParticleInitializer"]["name"]
+        = std::string{"MaxwellianParticleInitializer"};
+    dict["ions"]["pop1"]["ParticleInitializer"]["density"] = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["bulk_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_x"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_y"]
+        = static_cast<InitFunctionT>(step);
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["thermal_velocity_z"]
+        = static_cast<InitFunctionT>(step);
+
+
+    dict["ions"]["pop1"]["ParticleInitializer"]["nbrPartPerCell"] = int{100};
+    dict["ions"]["pop1"]["ParticleInitializer"]["charge"]         = -1.;
+    dict["ions"]["pop1"]["ParticleInitializer"]["basis"]          = std::string{"Cartesian"};
+
+    dict["electromag"]["name"]             = std::string{"EM"};
+    dict["electromag"]["electric"]["name"] = std::string{"E"};
+    dict["electromag"]["magnetic"]["name"] = std::string{"B"};
+
+    dict["electromag"]["magnetic"]["initializer"]["x_component"] = static_cast<InitFunctionT>(step);
+    dict["electromag"]["magnetic"]["initializer"]["y_component"] = static_cast<InitFunctionT>(step);
+    dict["electromag"]["magnetic"]["initializer"]["z_component"] = static_cast<InitFunctionT>(step);
+
+    dict["electrons"]["pressure_closure"]["name"] = std::string{"isothermal"};
+    dict["electrons"]["pressure_closure"]["Te"]   = 0.12;
+
+    return dict;
+}
+
+
+
+
+struct TestTagger : public ::testing::Test
+{
+    static constexpr auto dim            = 1;
+    static constexpr auto interp_order   = 1;
+    static constexpr auto refinedPartNbr = 2;
+
+    using phare_types = PHARE::PHARE_Types<dim, interp_order, refinedPartNbr>;
+    using Electromag  = typename phare_types::Electromag_t;
+    using Ions        = typename phare_types::Ions_t;
+    using Electrons   = typename phare_types::Electrons_t;
+    using Field       = typename phare_types::Field_t;
+    using GridLayoutT = GridLayout<GridLayoutImplYee<dim, interp_order>>;
+
+    struct SinglePatchHybridModel
+    {
+        using gridlayout_type           = GridLayout<GridLayoutImplYee<dim, interp_order>>;
+        static auto constexpr dimension = dim;
+        HybridState<Electromag, Ions, Electrons> state;
+    };
+
+
+    GridLayoutT layout;
+    Field Bx, By, Bz;
+    Field Ex, Ey, Ez;
+
+    SinglePatchHybridModel model;
+    std::vector<int> tags;
+
+    TestTagger()
+        : layout{{0.05}, {20}, {0.}}
+        , Bx{"Bx", HybridQuantity::Scalar::Bx, layout.allocSize(HybridQuantity::Scalar::Bx)}
+        , By{"By", HybridQuantity::Scalar::By, layout.allocSize(HybridQuantity::Scalar::By)}
+        , Bz{"Bz", HybridQuantity::Scalar::Bz, layout.allocSize(HybridQuantity::Scalar::Bz)}
+        , Ex{"Ex", HybridQuantity::Scalar::Ex, layout.allocSize(HybridQuantity::Scalar::Ex)}
+        , Ey{"Ey", HybridQuantity::Scalar::Ey, layout.allocSize(HybridQuantity::Scalar::Ey)}
+        , Ez{"Ez", HybridQuantity::Scalar::Ez, layout.allocSize(HybridQuantity::Scalar::Ez)}
+        , model{createDict()}
+        , tags(20 + layout.nbrGhosts(PHARE::core::QtyCentering::dual))
+    {
+        model.state.electromag.E.setBuffer("EM_E_x", &Ex);
+        model.state.electromag.E.setBuffer("EM_E_y", &Ey);
+        model.state.electromag.E.setBuffer("EM_E_z", &Ez);
+        model.state.electromag.B.setBuffer("EM_B_x", &Bx);
+        model.state.electromag.B.setBuffer("EM_B_y", &By);
+        model.state.electromag.B.setBuffer("EM_B_z", &Bz);
+        model.state.electromag.initialize(layout);
+    }
+};
+
+/* TODOmaybe find a way to test the tagging?
+TEST_F(TestTagger, scaledAvg)
+{
+    auto strat = DefaultHybridTaggerStrategy<SinglePatchHybridModel>();
+    strat.tag(model, layout, tags.data());
+    {
+        auto start
+            = layout.physicalStartIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+        auto end
+            = layout.physicalEndIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
+
+        auto endCell     = layout.nbrCells()[0] - 1;
+        double threshold = 0.1;
+
+
+        for (auto iCell = 0u, ix = start; iCell <= endCell; ++ix, ++iCell)
+        {
+            auto Bxavg = (Bx(ix - 1) + Bx(ix) + Bx(ix + 1)) / 3.;
+            auto Byavg = (By(ix - 1) + By(ix) + By(ix + 1)) / 3.;
+            auto Bzavg = (Bz(ix - 1) + Bz(ix) + Bz(ix + 1)) / 3.;
+
+            auto diffx = std::abs(Bxavg - Bx(ix));
+            auto diffy = std::abs(Byavg - By(ix));
+            auto diffz = std::abs(Bzavg - Bz(ix));
+
+            auto max = std::max({diffx, diffy, diffz});
+            if (max > threshold)
+            {
+                tags[iCell] = 1;
+            }
+            else
+                tags[iCell] = 0;
+        }
+    }
+}
+*/
+
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    int testResult = RUN_ALL_TESTS();
+    return testResult;
+}

--- a/tests/core/data/gridlayout/allocSizes.py
+++ b/tests/core/data/gridlayout/allocSizes.py
@@ -69,7 +69,11 @@ def main(path='./'):
     gl = gridlayout.GridLayout()
 
     directions = gl.directions
-    quantities = gl.hybridQuantities
+    quantities = ['Bx','By','Bz',
+                  'Ex','Ey','Ez',
+                  'Jx','Jy','Jz',
+                  'rho','Vx','Vy',
+                  'Vz','P']
 
 
     nbrCellXList=[40, 40, 40]

--- a/tests/core/data/gridlayout/gridIndexing.py
+++ b/tests/core/data/gridlayout/gridIndexing.py
@@ -82,7 +82,11 @@ def main(path='./'):
     gl = gridlayout.GridLayout()
 
     directions = gl.directions
-    quantities = gl.hybridQuantities
+    quantities = ['Bx','By','Bz',
+                  'Ex','Ey','Ez',
+                  'Jx','Jy','Jz',
+                  'rho','Vx','Vy',
+                  'Vz','P']
 
     nbrCellXList=[40, 40, 40]
     nbrCellYList=[ 0, 12, 12]

--- a/tests/core/data/maxwellian_particle_initializer/test_maxwellian_particle_initializer.cpp
+++ b/tests/core/data/maxwellian_particle_initializer/test_maxwellian_particle_initializer.cpp
@@ -40,7 +40,7 @@ public:
 
     GridLayoutT layout;
     ParticleArrayT particles;
-    std::uint32_t nbrParticlesPerCell{1000};
+    std::uint32_t nbrParticlesPerCell{10000};
     std::unique_ptr<MaxwellianParticleInitializer<ParticleArrayT, GridLayoutT>> initializer;
 };
 
@@ -68,6 +68,8 @@ TEST_F(AMaxwellianParticleInitializer1D, loadsParticlesInTheDomain)
         auto pos       = positionAsPoint(particle, layout);
         auto endDomain = layout.origin()[0] + layout.nbrCells()[0] * layout.meshSize()[0];
 
+        if (!((pos[0] > 0.) and (pos[0] < endDomain)))
+            std::cout << "position : " << pos[0] << " not in domain (0," << endDomain << ")\n";
         EXPECT_TRUE(pos[0] > 0. && pos[0] < endDomain);
         i++;
     }

--- a/tests/core/numerics/ohm/test_ohm.py
+++ b/tests/core/numerics/ohm/test_ohm.py
@@ -47,22 +47,7 @@ def test_ohm_yee1D(path):
 
     tv = TestVariables()
     eta = 1.0
-    nu = 0.001
-
-    Vx = np.zeros(layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    Vy = np.zeros(layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    Vz = np.zeros(layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]), dtype=np.float64)
-
-    Bx = np.zeros(layout.allocSize(tv.interpOrder, tv.BxCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    By = np.zeros(layout.allocSize(tv.interpOrder, tv.ByCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    Bz = np.zeros(layout.allocSize(tv.interpOrder, tv.BzCentering[0], tv.nbrCells[0]), dtype=np.float64)
-
-    n = np.zeros(layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    P = np.zeros(layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]), dtype=np.float64)
-
-    Jx = np.zeros(layout.allocSize(tv.interpOrder, tv.JxCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    Jy = np.zeros(layout.allocSize(tv.interpOrder, tv.JyCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    Jz = np.zeros(layout.allocSize(tv.interpOrder, tv.JzCentering[0], tv.nbrCells[0]), dtype=np.float64)
+    nu = 0.01
 
     idealx = np.zeros(layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]), dtype=np.float64)
     idealy = np.zeros(layout.allocSize(tv.interpOrder, tv.EyCentering[0], tv.nbrCells[0]), dtype=np.float64)
@@ -79,10 +64,6 @@ def test_ohm_yee1D(path):
     viscousx = np.zeros(layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]), dtype=np.float64)
     viscousy = np.zeros(layout.allocSize(tv.interpOrder, tv.EyCentering[0], tv.nbrCells[0]), dtype=np.float64)
     viscousz = np.zeros(layout.allocSize(tv.interpOrder, tv.EzCentering[0], tv.nbrCells[0]), dtype=np.float64)
-
-    ExNew = np.zeros(layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    EyNew = np.zeros(layout.allocSize(tv.interpOrder, tv.EyCentering[0], tv.nbrCells[0]), dtype=np.float64)
-    EzNew = np.zeros(layout.allocSize(tv.interpOrder, tv.EzCentering[0], tv.nbrCells[0]), dtype=np.float64)
 
     psi_p_X = layout.physicalStartIndex(tv.interpOrder, 'primal')
     pei_p_X = layout.physicalEndIndex(  tv.interpOrder, 'primal', tv.nbrCells[0])
@@ -135,9 +116,9 @@ def test_ohm_yee1D(path):
     viscousy[psi_p_X:pei_p_X+1] = -nu*(Jy[psi_p_X-1:pei_p_X]-2.0*Jy[psi_p_X:pei_p_X+1]+Jy[psi_p_X+1:pei_p_X+2])/(tv.meshSize[0]*tv.meshSize[0])
     viscousz[psi_p_X:pei_p_X+1] = -nu*(Jz[psi_p_X-1:pei_p_X]-2.0*Jz[psi_p_X:pei_p_X+1]+Jz[psi_p_X+1:pei_p_X+2])/(tv.meshSize[0]*tv.meshSize[0])
 
-    ExNew = idealx+pressx+resistx+viscousx
-    EyNew = idealy+pressy+resisty+viscousy
-    EzNew = idealz+pressz+resistz+viscousz
+    ExNew = idealx+0*pressx+0*resistx+viscousx
+    EyNew = idealy+0*pressy+0*resisty+viscousy
+    EzNew = idealz+0*pressz+0*resistz+viscousz
 
     filename_ohmx = "ohmx_yee_1D_order1.txt"
     filename_ohmy = "ohmy_yee_1D_order1.txt"
@@ -155,33 +136,7 @@ def test_ohm_yee2D(path):
 
     tv = TestVariables()
     eta = 1.0
-    nu = 0.001
-
-    Vx = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    Vy = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    Vz = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1])], dtype=np.float64)
-
-    Bx = np.zeros([layout.allocSize(tv.interpOrder, tv.BxCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.BxCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    By = np.zeros([layout.allocSize(tv.interpOrder, tv.ByCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.ByCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    Bz = np.zeros([layout.allocSize(tv.interpOrder, tv.BzCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.BzCentering[1], tv.nbrCells[1])], dtype=np.float64)
-
-    n = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                  layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    P = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                  layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1])], dtype=np.float64)
-
-    Jx = np.zeros([layout.allocSize(tv.interpOrder, tv.JxCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.JxCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    Jy = np.zeros([layout.allocSize(tv.interpOrder, tv.JyCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.JyCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    Jz = np.zeros([layout.allocSize(tv.interpOrder, tv.JzCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.JzCentering[1], tv.nbrCells[1])], dtype=np.float64)
+    nu = 0.01
 
     idealx = np.zeros([layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]),
                        layout.allocSize(tv.interpOrder, tv.ExCentering[1], tv.nbrCells[1])], dtype=np.float64)
@@ -210,13 +165,6 @@ def test_ohm_yee2D(path):
                          layout.allocSize(tv.interpOrder, tv.EyCentering[1], tv.nbrCells[1])], dtype=np.float64)
     viscousz = np.zeros([layout.allocSize(tv.interpOrder, tv.EzCentering[0], tv.nbrCells[0]),
                          layout.allocSize(tv.interpOrder, tv.EzCentering[1], tv.nbrCells[1])], dtype=np.float64)
-
-    ExNew = np.zeros([layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]),
-                      layout.allocSize(tv.interpOrder, tv.ExCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    EyNew = np.zeros([layout.allocSize(tv.interpOrder, tv.EyCentering[0], tv.nbrCells[0]),
-                      layout.allocSize(tv.interpOrder, tv.EyCentering[1], tv.nbrCells[1])], dtype=np.float64)
-    EzNew = np.zeros([layout.allocSize(tv.interpOrder, tv.EzCentering[0], tv.nbrCells[0]),
-                      layout.allocSize(tv.interpOrder, tv.EzCentering[1], tv.nbrCells[1])], dtype=np.float64)
 
     psi_p_X = layout.physicalStartIndex(tv.interpOrder, 'primal')
     pei_p_X = layout.physicalEndIndex(  tv.interpOrder, 'primal', tv.nbrCells[0])
@@ -363,44 +311,8 @@ def test_ohm_yee3D(path):
 
     tv = TestVariables()
     eta = 1.0
-    nu = 0.001
+    nu = 0.01
 
-    Vx = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    Vy = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    Vz = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.MomentsCentering[2], tv.nbrCells[2])], dtype=np.float64)
-
-    Bx = np.zeros([layout.allocSize(tv.interpOrder, tv.BxCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.BxCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.BxCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    By = np.zeros([layout.allocSize(tv.interpOrder, tv.ByCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.ByCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.ByCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    Bz = np.zeros([layout.allocSize(tv.interpOrder, tv.BzCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.BzCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.BzCentering[2], tv.nbrCells[2])], dtype=np.float64)
-
-    n = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                  layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1]),
-                  layout.allocSize(tv.interpOrder, tv.MomentsCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    P = np.zeros([layout.allocSize(tv.interpOrder, tv.MomentsCentering[0], tv.nbrCells[0]),
-                  layout.allocSize(tv.interpOrder, tv.MomentsCentering[1], tv.nbrCells[1]),
-                  layout.allocSize(tv.interpOrder, tv.MomentsCentering[2], tv.nbrCells[2])], dtype=np.float64)
-
-    Jx = np.zeros([layout.allocSize(tv.interpOrder, tv.JxCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.JxCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.JxCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    Jy = np.zeros([layout.allocSize(tv.interpOrder, tv.JyCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.JyCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.JyCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    Jz = np.zeros([layout.allocSize(tv.interpOrder, tv.JzCentering[0], tv.nbrCells[0]),
-                   layout.allocSize(tv.interpOrder, tv.JzCentering[1], tv.nbrCells[1]),
-                   layout.allocSize(tv.interpOrder, tv.JzCentering[2], tv.nbrCells[2])], dtype=np.float64)
 
     idealx = np.zeros([layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]),
                        layout.allocSize(tv.interpOrder, tv.ExCentering[1], tv.nbrCells[1]),
@@ -442,15 +354,6 @@ def test_ohm_yee3D(path):
                          layout.allocSize(tv.interpOrder, tv.EzCentering[1], tv.nbrCells[1]),
                          layout.allocSize(tv.interpOrder, tv.EzCentering[2], tv.nbrCells[2])], dtype=np.float64)
 
-    ExNew = np.zeros([layout.allocSize(tv.interpOrder, tv.ExCentering[0], tv.nbrCells[0]),
-                      layout.allocSize(tv.interpOrder, tv.ExCentering[1], tv.nbrCells[1]),
-                      layout.allocSize(tv.interpOrder, tv.ExCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    EyNew = np.zeros([layout.allocSize(tv.interpOrder, tv.EyCentering[0], tv.nbrCells[0]),
-                      layout.allocSize(tv.interpOrder, tv.EyCentering[1], tv.nbrCells[1]),
-                      layout.allocSize(tv.interpOrder, tv.EyCentering[2], tv.nbrCells[2])], dtype=np.float64)
-    EzNew = np.zeros([layout.allocSize(tv.interpOrder, tv.EzCentering[0], tv.nbrCells[0]),
-                      layout.allocSize(tv.interpOrder, tv.EzCentering[1], tv.nbrCells[1]),
-                      layout.allocSize(tv.interpOrder, tv.EzCentering[2], tv.nbrCells[2])], dtype=np.float64)
 
     psi_p_X = layout.physicalStartIndex(tv.interpOrder, 'primal')
     pei_p_X = layout.physicalEndIndex(  tv.interpOrder, 'primal', tv.nbrCells[0])

--- a/tests/functional/shock/CMakeLists.txt
+++ b/tests/functional/shock/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(test-shock1d)
+
+if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  file(GLOB PYFILES "*.py")
+  file(COPY ${PYFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+if(HighFive)
+
+  ## These test use dump diagnostics so require HighFive!
+phare_python3_exec(11 test-shock shock.py ${CMAKE_CURRENT_BINARY_DIR})
+endif()

--- a/tests/functional/shock/shock.py
+++ b/tests/functional/shock/shock.py
@@ -16,68 +16,84 @@ mpl.use('Agg')
 
 
 
+
 def config():
+    """ Configure the simulation
 
-    # configure the simulation
-
+    This function defines the Simulation object,
+    user initialization model and diagnostics.
+    """
     Simulation(
         smallest_patch_size=20,
         largest_patch_size=20,
-        time_step_nbr=10000,        # number of time steps (not specified if time_step and final_time provided)
-        final_time=10.,             # simulation final time (not specified if time_step and time_step_nbr provided)
+        time_step_nbr=6000,        # number of time steps (not specified if time_step and final_time provided)
+        final_time=30,             # simulation final time (not specified if time_step and time_step_nbr provided)
         boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
-        cells=40,                # integer or tuple length == dimension
-        dl=0.3,                  # mesh size of the root level, float or tuple
-        refinement_boxes={"L0": {"B0": [(10, ), (20, )]}},
-        diag_options={"format": "phareh5", "options": {"dir": "alfven_norefine","mode":"overwrite"}}
+        cells=2500,                # integer or tuple length == dimension
+        dl=0.2,                  # mesh size of the root level, float or tuple
+        #max_nbr_levels=1,          # (default=1) max nbr of levels in the AMR hierarchy
+        nesting_buffer=0,
+        refinement_boxes = {"L0":{"B0":[(125,), (750,)]}},
+        diag_options={"format": "phareh5", "options": {"dir": "shock_20dx_dx02_refined","mode":"overwrite"}}
     )
 
 
     def density(x):
-        return 1.
+        from pyphare.pharein.global_vars import sim
+        L = sim.simulation_domain()[0]
+        v1=1
+        v2=1.
+        return v1 + (v2-v1)*(S(x,L*0.2,1) -S(x, L*0.8, 1))
+
+
+    def S(x,x0,l):
+        return 0.5*(1+np.tanh((x-x0)/l))
+
+
+    def bx(x):
+        return 0.
 
 
     def by(x):
         from pyphare.pharein.global_vars import sim
-        L = sim.simulation_domain()
-        return 0.1*np.cos(2*np.pi*x/L[0])
-
+        L = sim.simulation_domain()[0]
+        v1=0.125
+        v2=4.0
+        return v1 + (v2-v1)*(S(x , L * s0.2, 1) -S(x, L * 0.8, 1))
 
     def bz(x):
-        from pyphare.pharein.global_vars import sim
-        L = sim.simulation_domain()
-        return 0.1*np.sin(2*np.pi*x/L[0])
+        return 0.
 
-
-    def bx(x):
-        return 1.
+    def T(x):
+        return 0.1
 
 
     def vx(x):
-        return 0.
+        from pyphare.pharein.global_vars import sim
+        L = sim.simulation_domain()[0]
+        v1 = 0.
+        v2 = 0.
+        return v1 + (v2-v1) * (S(x, L*0.25, 1) -S(x, L * 0.75, 1))
 
 
     def vy(x):
-        from pyphare.pharein.global_vars import sim
-        L = sim.simulation_domain()
-        return 0.1*np.cos(2*np.pi*x/L[0])
+        return 0.
+
 
     def vz(x):
-        from pyphare.pharein.global_vars import sim
-        L = sim.simulation_domain()
-        return 0.1*np.sin(2*np.pi*x/L[0])
+        return 0.
 
 
     def vthx(x):
-        return 0.01
+        return T(x)
 
 
     def vthy(x):
-        return 0.01
+        return T(x)
 
 
     def vthz(x):
-        return 0.01
+        return T(x)
 
 
     vvv = {
@@ -87,7 +103,7 @@ def config():
 
     MaxwellianFluidModel(
         bx=bx, by=by, bz=bz,
-        protons={"charge": 1, "density": density, **vvv, "init": {"seed": 1337}}
+        protons={"charge": 1, "density": density, **vvv}
     )
 
     ElectronModel(closure="isothermal", Te=0.12)
@@ -96,7 +112,7 @@ def config():
 
     sim = ph.global_vars.sim
 
-    timestamps = np.arange(0, sim.final_time +sim.time_step, 10*sim.time_step)
+    timestamps = np.arange(0, sim.final_time +sim.time_step, sim.time_step)
 
 
 
@@ -121,8 +137,8 @@ def config():
 def plot(bhier):
     times = np.sort(np.asarray(list(bhier.time_hier.keys())))
 
-    components  =("B_x", "B_y", "B_z")
-    ylims = ((0,1.5),(-0.25,0.25),(-0.25,0.25))
+    components  =("B_y", "B_z")
+    ylims = ((0.0, 2.),(0.,1.0))
 
     for component,ylim in zip(components,ylims):
         for it,t in enumerate(times):
@@ -153,9 +169,6 @@ def plot(bhier):
 
 
 
-
-
-
 def main():
     config()
     simulator = Simulator(gv.sim)
@@ -166,6 +179,6 @@ def main():
     #if cpp.mpi_rank() == 0:
     #    b = hierarchy_from(h5_filename="phare_outputs/EM_B.h5")
     #    plot(b)
-    #
+
 if __name__=="__main__":
     main()

--- a/tests/functional/tdtagged/CMakeLists.txt
+++ b/tests/functional/tdtagged/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(test-tdtagged)
+
+if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  file(GLOB PYFILES "*.py")
+  file(COPY ${PYFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+if(HighFive)
+
+  ## These test use dump diagnostics so require HighFive!
+phare_python3_exec(11 test-td-tagged td1dtagged.py ${CMAKE_CURRENT_BINARY_DIR})
+endif()

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+
 import pyphare.pharein as ph #lgtm [py/import-and-import-from]
 from pyphare.pharein import Simulation
 from pyphare.pharein import MaxwellianFluidModel
@@ -18,7 +19,6 @@ mpl.use('Agg')
 
 
 
-
 def config():
     """ Configure the simulation
 
@@ -26,16 +26,17 @@ def config():
     user initialization model and diagnostics.
     """
     Simulation(
-        smallest_patch_size=20,
+        smallest_patch_size=10,
         largest_patch_size=20,
         time_step_nbr=2000,        # number of time steps (not specified if time_step and final_time provided)
-        final_time=20.,             # simulation final time (not specified if time_step and time_step_nbr provided)
+        final_time=20,             # simulation final time (not specified if time_step and time_step_nbr provided)
         boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
-        cells=500,                # integer or tuple length == dimension
-        dl=1.,                  # mesh size of the root level, float or tuple
-        refinement_boxes={"L0": {"B0": [(80, ), (180, )]},
-                          "L1":{"B0":[(200,),(300,)]}},
-        diag_options={"format": "phareh5", "options": {"dir": "td_noflow","mode":"overwrite"}}
+        cells=400,                # integer or tuple length == dimension
+        dl=0.5,                  # mesh size of the root level, float or tuple
+        max_nbr_levels=3,          # (default=1) max nbr of levels in the AMR hierarchy
+        nesting_buffer=2,
+        refinement = "tagging",
+        diag_options={"format": "phareh5", "options": {"dir": "refine_dx05_lvl3","mode":"overwrite"}}
     )
 
 
@@ -73,7 +74,7 @@ def config():
 
 
     def vx(x):
-        return 0.
+        return 1.
 
 
     def vy(x):
@@ -132,11 +133,13 @@ def config():
             )
 
 
+
 def main():
     config()
     simulator = Simulator(gv.sim)
     simulator.initialize()
     simulator.run()
+
 
 
 if __name__=="__main__":

--- a/tests/functional/translation/CMakeLists.txt
+++ b/tests/functional/translation/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(test-translation)
+
+if(NOT ${PHARE_PROJECT_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+  file(GLOB PYFILES "*.py")
+  file(COPY ${PYFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+if(HighFive)
+
+  ## These test use dump diagnostics so require HighFive!
+phare_python3_exec(11 test-translation translat1d.py ${CMAKE_CURRENT_BINARY_DIR})
+endif()

--- a/tests/functional/translation/translat1d.py
+++ b/tests/functional/translation/translat1d.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+import pyphare.pharein as ph #lgtm [py/import-and-import-from]
+from pyphare.pharein import Simulation
+from pyphare.pharein import MaxwellianFluidModel
+from pyphare.pharein import ElectromagDiagnostics,FluidDiagnostics
+from pyphare.pharein import ElectronModel
+from pyphare.simulator.simulator import Simulator
+from pyphare.pharein import global_vars as gv
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+mpl.use('Agg')
+
+
+
+
+def config_uni(**kwargs):
+    """ Configure the simulation
+
+    This function defines the Simulation object,
+    user initialization model and diagnostics.
+    """
+    Simulation(
+        smallest_patch_size=20,
+        largest_patch_size=20,
+        time_step_nbr=2000,        # number of time steps (not specified if time_step and final_time provided)
+        final_time=20.,             # simulation final time (not specified if time_step and time_step_nbr provided)
+        boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
+        cells=500,                # integer or tuple length == dimension
+        dl=1,                  # mesh size of the root level, float or tuple
+        refinement_boxes={"L0": {"B0": [(100, ), (200, )]},
+                          "L1":{"B0":[(300,),(350,)]}},
+        diag_options={"format": "phareh5", "options": {"dir": kwargs["diagdir"],"mode":"overwrite"}}
+    )
+
+
+    def density(x):
+        return 1.
+
+    def bx(x):
+        return 0.
+
+    def by(x):
+        return 1.
+
+    def bz(x):
+        return 0.5
+
+
+    def vx(x):
+        return kwargs["vx"]
+
+    def vy(x):
+        return 0.
+
+    def vz(x):
+        return 0.
+
+
+    def vthx(x):
+        return 0.1
+
+
+    def vthy(x):
+        return 0.1
+
+
+    def vthz(x):
+        return 0.1
+
+
+    vvv = {
+        "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
+        "vthx": vthx, "vthy": vthy, "vthz": vthz
+    }
+
+    MaxwellianFluidModel(
+        bx=bx, by=by, bz=bz,
+        protons={"charge": 1, "density": density, **vvv}
+    )
+
+    ElectronModel(closure="isothermal", Te=0.12)
+
+
+
+    sim = ph.global_vars.sim
+
+    timestamps = np.arange(0, sim.final_time +sim.time_step, sim.time_step)
+
+
+
+    for quantity in ["E", "B"]:
+        ElectromagDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+        )
+
+
+    for quantity in ["density", "bulkVelocity"]:
+        FluidDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+            )
+
+
+
+
+
+def config_td(**kwargs):
+    """ Configure the simulation
+
+    This function defines the Simulation object,
+    user initialization model and diagnostics.
+    """
+    Simulation(
+        smallest_patch_size=20,
+        largest_patch_size=20,
+        time_step_nbr=2000,        # number of time steps (not specified if time_step and final_time provided)
+        final_time=20.,             # simulation final time (not specified if time_step and time_step_nbr provided)
+        boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
+        cells=200,                # integer or tuple length == dimension
+        dl=1,                  # mesh size of the root level, float or tuple
+        refinement_boxes={"L0": {"B0": [(50, ), (150, )]},
+                          "L1":{"B0":[(125,),(175,)]}},
+        diag_options={"format": "phareh5", "options": {"dir": kwargs["diagdir"],"mode":"overwrite"}}
+    )
+
+    def density(x):
+        return 1.
+
+
+    def S(x,x0,l):
+        return 0.5*(1+np.tanh((x-x0)/l))
+
+
+    def bx(x):
+        return 0.
+
+
+    def by(x):
+        from pyphare.pharein.global_vars import sim
+        L = sim.simulation_domain()[0]
+        v1=-1
+        v2=1.
+        return v1 + (v2-v1)*(S(x,L*0.25,1) -S(x, L*0.75, 1))
+
+
+    def bz(x):
+        return 0.5
+
+
+    def b2(x):
+        return bx(x)**2 + by(x)**2 + bz(x)**2
+
+
+    def T(x):
+        K = 1
+        return 1/density(x)*(K - b2(x)*0.5)
+
+
+    def vx(x):
+        return kwargs["vx"]
+
+
+    def vy(x):
+        return 0.
+
+
+    def vz(x):
+        return 0.
+
+
+    def vthx(x):
+        return T(x)
+
+
+    def vthy(x):
+        return T(x)
+
+
+    def vthz(x):
+        return T(x)
+
+
+    vvv = {
+        "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
+        "vthx": vthx, "vthy": vthy, "vthz": vthz
+    }
+
+    MaxwellianFluidModel(
+        bx=bx, by=by, bz=bz,
+        protons={"charge": 1, "density": density, **vvv}
+    )
+
+    ElectronModel(closure="isothermal", Te=0.12)
+
+
+
+    sim = ph.global_vars.sim
+
+    timestamps = np.arange(0, sim.final_time +sim.time_step, sim.time_step)
+
+
+
+    for quantity in ["E", "B"]:
+        ElectromagDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+        )
+
+
+    for quantity in ["density", "bulkVelocity"]:
+        FluidDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+            )
+
+
+
+
+def main():
+
+    for name,config in zip(("uni", "td"),(config_uni, config_td)):
+        params=[{"vx":-1,"diagdir":name + "_vxm2"},
+                {"vx":2,"diagdir":name + "_vx2"}]
+        for param in params:
+            if param["vx"] >-1:
+                continue
+            print("-----------------------------------")
+            print(param)
+            print("-----------------------------------")
+            config(**param)
+            simulator = Simulator(gv.sim)
+            simulator.initialize()
+            simulator.run()
+            gv.sim = None
+
+
+if __name__=="__main__":
+    main()

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -26,7 +26,7 @@ class AdvanceTest(unittest.TestCase):
                      diag_outputs="phare_outputs",
                      smallest_patch_size=5, largest_patch_size=5,
                      cells= 120, time_step=0.001,
-                     dl=0.1, extra_diag_options={}, time_step_nbr=1):
+                     dl=0.3, extra_diag_options={}, time_step_nbr=1):
 
         from pyphare.pharein import global_vars
         global_vars.sim = None
@@ -160,6 +160,7 @@ class AdvanceTest(unittest.TestCase):
 
         levelNumbers = list(range(global_vars.sim.max_nbr_levels))
         lvlSteps = global_vars.sim.level_time_steps
+        print("LEVELSTEPS === ", lvlSteps)
         assert len(lvlSteps) > 1  # this test makes no sense with only 1 level
 
         finestTimeStep = lvlSteps[-1]
@@ -201,12 +202,11 @@ class AdvanceTest(unittest.TestCase):
                         if lvlOverlap is not None:
                             for EM in ["E", "B"]:
                                 for xyz in ["x", "y", "z"]:
-                                    qty = f"EM_{EM}_{xyz}"
+                                    qty = f"{EM}{xyz}"
                                     coarse_pd = coarsePatch.patch_datas[qty]
                                     fine_pd  = finePatch.patch_datas[qty]
                                     coarseBox = boxm.coarsen(lvlOverlap, 2)
 
-                                    qty = f"{EM}{xyz}"
                                     nGhosts = coarse_pd.layout.nbrGhostFor(qty)
 
                                     coarse_pdDataset = coarse_pd.dataset[:]

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -201,16 +201,16 @@ class InitializationTest(unittest.TestCase):
             print("checking level {}".format(ilvl))
             for ip, patch in enumerate(level.patches):
 
-                xbx   = patch.patch_datas["EM_B_x"].x[:]
-                bx  = patch.patch_datas["EM_B_x"].dataset[:]
+                xbx   = patch.patch_datas["Bx"].x[:]
+                bx  = patch.patch_datas["Bx"].dataset[:]
                 np.testing.assert_allclose(bx, bx_fn(xbx), atol=3e-5)
 
-                xby   = patch.patch_datas["EM_B_y"].x[:]
-                by  = patch.patch_datas["EM_B_y"].dataset[:]
+                xby   = patch.patch_datas["By"].x[:]
+                by  = patch.patch_datas["By"].dataset[:]
                 np.testing.assert_allclose(by, by_fn(xby), atol=3e-5)
 
-                xbz   = patch.patch_datas["EM_B_z"].x[:]
-                bz  = patch.patch_datas["EM_B_z"].dataset[:]
+                xbz   = patch.patch_datas["Bz"].x[:]
+                bz  = patch.patch_datas["Bz"].dataset[:]
                 np.testing.assert_allclose(bz, bz_fn(xbz), atol=3e-5)
 
 
@@ -291,18 +291,18 @@ class InitializationTest(unittest.TestCase):
             for ip,patch in enumerate(level.patches):
                 print("patch {}".format(ip))
 
-                layout    = patch.patch_datas["protons_flux_x"].layout
-                centering = layout.centering["X"][patch.patch_datas["protons_flux_x"].field_name]
+                layout    = patch.patch_datas["protons_Fx"].layout
+                centering = layout.centering["X"][patch.patch_datas["protons_Fx"].field_name]
                 nbrGhosts = layout.nbrGhosts(interp_order, centering)
 
-                x   = patch.patch_datas["protons_flux_x"].x[nbrGhosts:-nbrGhosts]
-                fpx = patch.patch_datas["protons_flux_x"].dataset[nbrGhosts:-nbrGhosts]
-                fpy = patch.patch_datas["protons_flux_y"].dataset[nbrGhosts:-nbrGhosts]
-                fpz = patch.patch_datas["protons_flux_z"].dataset[nbrGhosts:-nbrGhosts]
-                fbx = patch.patch_datas["protons_flux_x"].dataset[nbrGhosts:-nbrGhosts]
-                fby = patch.patch_datas["protons_flux_y"].dataset[nbrGhosts:-nbrGhosts]
-                fbz = patch.patch_datas["protons_flux_z"].dataset[nbrGhosts:-nbrGhosts]
-                ni  = patch.patch_datas["density"].dataset[nbrGhosts:-nbrGhosts]
+                x   = patch.patch_datas["protons_Fx"].x[nbrGhosts:-nbrGhosts]
+                fpx = patch.patch_datas["protons_Fx"].dataset[nbrGhosts:-nbrGhosts]
+                fpy = patch.patch_datas["protons_Fy"].dataset[nbrGhosts:-nbrGhosts]
+                fpz = patch.patch_datas["protons_Fz"].dataset[nbrGhosts:-nbrGhosts]
+                fbx = patch.patch_datas["protons_Fx"].dataset[nbrGhosts:-nbrGhosts]
+                fby = patch.patch_datas["protons_Fy"].dataset[nbrGhosts:-nbrGhosts]
+                fbz = patch.patch_datas["protons_Fz"].dataset[nbrGhosts:-nbrGhosts]
+                ni  = patch.patch_datas["rho"].dataset[nbrGhosts:-nbrGhosts]
 
                 vxact = (fpx + fbx)/ni
                 vyact = (fpy + fby)/ni
@@ -339,13 +339,13 @@ class InitializationTest(unittest.TestCase):
             for ip,patch in enumerate(level.patches):
                 print("patch {}".format(ip))
 
-                ion_density     = patch.patch_datas["density"].dataset[:]
-                proton_density  = patch.patch_datas["protons_density"].dataset[:]
-                beam_density    = patch.patch_datas["beam_density"].dataset[:]
-                x               = patch.patch_datas["density"].x
+                ion_density     = patch.patch_datas["rho"].dataset[:]
+                proton_density  = patch.patch_datas["protons_rho"].dataset[:]
+                beam_density    = patch.patch_datas["beam_rho"].dataset[:]
+                x               = patch.patch_datas["rho"].x
 
-                layout    = patch.patch_datas["density"].layout
-                centering = layout.centering["X"][patch.patch_datas["density"].field_name]
+                layout    = patch.patch_datas["rho"].layout
+                centering = layout.centering["X"][patch.patch_datas["rho"].field_name]
                 nbrGhosts = layout.nbrGhosts(interp_order, centering)
 
                 protons_expected = proton_density_fn(x[nbrGhosts:-nbrGhosts])
@@ -398,11 +398,11 @@ class InitializationTest(unittest.TestCase):
             density_fn = protons["density"]
 
             patch       =  hier.level(0).patches[0]
-            ion_density = patch.patch_datas["density"].dataset[:]
-            x           = patch.patch_datas["density"].x
+            ion_density = patch.patch_datas["rho"].dataset[:]
+            x           = patch.patch_datas["rho"].x
 
-            layout = patch.patch_datas["density"].layout
-            centering = layout.centering["X"][patch.patch_datas["density"].field_name]
+            layout = patch.patch_datas["rho"].layout
+            centering = layout.centering["X"][patch.patch_datas["rho"].field_name]
             nbrGhosts = layout.nbrGhosts(interp_order, centering)
 
             expected = density_fn(x[nbrGhosts:-nbrGhosts])


### PR DESCRIPTION
add shock functional test.

Add Tagger for automatic refinement
MultiphysicsIntegrator uses the Tagger, which is abstract and actually depends on which model is being solved at current level.
There are therefore concrete taggers, per model. Each concrete Tagger can then have multiple tagging strategies. Only 1 is now coded. (Other attempts may come later, and also may be taken from user supplied python tagging methods.)

Bug fixes

    first bug fix concerns EM_old and Jold in the hybridMessenger. These quantities are supposed to store the current state of those model variables at time n before the level advances to time n+1. They are then used by next finer level to get ghosts at subcycle times which are per definition between coarse steps n and n+1. before this PR, the "old" quantities had their patchdata timestamp fixed at the creation of the level but never updated afterwards. The current PR thus sets their timestamps in prepareStep, i.e. before every advance().

    fix bug concerning regriding: Regriding means taking a level out of the hierarchy and replacing it by a new one. This action invalidates all the schedules stored in the RefinerPool that deal with the level being replaced. This PR now re-create schedules for the level that's being regrided and the next finer as well. This is important because SAMRAI typically will do things in the following order:

    for a hierarchy with 2 levels:

    tag level 1

    create level 2

    regrid level 1

thus at the time L2 is created, its schedules are made with the L1 taht is about to be taken out of the hierarchy. This PR now re-makes these schedules when regriding L1.

    the PR also adds particles to the maxwellian initializer test as well as prints, in an attempt to know more about latest (random?) failures observed of this tests...

tagging :
The concrete tagging strategy that is implemented tags a cell (==1) when the local 3 points average of the magnetic field differs from the current value from more than 10%. It's a first attempt that seems to give consistent results in tha tdtagged functional test but will need further attention in upcoming PRs.

Notes :

    The concrete tagging strategy ignores what samrai stuff is, and probably could be moved to a core lib section. That should be considered later as this matter possibly also concern other components.
