### PR TITLE
wip smoothing

### DIFF
--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -146,6 +146,7 @@ namespace amr
             electricGhosts_.registerLevel(hierarchy, level);
             currentGhosts_.registerLevel(hierarchy, level);
             patchGhostParticles_.registerLevel(hierarchy, level);
+            densityGhosts_.registerLevel(hierarchy, level);
 
             // root level is not initialized with a schedule using coarser level data
             // so we don't create these schedules if root level
@@ -292,6 +293,11 @@ namespace amr
             currentGhosts_.fill(J, levelNumber, fillTime);
         }
 
+
+        void fillDensityGhosts(int const levelNumber, double const fillTime) override
+        {
+            densityGhosts_.fill(levelNumber, fillTime);
+        }
 
 
 
@@ -554,6 +560,8 @@ namespace amr
 
             fillRefiners_(info->ghostCurrent, info->modelCurrent, VecFieldDescriptor{Jold_},
                           currentGhosts_);
+
+            fillRefiners_(info->ghostIonDensity, densityGhosts_);
         }
 
 
@@ -653,6 +661,11 @@ namespace amr
             }
         }
 
+        template<typename RefinerPool>
+        void fillRefiners_(FieldDescriptor const& descriptor, RefinerPool& refiner)
+        {
+            refiner.add(descriptor, nullptr, descriptor, resourcesManager_);
+        }
 
 
         void copyLevelGhostOldToPushable_(SAMRAI::hier::PatchLevel& level, IPhysicalModel& model)
@@ -720,6 +733,7 @@ namespace amr
 
         RefinerPool<RefinerType::GhostField> currentGhosts_;
 
+        RefinerPool<RefinerType::GhostField> densityGhosts_;
 
         // algo and schedule used to initialize domain particles
         // from coarser level using particleRefineOp<domain>

--- a/src/amr/messengers/hybrid_messenger.h
+++ b/src/amr/messengers/hybrid_messenger.h
@@ -62,7 +62,7 @@ namespace amr
         using IonsT          = decltype(std::declval<HybridModel>().state.ions);
         using VecFieldT      = decltype(std::declval<HybridModel>().state.electromag.E);
         using IPhysicalModel = typename HybridModel::Interface;
-
+        using FieldT         = typename VecFieldT::field_type;
 
         using stratT = HybridMessengerStrategy<HybridModel>;
 
@@ -300,6 +300,13 @@ namespace amr
         void fillCurrentGhosts(VecFieldT& J, int const levelNumber, double const fillTime)
         {
             strat_->fillCurrentGhosts(J, levelNumber, fillTime);
+        }
+
+
+
+        void fillDensityGhosts(int const levelNumber, double const fillTime)
+        {
+            strat_->fillDensityGhosts(levelNumber, fillTime);
         }
 
 

--- a/src/amr/messengers/hybrid_messenger_info.h
+++ b/src/amr/messengers/hybrid_messenger_info.h
@@ -97,6 +97,8 @@ namespace amr
         //! HybridMessenger::fillGhostCurrent
         std::vector<VecFieldDescriptor> ghostCurrent;
 
+        FieldDescriptor ghostIonDensity;
+
 
         virtual ~HybridMessengerInfo() = default;
     };

--- a/src/amr/messengers/hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_messenger_strategy.h
@@ -21,6 +21,7 @@ namespace amr
     {
         using IonsT          = decltype(std::declval<HybridModel>().state.ions);
         using VecFieldT      = decltype(std::declval<HybridModel>().state.electromag.E);
+        using FieldT         = typename VecFieldT::field_type;
         using IPhysicalModel = typename HybridModel::Interface;
 
     public:
@@ -77,6 +78,9 @@ namespace amr
 
         virtual void fillCurrentGhosts(VecFieldT& J, int const levelNumber, double const fillTime)
             = 0;
+
+
+        virtual void fillDensityGhosts(int const levelNumber, double const fillTime) = 0;
 
 
         virtual void fillIonGhostParticles(IonsT& ions, SAMRAI::hier::PatchLevel& level,

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.h
@@ -111,6 +111,9 @@ namespace amr
         }
 
 
+        void fillDensityGhosts(int const /*levelNumber*/, double const /*fillTime*/) override {}
+
+
         void fillIonGhostParticles(IonsT& /*ions*/, SAMRAI::hier::PatchLevel& /*level*/,
                                    double const /*fillTime*/) override
         {

--- a/src/core/numerics/filter/filter.h
+++ b/src/core/numerics/filter/filter.h
@@ -14,19 +14,34 @@ public:
     {
         auto start = layout.physicalStartIndex(density, Direction::X);
         auto end = layout.physicalEndIndex(density, Direction::X);
-        auto alpha = 0.5;
+
+        // this is hard coded but probably will never change
+        auto constexpr alpha = 0.5;
+
+        // this is doing a memory allocation
+        // which is not optimal since that function will be called
+        // several time per patch. Another way would be that
+        // the filter is owned by the Solver and has an interface
+        // used by the solver to declare a resource to the resource manager
+        // for that temporary object. This way the allocation would be done
+        // for all patches only once per regrid. This is something that should
+        // be done eventually.
+        std::vector<typename Field::type> tmp{density.data(), density.data()+density.size()};
+
         if constexpr (Field::dimension == 1)
         {
             for (auto ix=start; ix <= end; ++ix)
             {
-                density(ix) = alpha*density(ix) + 0.5*(1-alpha)*(density(ix-1)+ density(ix+1));
+                // also the fact that 'tmp' is a vector (and not a field)
+                // forces us to use [] and not (), which is ok in 1D but much less
+                // extensible to nD than if we had one tmp Field registered.
+                density(ix) = alpha*tmp[ix] + 0.5*(1-alpha)*(tmp[ix-1]+ tmp[ix+1]);
             }
         }
         else
         {
             std::runtime_error("unsupported filter dim");
         }
-
     }
 };
 

--- a/src/core/numerics/filter/filter.h
+++ b/src/core/numerics/filter/filter.h
@@ -1,0 +1,37 @@
+#ifndef FILTER_H
+#define FILTER_H
+
+#include "core/data/grid/gridlayoutdefs.h"
+
+namespace PHARE::core {
+
+
+class Filter
+{
+public:
+    template <typename Field, typename GridLayout>
+    void operator()(Field& density, GridLayout const& layout)
+    {
+        auto start = layout.physicalStartIndex(density, Direction::X);
+        auto end = layout.physicalEndIndex(density, Direction::X);
+        auto alpha = 0.5;
+        if constexpr (Field::dimension == 1)
+        {
+            for (auto ix=start; ix <= end; ++ix)
+            {
+                density(ix) = alpha*density(ix) + 0.5*(1-alpha)*(density(ix-1)+ density(ix+1));
+            }
+        }
+        else
+        {
+            std::runtime_error("unsupported filter dim");
+        }
+
+    }
+};
+
+
+}
+
+
+#endif // FILTER_H

--- a/src/solver/physical_models/hybrid_model.h
+++ b/src/solver/physical_models/hybrid_model.h
@@ -148,6 +148,7 @@ void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::fillMesse
     modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
     modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
     modelInfo.ghostCurrent.push_back(state.J);
+    modelInfo.ghostIonDensity = state.ions.densityName();
 
 
     auto transform_ = [](auto& ions, auto& inserter) {

--- a/src/solver/solvers/solver_ppc.h
+++ b/src/solver/solvers/solver_ppc.h
@@ -207,7 +207,7 @@ void SolverPPC<HybridModel, AMR_Types>::advanceLevel(std::shared_ptr<hierarchy_t
     moveIons_(*level, hybridState.ions, electromagAvg_, resourcesManager, fromCoarser, currentTime,
               newTime, core::UpdaterMode::moments_only);
 
-    // filterDensity_(*level, hybridModel, fromCoarser, newTime);
+    filterDensity_(*level, hybridModel, fromCoarser, newTime);
 
     predictor2_(*level, hybridModel, fromCoarser, currentTime, newTime);
 
@@ -216,7 +216,7 @@ void SolverPPC<HybridModel, AMR_Types>::advanceLevel(std::shared_ptr<hierarchy_t
     moveIons_(*level, hybridState.ions, electromagAvg_, resourcesManager, fromCoarser, currentTime,
               newTime, core::UpdaterMode::particles_and_moments);
 
-    // filterDensity_(*level, hybridModel, fromCoarser, newTime);
+    filterDensity_(*level, hybridModel, fromCoarser, newTime);
 
     corrector_(*level, hybridModel, fromCoarser, currentTime, newTime);
 
@@ -487,8 +487,11 @@ void SolverPPC<HybridModel, AMR_Types>::filterDensity_(level_t& level, HybridMod
     auto& ions             = model.state.ions;
     auto& resourcesManager = model.resourcesManager;
     PHARE::core::Filter filter;
+    auto levelNumber = level.getLevelNumber();
+    messenger.fillDensityGhosts(levelNumber, newTime);
 
-    for (auto i = 0; i < 10; ++i)
+
+    for (auto i = 0; i < 2; ++i)
     {
         for (auto& patch : level)
         {
@@ -498,7 +501,7 @@ void SolverPPC<HybridModel, AMR_Types>::filterDensity_(level_t& level, HybridMod
             auto& density = ions.density();
             filter(density, layout);
         }
-        messenger.fillDensityGhosts(level.getLevelNumber(), newTime);
+        messenger.fillDensityGhosts(levelNumber, newTime);
     }
 }
 


### PR DESCRIPTION
This is WIP

This PR adds the possibility to smooth the density. This helps reducing the noise mainly originating from the pressure gradient term in Ohm's law.
The way it is currently done is not ideal. Improvements can be

- let the Filter object declare a resource for a temporary density array, rather than allocating one on the fly, for each patch, each level, each pass. This would reduce the cadence of the memory allocation, basically to 1 per regrid.

- have configurable (via dict/python) number of filter passes. Not super important.

- The filter operates on a 3 points stencil, which means that border nodes need the first primal ghost. Before this, the first primal ghost was the copy of the border node, thus not equal to the overlaped neighbor domain primal node. This was not an issue since note used for domain computations (only for coarsening, which was OK). Now this ghost needs to be known. This means that a ghost exchange SAMRAI schedule is applied before filtering and at each filter pass.

- Currently, the filter passes are applied per level. This means that there is a potential "disconnection" at level boundaries. Ideally each pass of the filter should do the entire hierarchy, echange ghosts for each level, etc. for the level boundaries to stay in sync with other levels. Not doing that makes the level border mismatch only visible for high smoothing (large number of passes).