### PR TITLE
tagged tangential discontinuity now tests expected TD position

### DIFF
--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -31,8 +31,8 @@ def _compute_current(patch):
     Bz = patch.patch_datas["Bz"].dataset[:]
     xbz  = patch.patch_datas["Bz"].x
     Jy, Jz =  _current1d(By, Bz, xby, xbz)
-    return ({"name":"J_y", "data":Jy,"centering":"primal"},
-            {"name":"J_z", "data":Jz,"centering":"primal"})
+    return ({"name":"Jy", "data":Jy,"centering":"primal"},
+            {"name":"Jz", "data":Jz,"centering":"primal"})
 
 
 class Run:

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.h
@@ -8,6 +8,7 @@
 #include "amr/data/field/time_interpolate/field_linear_time_interpolate.h"
 #include "amr/data/particles/refine/particles_data_split.h"
 #include "amr/data/particles/refine/split.h"
+#include "amr/messengers/messenger_info.h"
 #include "amr/messengers/hybrid_messenger_info.h"
 #include "amr/messengers/hybrid_messenger_strategy.h"
 #include "amr/resources_manager/amr_utils.h"

--- a/tests/functional/alfven_wave/alfven_wave1d.py
+++ b/tests/functional/alfven_wave/alfven_wave1d.py
@@ -156,6 +156,8 @@ def phase_speed(run_path, ampl, xmax):
 
 def main():
     from pybindlibs.cpp import mpi_rank
+    from pyphare.pharesee.run import Run
+    from pyphare.pharesee.hierarchy import finest_field
 
 
     config()

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -19,89 +19,82 @@ mpl.use('Agg')
 from tests.diagnostic import all_timestamps
 
 
+def density(x):
+    return 1.
 
-def config():
-    """ Configure the simulation
 
-    This function defines the Simulation object,
-    user initialization model and diagnostics.
-    """
+def S(x,x0,l):
+    return 0.5*(1+np.tanh((x-x0)/l))
+
+
+def bx(x):
+    return 0.
+
+
+def by(x):
+    from pyphare.pharein.global_vars import sim
+    L = sim.simulation_domain()[0]
+    v1=-1
+    v2=1.
+    return v1 + (v2-v1)*(S(x,L*0.25,1) -S(x, L*0.75, 1))
+
+
+def bz(x):
+    return 0.5
+
+
+def b2(x):
+    return bx(x)**2 + by(x)**2 + bz(x)**2
+
+
+def T(x):
+    K = 1
+    return 1/density(x)*(K - b2(x)*0.5)
+
+
+def vx(x):
+    return 2.
+
+
+def vy(x):
+    return 0.
+
+
+def vz(x):
+    return 0.
+
+
+def vthx(x):
+    return T(x)
+
+
+def vthy(x):
+    return T(x)
+
+
+def vthz(x):
+    return T(x)
+
+vvv = {"vbulkx": vx, "vbulky": vy, "vbulkz": vz,
+        "vthx": vthx, "vthy": vthy, "vthz": vthz }
+
+def withTagging(**kwargs):
+
     Simulation(
-        smallest_patch_size=10,
+        smallest_patch_size=20,
         largest_patch_size=20,
-        time_step_nbr=2000,        # number of time steps (not specified if time_step and final_time provided)
-        final_time=20,             # simulation final time (not specified if time_step and time_step_nbr provided)
-        boundary_types="periodic", # boundary condition, string or tuple, length == len(cell) == len(dl)
-        cells=400,                # integer or tuple length == dimension
-        dl=0.5,                  # mesh size of the root level, float or tuple
-        max_nbr_levels=3,          # (default=1) max nbr of levels in the AMR hierarchy
-        nesting_buffer=2,
-        refinement = "tagging",
-        diag_options={"format": "phareh5", "options": {"dir": "refine_dx05_lvl3","mode":"overwrite"}}
+        time_step_nbr=2000,
+        final_time=20.,
+        boundary_types="periodic",
+        cells=200,
+        dl=1.0,
+        refinement="tagging",
+        max_nbr_levels = 3,
+        diag_options={"format": "phareh5",
+                      "options": {"dir": kwargs["diagdir"],
+                                  "mode":"overwrite"}}
     )
 
-
-    def density(x):
-        return 1.
-
-
-    def S(x,x0,l):
-        return 0.5*(1+np.tanh((x-x0)/l))
-
-
-    def bx(x):
-        return 0.
-
-
-    def by(x):
-        from pyphare.pharein.global_vars import sim
-        L = sim.simulation_domain()[0]
-        v1=-1
-        v2=1.
-        return v1 + (v2-v1)*(S(x,L*0.25,1) -S(x, L*0.75, 1))
-
-
-    def bz(x):
-        return 0.5
-
-
-    def b2(x):
-        return bx(x)**2 + by(x)**2 + bz(x)**2
-
-
-    def T(x):
-        K = 1
-        return 1/density(x)*(K - b2(x)*0.5)
-
-
-    def vx(x):
-        return 1.
-
-
-    def vy(x):
-        return 0.
-
-
-    def vz(x):
-        return 0.
-
-
-    def vthx(x):
-        return T(x)
-
-
-    def vthy(x):
-        return T(x)
-
-
-    def vthz(x):
-        return T(x)
-
-
-    vvv = {
-        "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
-        "vthx": vthx, "vthy": vthy, "vthz": vthz
-    }
 
     MaxwellianFluidModel(
         bx=bx, by=by, bz=bz,
@@ -112,8 +105,9 @@ def config():
 
 
 
-    timestamps = all_timestamps(gv.sim)
+    sim = ph.global_vars.sim
 
+    timestamps = all_timestamps(sim)
 
 
     for quantity in ["E", "B"]:
@@ -133,11 +127,158 @@ def config():
 
 
 
+
+def noRefinement(**kwargs):
+
+    Simulation(
+        smallest_patch_size=20,
+        largest_patch_size=20,
+        time_step_nbr=2000,
+        final_time=20.,
+        boundary_types="periodic",
+        cells=200,
+        dl=1.0,
+        diag_options={"format": "phareh5",
+                      "options": {"dir": kwargs["diagdir"],"mode":"overwrite"}}
+    )
+
+
+    MaxwellianFluidModel(
+        bx=bx, by=by, bz=bz,
+        protons={"charge": 1, "density": density, **vvv}
+    )
+
+    ElectronModel(closure="isothermal", Te=0.12)
+
+
+    sim = ph.global_vars.sim
+    timestamps = all_timestamps(sim)
+
+
+    for quantity in ["E", "B"]:
+        ElectromagDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+        )
+
+
+    for quantity in ["density", "bulkVelocity"]:
+        FluidDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+            )
+
+
+def make_figure():
+    from scipy.optimize import curve_fit
+    from pyphare.pharesee.hierarchy import finest_field
+
+    rwT    = Run("./withTagging")
+    rNoRef = Run("./noRefinement")
+
+    plot_time = 11
+    v = 2
+
+    BwT = rwT.GetB(plot_time)
+    BNoRef = rNoRef.GetB(plot_time)
+    JwT = rwT.GetJ(plot_time)
+    JNoRef = rNoRef.GetJ(plot_time)
+
+    bywT, xbywT  = finest_field(BwT, "By")
+    byNoRef, xbyNoRef  = finest_field(BNoRef, "By")
+    jzwT, xjzwT  = finest_field(JwT, "Jz")
+    jzNoRef, xjzNoRef  = finest_field(JNoRef, "Jz")
+
+    fig, axarr = plt.subplots(nrows=3, figsize=(8,8))
+
+    def S(x, x0, l):
+        return 0.5*(1+np.tanh((x-x0)/l))
+
+    def by(x):
+        L=200
+        v1=-1
+        v2=1
+        return v1 + (v2-v1)*(S(x, L*0.25, 1)-S(x, L*0.75, 1))
+
+    ax0, ax1, ax2 = axarr
+    ax0.plot(xbywT, bywT)
+    ax0.plot(xbyNoRef, byNoRef, color="k", alpha=0.6)
+    ax0.plot(xbyNoRef, by(xbyNoRef), ls='--')
+
+    ax1.plot(xbywT, bywT)
+    ax1.plot(xbyNoRef, byNoRef, color='k')
+    ax1.set_xlim((wT0,195))
+    ax1.set_ylim((-1.5, 2))
+
+    ax2.plot(xjzwT, jzwT)
+    ax2.plot(xjzNoRef, jzNoRef, color='k')
+    ax2.set_xlim((wT0,195))
+    ax2.set_ylim((-1.5, 0.5))
+
+
+    # draw level patches
+    for ilvl,level in BwT.levels().items():
+        for patch in level.patches:
+            dx = patch.layout.dl[0]
+            x0 = patch.origin[0]
+            x1 = (patch.box.upper[0]+1)*patch.layout.dl[0]
+            for ax in (ax1, ax2, ax0):
+                ax.axvspan(x0, x1, color='b',ec='k', alpha=0.2,
+                            ymin=ilvl/4, ymax=(ilvl+1)/4)
+
+
+    from pyphare.pharesee.plotting import zoom_effect
+    zoom_effect(ax0, ax1, wT0, 195)
+
+    for ax in (ax0, ax1, ax2):
+        ax.axvline(wT0+plot_time*v, color="r")
+
+
+    # select data around the rightward TD
+    idx = np.where((xby15>150) & (xby15<190))
+    xx = xby15[idx]
+    bby = by15[idx]
+
+
+    # now we will fit by_fit to the data
+    # and we expect to find x0=172 and L=1
+    # or close enough
+    def by_fit(x, x0,L):
+        v1=1
+        v2=-1
+        return v1 + (v2-v1)*S(x, x0, L)
+
+    popt,pcov = curve_fit(by_fit, xx, bby, p0=(150,1))
+    x0, L = popt
+
+    if np.abs(L-1)>0.5:
+        raise RuntimeError(f"L (={L}) too far from 1.O")
+    if np.abs(x0-(150+plot_time*v))>0.5:
+        raise RuntimeError(f"x0 (={x0}) too far from 172")
+
+
+
+
+
+
 def main():
-    config()
+    from pybindlibs.cpp import mpi_rank
+    withTagging(diagdir="withTagging")
     simulator = Simulator(gv.sim)
-    simulator.initialize()
-    simulator.run()
+    simulator.initialize().run()
+    gv.sim = None
+
+    noRefinement(diagdir="noRefinement")
+    simulator = Simulator(gv.sim)
+    simulator.initialize().run()
+    gv.sim = None
+
+
+    if mpi_rank() == 0:
+        make_figure()
+
 
 
 


### PR DESCRIPTION
update the tdtagged1d functional test.
The test now produces the figure of the paper 

![image](https://user-images.githubusercontent.com/3200931/114397353-e55ac000-9b9e-11eb-94ee-b40a8e23f7db.png)

and also checks wether the TD position at that time is what is expected
Data around the rightward TD is extracted and used to fit an tanh((x-x0)/L) where x0 and L are expected to be around 172 and 1.

Small test here gives (data blue, fit orange) : 

![image](https://user-images.githubusercontent.com/3200931/114397570-1e933000-9b9f-11eb-868a-43af1c187a68.png)

with L=1.18 and x0=171.7, not top bad.

