### PR TITLE
dbg pybind cpp lib / double diags exposed by dbg pybind cpp lib

### DIFF
--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -137,3 +137,9 @@ def top_git_hash():
     if len(hashes) > 0:
         return hashes[0]
     return "master" # github actions fails?
+
+
+def print_trace():
+    import sys, traceback
+    _, _, tb = sys.exc_info()
+    traceback.print_tb(tb)

--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -115,7 +115,7 @@ def decode_bytes(input, errors="ignore"):
     return input.decode("ascii", errors=errors)
 
 
-def run_cli_cmd(cmd, shell=True, capture_output=True, check=False, print_cmd=True):
+def run_cli_cmd(cmd, shell=True, capture_output=True, check=False, print_cmd=False):
     """
     https://docs.python.org/3/library/subprocess.html
     """

--- a/pyphare/pyphare/cpp/__init__.py
+++ b/pyphare/pyphare/cpp/__init__.py
@@ -1,17 +1,21 @@
 
 
+def cpp_lib():
+    import importlib
+    if not __debug__:
+        return importlib.import_module("pybindlibs.cpp")
+    try:
+        return importlib.import_module("pybindlibs.cpp_dbg")
+    except ImportError as err:
+        return importlib.import_module("pybindlibs.cpp")
+
+
 def splitter_type(dim, interp, n_particles):
-    from pybindlibs import cpp
-    return getattr(cpp,
-        "Splitter_" + str(dim) + "_" + str(interp)+ "_" + str(n_particles),
-    )
+    return getattr(cpp_lib(), f"Splitter_{dim}_{interp}_{n_particles}")
 
 def create_splitter(dim, interp, n_particles):
     return splitter_type(dim, interp, n_particles)()
 
 
 def split_pyarrays_fn(dim, interp, n_particles):
-    from pybindlibs import cpp
-    return getattr(cpp,
-        "split_pyarray_particles_" + str(dim) + "_" + str(interp)+ "_" + str(n_particles),
-    )
+    return getattr(cpp_lib(), f"split_pyarray_particles_{dim}_{interp}_{n_particles}")

--- a/pyphare/pyphare/data/wrangler.py
+++ b/pyphare/pyphare/data/wrangler.py
@@ -6,15 +6,13 @@ class DataWrangler:
 
     def __init__(self, simulator):
         from .. import pharein as ph
-        from pybindlibs import cpp
+        from pyphare.cpp import cpp_lib
 
         self.dim = ph.global_vars.sim.ndim
         self.interp = ph.global_vars.sim.interp_order
         self.refined_particle_nbr = ph.global_vars.sim.refined_particle_nbr
-        self.cpp = getattr(
-            cpp,
-            "DataWrangler_" + str(self.dim) + "_" + str(self.interp)+ "_" + str(self.refined_particle_nbr),
-        )(simulator.cpp_sim, simulator.cpp_hier)
+        self.cpp = getattr(cpp_lib(), f"DataWrangler_{self.dim}_{self.interp}_{self.refined_particle_nbr}")\
+                                            (simulator.cpp_sim, simulator.cpp_hier)
 
     def kill(self):
         del self.cpp

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -63,10 +63,10 @@ class fn_wrapper:
         if is_scalar(ret):
             ret = np.full(len(args[-1]), ret)
 
-        from pybindlibs import cpp
+        from pyphare.cpp import cpp_lib
         # convert numpy array to C++ SubSpan
         # couples vector init functions to C++
-        return cpp.makePyArrayWrapper(ret)
+        return cpp_lib().makePyArrayWrapper(ret)
 
 
 

--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -52,7 +52,7 @@ def validate_timestamps(clazz, **kwargs):
             raise RuntimeError(f"Error: timestamp({sim.time_step_nbr}) cannot be greater than simulation.final_time({sim.final_time}))")
         if not np.all(np.diff(timestamps) >= 0):
             raise RuntimeError(f"Error: {clazz}.{key} not in ascending order)")
-        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):            
+        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):
             raise RuntimeError(f"Error: {clazz}.{key} is inconsistent with simulation.time_step")
 
 
@@ -63,8 +63,8 @@ def validate_timestamps(clazz, **kwargs):
 
 def try_cpp_dep_vers():
     try:
-        from pybindlibs import cpp
-        return cpp.phare_deps()
+        from pyphare.cpp import cpp_lib
+        return cpp_lib().phare_deps()
     except ImportError:
         return {}
 

--- a/pyphare/pyphare/pharesee/particles.py
+++ b/pyphare/pyphare/pharesee/particles.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-from ..core.phare_utilities import refinement_ratio
+from ..core.phare_utilities import refinement_ratio, print_trace
 
 class Particles:
     """
@@ -88,6 +88,8 @@ class Particles:
                 all_assert(self, that)
                 return True
             except AssertionError as ex:
+                print(f"particles.py:Particles::eq failed with:", ex)
+                print_trace()
                 return False
         return False
 
@@ -150,7 +152,8 @@ def all_assert(part1, part2):
 
     np.testing.assert_array_equal(part1.iCells[idx1], part2.iCells[idx2])
 
-    np.testing.assert_allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12)
+    deltol = 1e-6 if any([part.deltas.dtype == np.float32 for part in [part1, part2]] ) else 1e-12
+    np.testing.assert_allclose(part1.deltas[idx1], part2.deltas[idx2], atol=deltol)
 
     np.testing.assert_allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12)
     np.testing.assert_allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12)

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -15,15 +15,15 @@ def simulator_shutdown():
 
 
 def make_cpp_simulator(dim, interp, nbrRefinedPart, hier):
-    from pybindlibs import cpp
-    make_sim = "make_simulator_" + str(dim) + "_" + str(interp)+ "_" + str(nbrRefinedPart)
-    return getattr(cpp, make_sim)(hier)
+    from pyphare.cpp import cpp_lib
+    make_sim = f"make_simulator_{dim}_{interp}_{nbrRefinedPart}"
+    return getattr(cpp_lib(), make_sim)(hier)
 
 
 def startMPI():
     if "samrai" not in life_cycles:
-        from pybindlibs import cpp
-        life_cycles["samrai"] = cpp.SamraiLifeCycle()
+        from pyphare.cpp import cpp_lib
+        life_cycles["samrai"] = cpp_lib().SamraiLifeCycle()
 
 
 class Simulator:
@@ -47,11 +47,11 @@ class Simulator:
         if self.cpp_sim is not None:
             raise ValueError("Simulator already initialized: requires reset to re-initialize")
         try:
-            from pybindlibs import cpp
+            from pyphare.cpp import cpp_lib
             from pyphare.pharein import populateDict
             startMPI()
             populateDict()
-            self.cpp_hier = cpp.make_hierarchy()
+            self.cpp_hier = cpp_lib().make_hierarchy()
 
             self.cpp_sim = make_cpp_simulator(
               self.simulation.ndim, self.simulation.interp_order, self.simulation.refined_particle_nbr, self.cpp_hier
@@ -79,7 +79,7 @@ class Simulator:
                          self.timeStep())
 
     def run(self):
-        from pybindlibs import cpp
+        from pyphare.cpp import cpp_lib
         self._check_init()
         perf = []
         end_time = self.cpp_sim.endTime()
@@ -91,7 +91,7 @@ class Simulator:
             ticktock = tock-tick
             perf.append(ticktock)
             t = self.cpp_sim.currentTime()
-            if cpp.mpi_rank() == 0:
+            if cpp_lib().mpi_rank() == 0:
                 print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, ticktock, np.sum(perf)))
 
         print("mean advance time = {}".format(np.mean(perf)))

--- a/res/cmake/dep/highfive.cmake
+++ b/res/cmake/dep/highfive.cmake
@@ -27,6 +27,7 @@ if(HighFive)
     ${HIGHFIVE_SRC}/include
     ${CMAKE_BINARY_DIR}/subprojects/highfive/include # configured include for version info
   )
+  set(HIGHFIVE_UNIT_TESTS OFF) # silence warning
   set(HIGHFIVE_USE_BOOST OFF)
   set(HIGHFIVE_BUILD_DOCS OFF) # conflicts with phare doc target
   add_subdirectory(${HIGHFIVE_SRC})

--- a/src/core/data/ions/particle_initializers/maxwellian_particle_initializer.h
+++ b/src/core/data/ions/particle_initializers/maxwellian_particle_initializer.h
@@ -144,7 +144,7 @@ void MaxwellianParticleInitializer<ParticleArray, GridLayout>::loadParticles(
     };
 
 
-    auto deltas = [](auto& pos, auto& gen) -> std::array<float, dimension> {
+    auto deltas = [](auto& pos, auto& gen) -> std::array<double, dimension> {
         if constexpr (dimension == 1)
             return {pos(gen)};
         if constexpr (dimension == 2)
@@ -172,7 +172,7 @@ void MaxwellianParticleInitializer<ParticleArray, GridLayout>::loadParticles(
 
     auto const [n, V, Vth] = fns();
     auto randGen           = getRNG(rngSeed_);
-    ParticleDeltaDistribution deltaDistrib;
+    ParticleDeltaDistribution<double> deltaDistrib;
 
     for (std::size_t flatCellIdx = 0; flatCellIdx < ndCellIndices.size(); flatCellIdx++)
     {

--- a/src/core/data/particles/particle.h
+++ b/src/core/data/particles/particle.h
@@ -41,9 +41,9 @@ struct Particle
     double weight;
     double charge;
 
-    std::array<int, dim> iCell   = ConstArray<int, dim>();
-    std::array<float, dim> delta = ConstArray<float, dim>();
-    std::array<double, 3> v      = ConstArray<double, 3>();
+    std::array<int, dim> iCell    = ConstArray<int, dim>();
+    std::array<double, dim> delta = ConstArray<double, dim>();
+    std::array<double, 3> v       = ConstArray<double, 3>();
 
     double Ex = 0, Ey = 0, Ez = 0;
     double Bx = 0, By = 0, Bz = 0;
@@ -59,7 +59,7 @@ struct ParticleView
     double& weight;
     double& charge;
     std::array<int, dim>& iCell;
-    std::array<float, dim>& delta;
+    std::array<double, dim>& delta;
     std::array<double, 3>& v;
 };
 
@@ -85,8 +85,8 @@ struct ContiguousParticles
     {
     }
 
-    template<typename Container_int, typename Container_float, typename Container_double>
-    ContiguousParticles(Container_int&& _iCell, Container_float&& _delta,
+    template<typename Container_int, typename Container_double>
+    ContiguousParticles(Container_int&& _iCell, Container_double&& _delta,
                         Container_double&& _weight, Container_double&& _charge,
                         Container_double&& _v)
         : iCell{_iCell}
@@ -152,7 +152,7 @@ struct ContiguousParticles
     auto cend() const { return iterator(this); }
 
     container_t<int> iCell;
-    container_t<float> delta;
+    container_t<double> delta;
     container_t<double> weight, charge, v;
 };
 

--- a/src/diagnostic/detail/h5writer.h
+++ b/src/diagnostic/detail/h5writer.h
@@ -17,6 +17,11 @@
 #include "core/utilities/types.h"
 
 
+#if !defined(PHARE_DIAG_DOUBLES)
+#error // PHARE_DIAG_DOUBLES not defined
+#endif
+
+
 namespace PHARE::diagnostic::h5
 {
 template<typename H5Writer>
@@ -31,6 +36,8 @@ class ParticlesDiagnosticWriter;
 template<typename ModelView>
 class Writer : public PHARE::diagnostic::IWriter
 {
+    using FloatType = std::conditional_t<PHARE_DIAG_DOUBLES, double, float>;
+
     static constexpr std::size_t timestamp_precision = 10;
 
 public:
@@ -107,10 +114,12 @@ public:
     static void createDataSet(HiFile& h5, std::string const& path, std::size_t size)
     {
         if constexpr (std::is_same_v<Type, double>) // force doubles for floats for storage
-            This::createDatasetsPerMPI<float>(h5, path, size);
+            This::createDatasetsPerMPI<FloatType>(h5, path, size);
         else
             This::createDatasetsPerMPI<Type>(h5, path, size);
     }
+
+
 
     template<typename Array, typename String>
     static void writeDataSet(HiFile& h5, String path, Array const* const array)

--- a/src/diagnostic/detail/types/electromag.h
+++ b/src/diagnostic/detail/types/electromag.h
@@ -25,6 +25,7 @@ public:
     using Super::checkCreateFileFor_;
     using Attributes = typename Super::Attributes;
     using GridLayout = typename H5Writer::GridLayout;
+    using FloatType  = typename H5Writer::FloatType;
 
     ElectromagDiagnosticWriter(H5Writer& h5Writer)
         : Super{h5Writer}
@@ -103,7 +104,7 @@ void ElectromagDiagnosticWriter<H5Writer>::initDataSets(
         for (auto& [id, type] : core::Components::componentMap)
         {
             auto vFPath = path + "/" + key + "_" + id;
-            h5Writer.template createDataSet<float>(
+            h5Writer.template createDataSet<FloatType>(
                 h5file, vFPath, null ? 0 : attr[key][id].template to<std::size_t>());
 
             this->writeGhostsAttr_(
@@ -163,8 +164,8 @@ void ElectromagDiagnosticWriter<H5Writer>::writeAttributes(
         patchAttributes,
     std::size_t maxLevel)
 {
-    writeAttributes_(diagnostic, fileData_.at(diagnostic.quantity)->file(), fileAttributes, patchAttributes,
-                     maxLevel);
+    writeAttributes_(diagnostic, fileData_.at(diagnostic.quantity)->file(), fileAttributes,
+                     patchAttributes, maxLevel);
 }
 
 

--- a/src/diagnostic/detail/types/fluid.h
+++ b/src/diagnostic/detail/types/fluid.h
@@ -31,6 +31,7 @@ public:
     using Super::checkCreateFileFor_;
     using Attributes = typename Super::Attributes;
     using GridLayout = typename H5Writer::GridLayout;
+    using FloatType  = typename H5Writer::FloatType;
 
     FluidDiagnosticWriter(H5Writer& h5Writer)
         : Super{h5Writer}
@@ -145,15 +146,15 @@ void FluidDiagnosticWriter<H5Writer>::initDataSets(
 
     auto initDS = [&](auto& path, auto& attr, std::string key, auto null) {
         auto dsPath = path + key;
-        h5Writer.template createDataSet<float>(file, dsPath,
-                                               null ? 0 : attr[key].template to<std::size_t>());
+        h5Writer.template createDataSet<FloatType>(file, dsPath,
+                                                   null ? 0 : attr[key].template to<std::size_t>());
         writeGhosts(dsPath, attr, key, null);
     };
     auto initVF = [&](auto& path, auto& attr, std::string key, auto null) {
         for (auto& [id, type] : core::Components::componentMap)
         {
             auto vFPath = path + key + "_" + id;
-            h5Writer.template createDataSet<float>(
+            h5Writer.template createDataSet<FloatType>(
                 file, vFPath, null ? 0 : attr[key][id].template to<std::size_t>());
             writeGhosts(vFPath, attr[key], id, null);
         }

--- a/src/diagnostic/detail/types/particle.h
+++ b/src/diagnostic/detail/types/particle.h
@@ -39,6 +39,7 @@ public:
     static constexpr auto interpOrder = H5Writer::interpOrder;
     using Attributes                  = typename Super::Attributes;
     using Packer                      = core::ParticlePacker<dimension>;
+    using FloatType                   = typename H5Writer::FloatType;
 
     ParticlesDiagnosticWriter(H5Writer& h5Writer)
         : Super{h5Writer}

--- a/src/diagnostic/diagnostics.h
+++ b/src/diagnostic/diagnostics.h
@@ -8,6 +8,10 @@
 #error // PHARE_HAS_HIGHFIVE expected to be defined as bool
 #endif
 
+#if !defined(PHARE_DIAG_DOUBLES)
+#define PHARE_DIAG_DOUBLES false
+#endif
+
 #if PHARE_HAS_HIGHFIVE
 #include "highfive/H5Version.hpp"
 #define _PHARE_WITH_HIGHFIVE(...) __VA_ARGS__

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -11,3 +11,14 @@ set_target_properties(cpp
 )
 # this is on by default "pybind11_add_module" but can interfere with coverage so we disable it if coverage is enabled
 set_property(TARGET cpp PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  pybind11_add_module(cpp_dbg cpp_simulator.cpp)
+  target_link_libraries(cpp_dbg PUBLIC phare_simulator)
+  target_compile_options(cpp_dbg PRIVATE ${PHARE_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE} -DPHARE_DIAG_DOUBLES=1 -DPHARE_CPP_MOD_NAME=cpp_dbg)
+  set_target_properties(cpp_dbg
+      PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pybindlibs"
+  )
+  set_property(TARGET cpp_dbg PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})
+endif (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/python3/cpp_simulator.cpp
+++ b/src/python3/cpp_simulator.cpp
@@ -26,6 +26,12 @@
 #include "python3/patch_level.h"
 #include "python3/data_wrangler.h"
 
+
+#if !defined(PHARE_CPP_MOD_NAME)
+#define PHARE_CPP_MOD_NAME cpp
+#endif
+
+
 namespace py = pybind11;
 
 namespace PHARE::pydata
@@ -181,7 +187,7 @@ auto samrai_version()
 
 
 
-PYBIND11_MODULE(cpp, m)
+PYBIND11_MODULE(PHARE_CPP_MOD_NAME, m)
 {
     py::class_<SamraiLifeCycle, std::shared_ptr<SamraiLifeCycle>>(m, "SamraiLifeCycle")
         .def(py::init<>())

--- a/src/python3/particles.h
+++ b/src/python3/particles.h
@@ -17,7 +17,7 @@ template<std::size_t dim, typename PyArrayTuple>
 core::ContiguousParticlesView<dim> contiguousViewFrom(PyArrayTuple const& py_particles)
 {
     return {makeSpan<int>(std::get<0>(py_particles)),     // iCell
-            makeSpan<float>(std::get<1>(py_particles)),   // delta
+            makeSpan<double>(std::get<1>(py_particles)),  // delta
             makeSpan<double>(std::get<2>(py_particles)),  // weight
             makeSpan<double>(std::get<3>(py_particles)),  // charge
             makeSpan<double>(std::get<4>(py_particles))}; // v
@@ -26,11 +26,11 @@ core::ContiguousParticlesView<dim> contiguousViewFrom(PyArrayTuple const& py_par
 template<std::size_t dim>
 pyarray_particles_t makePyArrayTuple(std::size_t const size)
 {
-    return std::make_tuple(py_array_t<int>(size * dim),   // iCell
-                           py_array_t<float>(size * dim), // delta
-                           py_array_t<double>(size),      // weight
-                           py_array_t<double>(size),      // charge
-                           py_array_t<double>(size * 3)); // v
+    return std::make_tuple(py_array_t<int>(size * dim),    // iCell
+                           py_array_t<double>(size * dim), // delta
+                           py_array_t<double>(size),       // weight
+                           py_array_t<double>(size),       // charge
+                           py_array_t<double>(size * 3));  // v
 }
 
 

--- a/src/python3/pybind_def.h
+++ b/src/python3/pybind_def.h
@@ -17,11 +17,11 @@ template<typename T>
 using py_array_t = pybind11::array_t<T, pybind11::array::c_style | pybind11::array::forcecast>;
 
 
-using pyarray_particles_t = std::tuple<py_array_t<int32_t>, py_array_t<float>, py_array_t<double>,
+using pyarray_particles_t = std::tuple<py_array_t<int32_t>, py_array_t<double>, py_array_t<double>,
                                        py_array_t<double>, py_array_t<double>>;
 
 using pyarray_particles_crt
-    = std::tuple<py_array_t<int32_t> const&, py_array_t<float> const&, py_array_t<double> const&,
+    = std::tuple<py_array_t<int32_t> const&, py_array_t<double> const&, py_array_t<double> const&,
                  py_array_t<double> const&, py_array_t<double> const&>;
 
 template<typename PyArrayInfo>

--- a/tests/core/data/particles/test_interop.cpp
+++ b/tests/core/data/particles/test_interop.cpp
@@ -32,7 +32,7 @@ TYPED_TEST(ParticleListTest, SoAandAoSInterop)
         view.weight = 1 + i;
         view.charge = 1 + i;
         view.iCell  = ConstArray<int, dim>(i);
-        view.delta  = ConstArray<float, dim>(i + 1);
+        view.delta  = ConstArray<double, dim>(i + 1);
         view.v      = ConstArray<double, 3>(view.weight + 2);
         EXPECT_EQ(std::copy(view), view);
     }

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -710,7 +710,7 @@ struct ACollectionOfParticles_2d : public ::testing::Test
             {
                 auto& part  = particles.emplace_back();
                 part.iCell  = {i, j};
-                part.delta  = ConstArray<float, dim>(.5);
+                part.delta  = ConstArray<double, dim>(.5);
                 part.weight = 1.;
                 part.v[0]   = +2.;
                 part.v[1]   = -1.;

--- a/tests/simulator/data_wrangler.py
+++ b/tests/simulator/data_wrangler.py
@@ -3,7 +3,8 @@
 # formatted with black
 
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 from tests.simulator import populate_simulation
 import numpy as np
 from pyphare.simulator.simulator import Simulator

--- a/tests/simulator/refined_particle_nbr.py
+++ b/tests/simulator/refined_particle_nbr.py
@@ -2,7 +2,8 @@
 #
 # formatted with black
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 import os, sys, unittest, yaml
 import numpy as np

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -2,7 +2,8 @@
 #
 # formatted with black
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 import unittest, os, pyphare.pharein as ph
 from datetime import datetime, timezone

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -1,5 +1,6 @@
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 from pyphare.simulator.simulator import Simulator, startMPI
 from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
@@ -390,6 +391,13 @@ class AdvanceTest(unittest.TestCase):
                         # overlap box must be shifted by -offset to select data in the patches
                         part1 = copy(pd1.dataset.select(boxm.shift(box, -offsets[0])))
                         part2 = copy(pd2.dataset.select(boxm.shift(box, -offsets[1])))
+
+                        def contains_duplicates(X):
+                            return len(np.unique(X)) != len(X)
+
+                        if contains_duplicates(part1.deltas) and contains_duplicates(part2.deltas):
+                            # https://github.com/PHAREHUB/PHARE/issues/513
+                            continue
 
                         idx1 = np.argsort(part1.iCells + part1.deltas)
                         idx2 = np.argsort(part2.iCells + part2.deltas)

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -7,10 +7,10 @@ from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
 from pyphare.pharein import MaxwellianFluidModel
 from pyphare.pharein.diagnostics import ParticleDiagnostics, FluidDiagnostics, ElectromagDiagnostics
 from pyphare.pharein import ElectronModel
-from pyphare.pharein.simulation import Simulation
+from pyphare.pharein.simulation import Simulation, supported_dimensions
 from pyphare.pharesee.geometry import level_ghost_boxes, hierarchy_overlaps
 from pyphare.core.gridlayout import yee_element_is_primal
-from pyphare.pharesee.particles import aggregate as aggregate_particles
+from pyphare.pharesee.particles import aggregate as aggregate_particles, any_assert as particles_any_assert
 import pyphare.core.box as boxm
 from pyphare.core.box import Box, Box1D
 import numpy as np
@@ -18,7 +18,6 @@ import unittest
 from ddt import ddt, data, unpack
 
 
-# AdvanceTest.test_field_level_ghosts_via_subcycles_and_coarser_interpolation_1
 
 @ddt
 class AdvanceTest(unittest.TestCase):
@@ -77,13 +76,13 @@ class AdvanceTest(unittest.TestCase):
             return 1/density(x)*(K - b2(x)*0.5)
 
         def vx(x):
-            return 0.
+            return 0.1
 
         def vy(x):
-            return 0.
+            return 0.1
 
         def vz(x):
-            return 0.
+            return 0.1
 
         def vthx(x):
             return T(x)
@@ -136,7 +135,7 @@ class AdvanceTest(unittest.TestCase):
                                     write_timestamps=timestamps,
                                     population_name=pop)
 
-        Simulator(global_vars.sim).initialize().run()
+        Simulator(global_vars.sim).run()
 
         eb_hier = None
         if qty in ["e", "eb"]:
@@ -392,31 +391,76 @@ class AdvanceTest(unittest.TestCase):
                         part1 = copy(pd1.dataset.select(boxm.shift(box, -offsets[0])))
                         part2 = copy(pd2.dataset.select(boxm.shift(box, -offsets[1])))
 
-                        def contains_duplicates(X):
-                            return len(np.unique(X)) != len(X)
-
-                        if contains_duplicates(part1.deltas) and contains_duplicates(part2.deltas):
-                            # https://github.com/PHAREHUB/PHARE/issues/513
-                            continue
-
                         idx1 = np.argsort(part1.iCells + part1.deltas)
                         idx2 = np.argsort(part2.iCells + part2.deltas)
 
-                        # if there is an overlap, there should be particles
-                        # in these cells
+                        # if there is an overlap, there should be particles in these cells
                         assert(len(idx1) >0)
                         assert(len(idx2) >0)
+                        assert(len(idx1) == len(idx2))
 
                         print("respectively {} and {} in overlaped patchdatas".format(len(idx1), len(idx2)))
 
                         # particle iCells are in their patch AMR space
                         # so we need to shift them by +offset to move them to the box space
-                        np.testing.assert_array_equal(part1.iCells[idx1]+offsets[0], part2.iCells[idx2]+offsets[1])
 
-                        self.assertTrue(np.allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12))
-                        self.assertTrue(np.allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12))
-                        self.assertTrue(np.allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12))
-                        self.assertTrue(np.allclose(part1.v[idx1,2], part2.v[idx2,2], atol=1e-12))
+                        # find difference in case of duplicates
+                        tmp = (part1.v[idx1,0] - part2.v[idx2,0])
+                        cell = np.where(tmp > 0)[0]
+                        duplicate_found = len(cell)
+                        if duplicate_found:
+                            cell = cell[0]
+
+                            assert dim == 1, "not sure this works in 2d"
+                            def pop_indicis(parts, idx):
+                                return parts.pop(np.unique(np.concatenate(
+                                  np.asarray([np.where(parts.deltas == part_delta)[0] for part_delta in [
+                                      parts.deltas[idx][cell - 1], parts.deltas[idx][cell], parts.deltas[idx][cell + 1]
+                                ]])).ravel()))
+
+                            particles_any_assert(pop_indicis(part1, idx1), pop_indicis(part2, idx2))
+
+                            # redo after removing indexes
+                            idx1 = np.argsort(part1.iCells + part1.deltas)
+                            idx2 = np.argsort(part2.iCells + part2.deltas)
+
+                        np.testing.assert_array_equal(part1.iCells[idx1]+offsets[0], part2.iCells[idx2]+offsets[1])
+                        np.testing.assert_allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12)
+                        np.testing.assert_allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12)
+                        np.testing.assert_allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12)
+                        np.testing.assert_allclose(part1.v[idx1,2], part2.v[idx2,2], atol=1e-12)
+
+
+
+
+
+
+    def test_L0_particle_number_conservation(self):
+        nbr_part_per_cell=100
+        cells=120
+        time_step_nbr=10
+        time_step=0.001
+
+        # to2d
+        for ndim in [1]:
+            n_particles = nbr_part_per_cell * (cells ** ndim)
+            for interp_order in [1, 2, 3]:
+                diag_outputs=f"phare_L0_particle_number_conservation_{ndim}_{interp_order}"
+                datahier = self.getHierarchy(interp_order, None, "particles", diag_outputs=diag_outputs,
+                                          time_step=time_step, time_step_nbr=time_step_nbr,
+                                          nbr_part_per_cell=nbr_part_per_cell, cells=cells)
+                for time_step_idx in range(time_step_nbr + 1):
+                    coarsest_time =  time_step_idx * time_step
+                    n_particles_at_t = 0
+                    for patch in datahier.level(0, coarsest_time).patches:
+                        n_particles_at_t += patch.patch_datas["protons_particles"].dataset[patch.box].size()
+                    self.assertEqual(n_particles, n_particles_at_t)
+
+
+
+
+
+
 
     @data(
       {"L0": [Box1D(10, 20)]},

--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -1,7 +1,8 @@
 
 #!/usr/bin/env python3
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 from tests.diagnostic import dump_all_diags
 from tests.simulator import populate_simulation
 from pyphare.pharein import ElectronModel

--- a/tests/simulator/test_diagnostics.py
+++ b/tests/simulator/test_diagnostics.py
@@ -2,7 +2,9 @@
 #!/usr/bin/env python3
 
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
+
 from tests.diagnostic import dump_all_diags
 from tests.simulator import populate_simulation
 from pyphare.pharein import ElectronModel

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -1,5 +1,6 @@
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 from pyphare.simulator.simulator import Simulator, startMPI
 from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
@@ -515,7 +516,7 @@ class InitializationTest(unittest.TestCase):
 
     def _test_patch_ghost_on_refined_level_case(self, has_patch_ghost, **kwargs):
         import pyphare.pharein as ph
-        from pybindlibs import cpp
+
         from pyphare.simulator.simulator import startMPI
 
         startMPI()


### PR DESCRIPTION
includes https://github.com/PHAREHUB/PHARE/pull/517

if cmake is configured via CMAKE_BUILD_TYPE=Debug, or not configured with CMAKE_BUILD_TYPE (which defaults to Debug), two pybind libraries are built, one with existing functionality, and one with extra debug info, in this PR that includes diagnostic quantities being written in double precision, for double values.

in python, we check to see if we're in \_\_debug\_\_ ,  if not (python -O), we return the normal cpp lib, otherwise we attempt to load the debug library, falling back on the regular library if debug is not present.

