### PR TITLE
Runtimestamp

### DIFF
--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -40,7 +40,7 @@ class Run:
         self.path = path
 
     def _get_hierarchy(self, time, filename):
-        t = "t{:.6f}".format(time)
+        t = "t{:.10f}".format(time)
         return hierarchy_from(h5_filename=os.path.join(self.path, filename), time=t)
 
     def GetB(self, time):

--- a/src/core/utilities/types.h
+++ b/src/core/utilities/types.h
@@ -190,6 +190,10 @@ namespace core
         std::ostringstream out;
         out.precision(len);
         out << std::fixed << a_value;
+        auto str = out.str();
+        // last digit may be non 0 because of rounding
+        // and we know at that decimal it should be so we force it
+        str.replace(str.end() - 1, str.end(), 1, '0');
         return out.str();
     }
 


### PR DESCRIPTION
last digit of diag timestamps sometime is non zero probably to some rounding error.
This PR sets it to 0.
python run is updated so to look for 10 decimal time stamps