### PR TITLE
fix time stamps in td functional test

### DIFF
--- a/tests/functional/td/td1d.py
+++ b/tests/functional/td/td1d.py
@@ -112,7 +112,9 @@ def config():
 
     sim = ph.global_vars.sim
 
-    timestamps = np.arange(0, sim.final_time +sim.time_step, sim.time_step)
+    dt_dump = 0.1
+    n_dump = int(sim.final_time/dt_dump)+1
+    timestamps = np.linspace(0, sim.final_time, n_dump)
 
 
 


### PR DESCRIPTION
on TC:

```
    File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharein/diagnostics.py", line 52, in validate_timestamps
      raise RuntimeError(f"Error: timestamp({sim.time_step_nbr}) cannot be greater than simulation.final_time({sim.final_time}))")
  RuntimeError: Error: timestamp(2000) cannot be greater than simulation.final_time(20.0)) 
```