### PR TITLE
refactor finest data

### DIFF
--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -52,8 +52,7 @@ def validate_timestamps(clazz, **kwargs):
             raise RuntimeError(f"Error: timestamp({sim.time_step_nbr}) cannot be greater than simulation.final_time({sim.final_time}))")
         if not np.all(np.diff(timestamps) >= 0):
             raise RuntimeError(f"Error: {clazz}.{key} not in ascending order)")
-        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):
-            print(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step)).max())
+        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):            
             raise RuntimeError(f"Error: {clazz}.{key} is inconsistent with simulation.time_step")
 
 

--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -52,8 +52,9 @@ def validate_timestamps(clazz, **kwargs):
             raise RuntimeError(f"Error: timestamp({sim.time_step_nbr}) cannot be greater than simulation.final_time({sim.final_time}))")
         if not np.all(np.diff(timestamps) >= 0):
             raise RuntimeError(f"Error: {clazz}.{key} not in ascending order)")
-        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-10)):
-            raise RuntimeError(f"Error: {clazz}.{key} is inconsistent with simulation.time_step)")
+        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):
+            print(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step)).max())
+            raise RuntimeError(f"Error: {clazz}.{key} is inconsistent with simulation.time_step")
 
 
 

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -178,8 +178,8 @@ class PatchLevel:
 
 
 
-def are_adjacent(lower_x, upper_x, atol=1e-6):
-    return np.abs(upper_x[0]-lower_x[-1]) < atol
+def are_adjacent(lower, upper, atol=1e-6):
+    return np.abs(upper[0]-lower[-1]) < atol
 
 
 def overlap_mask(x, level, qty):
@@ -221,14 +221,11 @@ def finest_field(hierarchy, qty, time=None):
        associated to the given hierarchy
        the quantity "qty" must be a field
     """
-    if time is None:
-        time = hierarchy.times()[0] # to replace with default
-
     lvl = hierarchy.levels(time)
 
     for ilvl in range(hierarchy.finest_level(time)+1)[::-1]:
         sorted_patches = sorted(lvl[ilvl].patches,
-                                key= lambda p:p.layout.box.lower[0])
+                                key= lambda p:p.box.lower[0])
 
         for ip, patch in enumerate(sorted_patches):
 
@@ -545,13 +542,14 @@ class PatchHierarchy:
         time = kwargs.get("time", self.times()[0])
         axis = kwargs.get("axis", ("Vx", "Vy"))
         all_pops = list(self.level(0,time).patches[0].patch_datas.keys())
+
+        vmin = kwargs.get("vmin", -2)
+        vmax = kwargs.get("vmax", 2)
+        dv = kwargs.get("dv", 0.05)
+        vbins = vmin + dv*np.arange(int((vmax-vmin)/dv))
+
         if finest:
             final = finest_part_data(self)
-            vmin = kwargs.get("vmin", -2)
-            vmax = kwargs.get("vmax", 2)
-            dv = kwargs.get("dv", 0.05)
-            vbins = vmin + dv*np.arange(int((vmax-vmin)/dv))
-
             if axis[0] == "x":
                 xbins = amr_grid(self, time)
                 bins = (xbins, vbins)

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -217,8 +217,9 @@ def overlap_mask(x, level, qty):
 
 
 def finest_field(hierarchy, qty, time=None):
-    """returns a non-uniform contiguous primal grid
+    """returns a non-uniform contiguous (value,grid)
        associated to the given hierarchy
+       the quantity "qty" must be a field
     """
     if time is None:
         time = hierarchy.times()[0] # to replace with default

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -6,6 +6,7 @@ from mpl_toolkits.axes_grid1.inset_locator import (
 
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm, Normalize
 
 def dist_plot(particles, **kwargs):
     """
@@ -29,7 +30,6 @@ def dist_plot(particles, **kwargs):
     return value : fig,ax
     """
     from pyphare.pharesee.particles import Particles, aggregate
-    from matplotlib.colors import Normalize
 
     if isinstance(particles, list):
         particles = aggregate(particles)
@@ -61,8 +61,21 @@ def dist_plot(particles, **kwargs):
               weights=particles.weights)
 
     sig = kwargs.get("sigma", (0,0))
-    hm = kwargs.get("norm", h.max())
-    im = ax.pcolormesh(xh, yh, gf(h.T, sigma=sig), cmap="jet", norm=Normalize(0,hm))
+    cmax = kwargs.get("color_max", h.max())
+    cmin = kwargs.get("color_min", h.min())
+    cmin = max(cmin, 1e-4)
+
+    color_scale = kwargs.get("color_scale", "log")
+    if color_scale == "log":
+        norm = LogNorm(vmin=cmin, vmax=cmax)
+    elif color_scale == "linear":
+        norm = Normalize(cmin, cmax)
+
+
+    im = ax.pcolormesh(xh, yh, gf(h.T, sigma=sig),
+                       cmap = "jet",
+                       norm = norm)
+
     fig.colorbar(im, ax=ax)
 
     if kwargs.get("kde",False) is True:


### PR DESCRIPTION
(on top of #456 )

Previously finest_data was working per patch_data. This forced the client code to loop over the hierarchy etc.
This new version is more convenient, you just pass a field hierarchy and it 

example of usage 

```python
r007 = Run("../phare_jobs/tests/alfven_wave/run007/")
B = r007.GetB(0)
bx, xbx = finest_field(B, "Bx")
print(np.allclose(xbx, amr_grid(B, 0)))
by, xby = finest_field(B, "By")
fig,ax = plt.subplots(figsize=(10,5))
ax.plot(xb, bb, marker="x", markersize=5)
```

returns

```
True
```

![image](https://user-images.githubusercontent.com/3200931/111652597-7a200700-8807-11eb-98b0-44680671d85a.png)


this simplify functions used to plot stuff like (same simulation, hierarchy patches to be compared with marker density above)

![image](https://user-images.githubusercontent.com/3200931/111652750-9f147a00-8807-11eb-9718-3960c961572d.png)



where one had to loop over the patches etc. and call former finest_data() per patch as in : 

```python
for ilvl, lvl in self.patch_levels.items():
        for pidx, patch in enumerate(lvl.patches):
            pdata  = patch.patch_datas[qty]
            x,v = finest_data(pdata, ilvl, self)
            ax1.plot(x, v,label="lev{} - patch{}".format(ilvl, pidx),
                     marker='o', markersize=2, color=colors[ilvl])

```


moreover we now have a contiguous array for data, which is convenient.