### PR TITLE
Debug: Less screen printing in cmake release build mode

### DIFF
--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -78,5 +78,7 @@ def check_mandatory_keywords(mandatory_kwd_list, **kwargs):
     check = [(mk, mk in keys) for mk in mandatory_kwd_list]
     return [mk[0] for mk in check if mk[1] is False]
 
-
+def dbg_print(*args):
+    if __debug__:
+        print(*args)
 

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -91,10 +91,12 @@ class Simulator:
             ticktock = tock-tick
             perf.append(ticktock)
             t = self.cpp_sim.currentTime()
-            print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, ticktock, np.sum(perf)))
+            if __debug__:
+                print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, ticktock, np.sum(perf)))
 
         print("mean advance time = {}".format(np.mean(perf)))
         print("total advance time = {}".format(np.sum(perf)))
+        return self
 
 
 

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -3,6 +3,8 @@ import atexit
 import time as timem
 import numpy as np
 
+from pyphare.core.phare_utilities import dbg_print
+
 
 life_cycles = {}
 
@@ -16,8 +18,8 @@ def simulator_shutdown():
 
 def make_cpp_simulator(dim, interp, nbrRefinedPart, hier):
     from pybindlibs import cpp
-    make_sim = "make_simulator_" + str(dim) + "_" + str(interp)+ "_" + str(nbrRefinedPart)
-    print("make_sim", make_sim)
+    make_sim = f"make_simulator_{dim}_{interp}_{nbrRefinedPart}"
+    dbg_print("make_sim", make_sim)
     return getattr(cpp, make_sim)(hier)
 
 
@@ -91,8 +93,7 @@ class Simulator:
             ticktock = tock-tick
             perf.append(ticktock)
             t = self.cpp_sim.currentTime()
-            if __debug__:
-                print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, ticktock, np.sum(perf)))
+            dbg_print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, ticktock, np.sum(perf)))
 
         print("mean advance time = {}".format(np.mean(perf)))
         print("total advance time = {}".format(np.sum(perf)))

--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -25,6 +25,11 @@
 
 if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
+  set(PHARE_PY_EXEC_FLAGS -u)
+  if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(PHARE_PY_EXEC_FLAGS ${PHARE_PY_EXEC_FLAGS} -O)
+  endif()
+
   if (NOT DEFINED PHARE_MPI_PROCS)
     set(PHARE_MPI_PROCS 1)
     if(testMPI)
@@ -56,7 +61,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
   function(add_no_mpi_python3_test name file directory)
     if(NOT testMPI OR (testMPI AND forceSerialTests))
-      add_test(NAME py3_${name} COMMAND python3 ${file} WORKING_DIRECTORY ${directory})
+      add_test(NAME py3_${name} COMMAND ${PYTHON_EXECUTABLE} ${PHARE_PY_EXEC_FLAGS} ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name})
     endif()
   endfunction(add_no_mpi_python3_test)
@@ -68,12 +73,12 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
     endfunction(add_phare_test)
 
     function(add_python3_test name file directory)
-      add_test(NAME py3_${name} COMMAND mpirun -n ${PHARE_MPI_PROCS} python3 ${file} WORKING_DIRECTORY ${directory})
+      add_test(NAME py3_${name} COMMAND mpirun -n ${PHARE_MPI_PROCS} ${PYTHON_EXECUTABLE} ${PHARE_PY_EXEC_FLAGS} ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name})
     endfunction(add_python3_test)
 
     function(add_mpi_python3_test N name file directory)
-      add_test(NAME py3_${name}_mpi_n_${N} COMMAND mpirun -n ${N} python3 ${file} WORKING_DIRECTORY ${directory})
+      add_test(NAME py3_${name}_mpi_n_${N} COMMAND mpirun -n ${N} ${PYTHON_EXECUTABLE} ${PHARE_PY_EXEC_FLAGS} ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name}_mpi_n_${N})
     endfunction(add_mpi_python3_test)
   else()
@@ -120,7 +125,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
   function(phare_python3_exec level target file directory)
     if(${level} GREATER_EQUAL ${PHARE_EXEC_LEVEL_MIN} AND ${level} LESS_EQUAL ${PHARE_EXEC_LEVEL_MAX})
-      add_test(NAME ${target} COMMAND python3 -u ${file} WORKING_DIRECTORY ${directory})
+      add_test(NAME ${target} COMMAND ${PYTHON_EXECUTABLE} ${PHARE_PY_EXEC_FLAGS} ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(${target})
     endif()
   endfunction(phare_python3_exec)

--- a/src/amr/messengers/communicators.h
+++ b/src/amr/messengers/communicators.h
@@ -1,6 +1,7 @@
 #ifndef PHARE_COMMUNICATORS_H
 #define PHARE_COMMUNICATORS_H
 
+#include "core/def.h"
 #include "quantity_communicator.h"
 
 #include <SAMRAI/hier/RefineOperator.h>
@@ -224,8 +225,8 @@ namespace amr
 
                 if constexpr (Type == RefinerType::LevelBorderParticles)
                 {
-                    std::cout << "regriding adding levelghostparticles on level " << levelNumber
-                              << " " << key << "\n";
+                    PHARE_DEBUG_PRINT("regriding adding levelghostparticles on level ", levelNumber,
+                                      " ", key);
                     auto schedule = algo->createSchedule(
                         std::make_shared<SAMRAI::xfer::PatchLevelBorderFillPattern>(), level,
                         oldLevel, level->getNextCoarserHierarchyLevelNumber(), hierarchy);
@@ -233,7 +234,7 @@ namespace amr
                 }
                 else
                 {
-                    std::cout << "regriding adding " << key << " on level " << levelNumber << " \n";
+                    PHARE_DEBUG_PRINT("regriding adding ", key, " on level ", levelNumber);
                     auto schedule = algo->createSchedule(
                         level, oldLevel, level->getNextCoarserHierarchyLevelNumber(), hierarchy);
                     schedule->fillData(initDataTime);

--- a/src/amr/wrappers/integrator.h
+++ b/src/amr/wrappers/integrator.h
@@ -17,7 +17,7 @@
 #include <SAMRAI/tbox/MemoryDatabase.h>
 
 
-
+#include "core/def.h"
 #include "initializer/data_provider.h"
 
 
@@ -115,7 +115,7 @@ getUserRefinementBoxesDatabase(PHARE::initializer::PHAREDict& amr)
         // auto at0db = refinementBoxesDatabase->putDatabase("at_0");
         // at0db->putInteger("cycle", 0);
         // auto tag0db = at0db->putDatabase("tag_0");
-        std::cout << "tagging method is set to REFINE_BOXES\n";
+        PHARE_DEBUG_PRINT("tagging method is set to REFINE_BOXES");
         refinementBoxesDatabase->putString("tagging_method", "REFINE_BOXES");
 
 

--- a/src/core/def.h
+++ b/src/core/def.h
@@ -1,0 +1,23 @@
+
+#ifndef PHARE_CORE_DEF_H
+#define PHARE_CORE_DEF_H
+
+
+#if !defined(NDEBUG) || defined(PHARE_FORCE_DEBUG_DO)
+#define PHARE_DEBUG_DO(...) __VA_ARGS__
+
+template<class... Args>
+void PHARE_DEBUG_PRINT(Args... args)
+{
+    (std::cout << ... << args) << "\n";
+}
+#else
+#define PHARE_DEBUG_DO(...)
+
+template<class... Args>
+void PHARE_DEBUG_PRINT(Args... args)
+{
+}
+#endif
+
+#endif // PHARE_CORE_DEF_H

--- a/src/core/def.h
+++ b/src/core/def.h
@@ -1,9 +1,10 @@
-
 #ifndef PHARE_CORE_DEF_H
 #define PHARE_CORE_DEF_H
 
-
 #if !defined(NDEBUG) || defined(PHARE_FORCE_DEBUG_DO)
+
+#include <iostream>
+
 #define PHARE_DEBUG_DO(...) __VA_ARGS__
 
 template<class... Args>

--- a/src/core/utilities/types.h
+++ b/src/core/utilities/types.h
@@ -9,14 +9,7 @@
 #include <tuple>
 #include <vector>
 
-
 #include "cppdict/include/dict.hpp"
-
-#if !defined(NDEBUG) || defined(PHARE_FORCE_DEBUG_DO)
-#define PHARE_DEBUG_DO(...) __VA_ARGS__
-#else
-#define PHARE_DEBUG_DO(...)
-#endif
 
 
 namespace PHARE

--- a/src/phare_core.h
+++ b/src/phare_core.h
@@ -2,6 +2,7 @@
 #ifndef PHARE_CORE_INCLUDE_H
 #define PHARE_CORE_INCLUDE_H
 
+#include "core/def.h"
 #include "core/data/electromag/electromag.h"
 #include "core/data/electrons/electrons.h"
 #include "core/data/grid/gridlayout.h"

--- a/src/simulator/simulator.h
+++ b/src/simulator/simulator.h
@@ -115,7 +115,7 @@ private:
 
     SimFunctors functors_setup(PHARE::initializer::PHAREDict const& dict)
     {
-        return {{"pre_advance", {/*empty vector*/}}};
+        return {{"post_advance", {/*empty vector*/}}};
     }
 
     std::shared_ptr<MultiPhysicsIntegrator> multiphysInteg_{nullptr};
@@ -187,7 +187,7 @@ Simulator<_dimension, _interp_order, _nbRefinedPart>::Simulator(
                 if (fine_dump_lvl_max > 0)
                 { // copy for later
                     this->fineDumpLvlMax = static_cast<std::size_t>(fine_dump_lvl_max);
-                    functors_["pre_advance"]["fine_dump"] = [&](SimFunctorParams const& params) {
+                    functors_["post_advance"]["fine_dump"] = [&](SimFunctorParams const& params) {
                         std::size_t level_nbr = params["level_nbr"].template to<int>();
                         auto timestamp        = params["timestamp"].template to<double>();
 

--- a/src/solver/multiphysics_integrator.h
+++ b/src/solver/multiphysics_integrator.h
@@ -301,8 +301,8 @@ namespace solver
             bool const isRegridding = oldLevel != nullptr;
             auto level              = hierarchy->getPatchLevel(levelNumber);
 
-            std::cout << "init level " << levelNumber << " with regriding = " << isRegridding
-                      << "\n";
+            PHARE_DEBUG_PRINT("init level ", levelNumber, " with regriding = ", isRegridding);
+
             if (allocateData)
             {
                 for (auto patch : *level)
@@ -400,13 +400,13 @@ namespace solver
         void dump_(int iLevel)
         {
             // we skip first/last as that's done via regular diag dump mechanism
-            bool fineDumpsActive = simFuncs_.at("pre_advance").count("fine_dump") > 0;
+            bool fineDumpsActive = simFuncs_.at("post_advance").count("fine_dump") > 0;
             bool notCoarsestTime = subcycleEndTimes_[iLevel] != subcycleEndTimes_[0];
             bool shouldDump      = fineDumpsActive and notCoarsestTime and iLevel > 0;
 
             if (shouldDump)
             {
-                auto const& dump_functor = simFuncs_.at("pre_advance").at("fine_dump");
+                auto const& dump_functor = simFuncs_.at("post_advance").at("fine_dump");
                 SimFunctorParams fineDumpParams;
                 fineDumpParams["level_nbr"] = iLevel;
                 fineDumpParams["timestamp"] = subcycleEndTimes_[iLevel];
@@ -443,8 +443,10 @@ namespace solver
 
 
             auto iLevel = level->getLevelNumber();
-            std::cout << "advanceLevel " << iLevel << " with dt = " << newTime - currentTime
-                      << " from t = " << currentTime << "to t = " << newTime << "\n";
+
+            PHARE_DEBUG_PRINT("advanceLevel ", iLevel, " with dt = ", newTime - currentTime,
+                              " from t = ", currentTime, "to t = ", newTime);
+
             auto& solver      = getSolver_(iLevel);
             auto& model       = getModel_(iLevel);
             auto& fromCoarser = getMessengerWithCoarser_(iLevel);


### PR DESCRIPTION
refactor "pre_advance" functions to "post_advance" as it's used for dumping finer level diagostics after the point which their subcycle has "advanced"