### PR TITLE
C++ messenger function postSynchronize to copy patchghost values after coarsening from finer level

### DIFF
--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -513,7 +513,14 @@ namespace amr
             // ionBulkVelSynchronizers_.sync(levelNumber);
         }
 
-
+        void postSynchronize(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                             double const time) override
+        {
+            auto levelNumber  = level.getLevelNumber();
+            auto& hybridModel = static_cast<HybridModel&>(model);
+            magneticGhosts_.fill(hybridModel.state.electromag.B, levelNumber, time);
+            electricGhosts_.fill(hybridModel.state.electromag.E, levelNumber, time);
+        }
 
     private:
         void registerGhostComms_(std::unique_ptr<HybridMessengerInfo> const& info)

--- a/src/amr/messengers/hybrid_messenger.h
+++ b/src/amr/messengers/hybrid_messenger.h
@@ -192,6 +192,12 @@ namespace amr
 
         void synchronize(SAMRAI::hier::PatchLevel& level) override { strat_->synchronize(level); }
 
+        void postSynchronize(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                             double const time) override
+        {
+            strat_->postSynchronize(model, level, time);
+        }
+
 
 
         /**

--- a/src/amr/messengers/hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_messenger_strategy.h
@@ -116,6 +116,10 @@ namespace amr
 
         virtual void synchronize(SAMRAI::hier::PatchLevel& level) = 0;
 
+        virtual void postSynchronize(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                                     double const time)
+            = 0;
+
 
         std::string name() const { return stratname_; }
 

--- a/src/amr/messengers/messenger.h
+++ b/src/amr/messengers/messenger.h
@@ -205,6 +205,10 @@ namespace amr
 
         virtual void synchronize(SAMRAI::hier::PatchLevel& level) = 0;
 
+        virtual void postSynchronize(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
+                                     double const time)
+            = 0;
+
 
         /**
          * @brief fineModelName returns the name of the fine model involved in the messenger

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.h
@@ -148,6 +148,11 @@ namespace amr
             // call coarsning schedules...
         }
 
+        void postSynchronize(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
+                             double const /*time*/) override
+        {
+        }
+
 
 
 

--- a/src/amr/messengers/mhd_messenger.h
+++ b/src/amr/messengers/mhd_messenger.h
@@ -110,6 +110,10 @@ namespace amr
             // call coarsning schedules...
         }
 
+        void postSynchronize(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
+                             double const /*time*/) override
+        {
+        }
 
 
         std::string name() override { return stratName; }


### PR DESCRIPTION
also includes levelghost copies, so https://github.com/PHAREHUB/PHARE/issues/487 is there