### PR TITLE
change particle delta from float to double

### DIFF
--- a/src/core/data/ions/particle_initializers/maxwellian_particle_initializer.h
+++ b/src/core/data/ions/particle_initializers/maxwellian_particle_initializer.h
@@ -144,7 +144,7 @@ void MaxwellianParticleInitializer<ParticleArray, GridLayout>::loadParticles(
     };
 
 
-    auto deltas = [](auto& pos, auto& gen) -> std::array<float, dimension> {
+    auto deltas = [](auto& pos, auto& gen) -> std::array<double, dimension> {
         if constexpr (dimension == 1)
             return {pos(gen)};
         if constexpr (dimension == 2)
@@ -172,7 +172,7 @@ void MaxwellianParticleInitializer<ParticleArray, GridLayout>::loadParticles(
 
     auto const [n, V, Vth] = fns();
     auto randGen           = getRNG(rngSeed_);
-    ParticleDeltaDistribution deltaDistrib;
+    ParticleDeltaDistribution<double> deltaDistrib;
 
     for (std::size_t flatCellIdx = 0; flatCellIdx < ndCellIndices.size(); flatCellIdx++)
     {

--- a/src/core/data/particles/particle.h
+++ b/src/core/data/particles/particle.h
@@ -41,9 +41,9 @@ struct Particle
     double weight;
     double charge;
 
-    std::array<int, dim> iCell   = ConstArray<int, dim>();
-    std::array<float, dim> delta = ConstArray<float, dim>();
-    std::array<double, 3> v      = ConstArray<double, 3>();
+    std::array<int, dim> iCell    = ConstArray<int, dim>();
+    std::array<double, dim> delta = ConstArray<double, dim>();
+    std::array<double, 3> v       = ConstArray<double, 3>();
 
     double Ex = 0, Ey = 0, Ez = 0;
     double Bx = 0, By = 0, Bz = 0;
@@ -59,7 +59,7 @@ struct ParticleView
     double& weight;
     double& charge;
     std::array<int, dim>& iCell;
-    std::array<float, dim>& delta;
+    std::array<double, dim>& delta;
     std::array<double, 3>& v;
 };
 
@@ -85,8 +85,8 @@ struct ContiguousParticles
     {
     }
 
-    template<typename Container_int, typename Container_float, typename Container_double>
-    ContiguousParticles(Container_int&& _iCell, Container_float&& _delta,
+    template<typename Container_int, typename Container_double>
+    ContiguousParticles(Container_int&& _iCell, Container_double&& _delta,
                         Container_double&& _weight, Container_double&& _charge,
                         Container_double&& _v)
         : iCell{_iCell}
@@ -152,7 +152,7 @@ struct ContiguousParticles
     auto cend() const { return iterator(this); }
 
     container_t<int> iCell;
-    container_t<float> delta;
+    container_t<double> delta;
     container_t<double> weight, charge, v;
 };
 

--- a/src/python3/particles.h
+++ b/src/python3/particles.h
@@ -17,7 +17,7 @@ template<std::size_t dim, typename PyArrayTuple>
 core::ContiguousParticlesView<dim> contiguousViewFrom(PyArrayTuple const& py_particles)
 {
     return {makeSpan<int>(std::get<0>(py_particles)),     // iCell
-            makeSpan<float>(std::get<1>(py_particles)),   // delta
+            makeSpan<double>(std::get<1>(py_particles)),  // delta
             makeSpan<double>(std::get<2>(py_particles)),  // weight
             makeSpan<double>(std::get<3>(py_particles)),  // charge
             makeSpan<double>(std::get<4>(py_particles))}; // v
@@ -26,11 +26,11 @@ core::ContiguousParticlesView<dim> contiguousViewFrom(PyArrayTuple const& py_par
 template<std::size_t dim>
 pyarray_particles_t makePyArrayTuple(std::size_t const size)
 {
-    return std::make_tuple(py_array_t<int>(size * dim),   // iCell
-                           py_array_t<float>(size * dim), // delta
-                           py_array_t<double>(size),      // weight
-                           py_array_t<double>(size),      // charge
-                           py_array_t<double>(size * 3)); // v
+    return std::make_tuple(py_array_t<int>(size * dim),    // iCell
+                           py_array_t<double>(size * dim), // delta
+                           py_array_t<double>(size),       // weight
+                           py_array_t<double>(size),       // charge
+                           py_array_t<double>(size * 3));  // v
 }
 
 

--- a/tests/core/data/particles/test_interop.cpp
+++ b/tests/core/data/particles/test_interop.cpp
@@ -32,7 +32,7 @@ TYPED_TEST(ParticleListTest, SoAandAoSInterop)
         view.weight = 1 + i;
         view.charge = 1 + i;
         view.iCell  = ConstArray<int, dim>(i);
-        view.delta  = ConstArray<float, dim>(i + 1);
+        view.delta  = ConstArray<double, dim>(i + 1);
         view.v      = ConstArray<double, 3>(view.weight + 2);
         EXPECT_EQ(std::copy(view), view);
     }

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -710,7 +710,7 @@ struct ACollectionOfParticles_2d : public ::testing::Test
             {
                 auto& part  = particles.emplace_back();
                 part.iCell  = {i, j};
-                part.delta  = ConstArray<float, dim>(.5);
+                part.delta  = ConstArray<double, dim>(.5);
                 part.weight = 1.;
                 part.v[0]   = +2.;
                 part.v[1]   = -1.;


### PR DESCRIPTION
initialization test crashes with 
```
[pharemer:4042883] [ 0] /lib64/libc.so.6(+0x3ca70)[0x7f5e7caf5a70]
[pharemer:4042883] [ 1] /lib64/libc.so.6(gsignal+0x145)[0x7f5e7caf59e5]
[pharemer:4042883] [ 2] /lib64/libc.so.6(abort+0x127)[0x7f5e7cade895]
[pharemer:4042883] [ 3] /lib64/libc.so.6(+0x80857)[0x7f5e7cb39857]
[pharemer:4042883] [ 4] /lib64/libc.so.6(+0x87d7c)[0x7f5e7cb40d7c]
[pharemer:4042883] [ 5] /lib64/libc.so.6(+0x89452)[0x7f5e7cb42452]
[pharemer:4042883] [ 6] /usr/lib64/python3.8/site-packages/numpy/core/_multiarray_umath.cpython-38-x86_64-linux-gnu.so(+0x2d868)[0x7f5e6d624868]
[pharemer:4042883] [ 7] /usr/lib64/python3.8/site-packages/numpy/core/_multiarray_umath.cpython-38-x86_64-linux-gnu.so(+0x31513)[0x7f5e6d628513]
[pharemer:4042883] [ 8] /home/aunai/Documents/code/phare/build-PHARE-mpi-Release/pybindlibs/cpp.cpython-38-x86_64-linux-gnu.so(+0x489560)[0x7f5e6ed5f560]
[pharemer:4042883] [ 9] /home/aunai/Documents/code/phare/build-PHARE-mpi-Release/pybindlibs/cpp.cpython-38-x86_64-linux-gnu.so(+0x1de3f0)[0x7f5e6eab43f0]
[pharemer:4042883] [10] /lib64/libpython3.8.so.1.0(+0x12064a)[0x7f5e7c8a464a]
[pharemer:4042883] [11] /lib64/libpython3.8.so.1.0(_PyObject_MakeTpCall+0xe1)[0x7f5e7c894c41]
[pharemer:4042883] [12] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x5171)[0x7f5e7c891581]
[pharemer:4042883] [13] /lib64/libpython3.8.so.1.0(+0x116777)[0x7f5e7c89a777]
[pharemer:4042883] [14] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x807)[0x7f5e7c88cc17]
[pharemer:4042883] [15] /lib64/libpython3.8.so.1.0(_PyEval_EvalCodeWithName+0x7df)[0x7f5e7c88b7ef]
[pharemer:4042883] [16] /lib64/libpython3.8.so.1.0(_PyFunction_Vectorcall+0xc3)[0x7f5e7c89a423]
[pharemer:4042883] [17] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x3fd)[0x7f5e7c88c80d]
[pharemer:4042883] [18] /lib64/libpython3.8.so.1.0(_PyEval_EvalCodeWithName+0x9b4)[0x7f5e7c88b9c4]
[pharemer:4042883] [19] /lib64/libpython3.8.so.1.0(_PyFunction_Vectorcall+0xc3)[0x7f5e7c89a423]
[pharemer:4042883] [20] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x807)[0x7f5e7c88cc17]
[pharemer:4042883] [21] /lib64/libpython3.8.so.1.0(+0x116777)[0x7f5e7c89a777]
[pharemer:4042883] [22] /lib64/libpython3.8.so.1.0(PyVectorcall_Call+0x70)[0x7f5e7c8a3170]
[pharemer:4042883] [23] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x2438)[0x7f5e7c88e848]
[pharemer:4042883] [24] /lib64/libpython3.8.so.1.0(_PyEval_EvalCodeWithName+0x9b4)[0x7f5e7c88b9c4]
[pharemer:4042883] [25] /lib64/libpython3.8.so.1.0(_PyFunction_Vectorcall+0xc3)[0x7f5e7c89a423]
[pharemer:4042883] [26] /lib64/libpython3.8.so.1.0(+0x11ecd2)[0x7f5e7c8a2cd2]
[pharemer:4042883] [27] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x3fd)[0x7f5e7c88c80d]
[pharemer:4042883] [28] /lib64/libpython3.8.so.1.0(+0x116777)[0x7f5e7c89a777]
[pharemer:4042883] [29] /lib64/libpython3.8.so.1.0(_PyEval_EvalFrameDefault+0x807)[0x7f5e7c88cc17]
[pharemer:4042883] *** End of error message ***

```

not sure why atm