### PR TITLE
Parallel pusher

### DIFF
--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -137,3 +137,9 @@ def top_git_hash():
     if len(hashes) > 0:
         return hashes[0]
     return "master" # github actions fails?
+
+
+def print_trace():
+    import sys, traceback
+    _, _, tb = sys.exc_info()
+    traceback.print_tb(tb)

--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -115,7 +115,7 @@ def decode_bytes(input, errors="ignore"):
     return input.decode("ascii", errors=errors)
 
 
-def run_cli_cmd(cmd, shell=True, capture_output=True, check=False, print_cmd=True):
+def run_cli_cmd(cmd, shell=True, capture_output=True, check=False, print_cmd=False):
     """
     https://docs.python.org/3/library/subprocess.html
     """

--- a/pyphare/pyphare/cpp/__init__.py
+++ b/pyphare/pyphare/cpp/__init__.py
@@ -1,17 +1,21 @@
 
 
+def cpp_lib():
+    import importlib
+    if not __debug__:
+        return importlib.import_module("pybindlibs.cpp")
+    try:
+        return importlib.import_module("pybindlibs.cpp_dbg")
+    except ImportError as err:
+        return importlib.import_module("pybindlibs.cpp")
+
+
 def splitter_type(dim, interp, n_particles):
-    from pybindlibs import cpp
-    return getattr(cpp,
-        "Splitter_" + str(dim) + "_" + str(interp)+ "_" + str(n_particles),
-    )
+    return getattr(cpp_lib(), f"Splitter_{dim}_{interp}_{n_particles}")
 
 def create_splitter(dim, interp, n_particles):
     return splitter_type(dim, interp, n_particles)()
 
 
 def split_pyarrays_fn(dim, interp, n_particles):
-    from pybindlibs import cpp
-    return getattr(cpp,
-        "split_pyarray_particles_" + str(dim) + "_" + str(interp)+ "_" + str(n_particles),
-    )
+    return getattr(cpp_lib(), f"split_pyarray_particles_{dim}_{interp}_{n_particles}")

--- a/pyphare/pyphare/data/wrangler.py
+++ b/pyphare/pyphare/data/wrangler.py
@@ -6,15 +6,13 @@ class DataWrangler:
 
     def __init__(self, simulator):
         from .. import pharein as ph
-        from pybindlibs import cpp
+        from pyphare.cpp import cpp_lib
 
         self.dim = ph.global_vars.sim.ndim
         self.interp = ph.global_vars.sim.interp_order
         self.refined_particle_nbr = ph.global_vars.sim.refined_particle_nbr
-        self.cpp = getattr(
-            cpp,
-            "DataWrangler_" + str(self.dim) + "_" + str(self.interp)+ "_" + str(self.refined_particle_nbr),
-        )(simulator.cpp_sim, simulator.cpp_hier)
+        self.cpp = getattr(cpp_lib(), f"DataWrangler_{self.dim}_{self.interp}_{self.refined_particle_nbr}")\
+                                            (simulator.cpp_sim, simulator.cpp_hier)
 
     def kill(self):
         del self.cpp

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -63,10 +63,10 @@ class fn_wrapper:
         if is_scalar(ret):
             ret = np.full(len(args[-1]), ret)
 
-        from pybindlibs import cpp
+        from pyphare.cpp import cpp_lib
         # convert numpy array to C++ SubSpan
         # couples vector init functions to C++
-        return cpp.makePyArrayWrapper(ret)
+        return cpp_lib().makePyArrayWrapper(ret)
 
 
 

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -159,6 +159,7 @@ def populateDict():
         add_string("simulation/AMR/refinement/tagging/method","none") # integrator.h might want some looking at
 
     add_string("simulation/algo/ion_updater/pusher/name", simulation.particle_pusher)
+    add_size_t("simulation/algo/ion_updater/pusher/threads", 1)
     add_double("simulation/algo/ohm/resistivity", simulation.resistivity)
     add_double("simulation/algo/ohm/hyper_resistivity", simulation.hyper_resistivity)
 

--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -52,7 +52,7 @@ def validate_timestamps(clazz, **kwargs):
             raise RuntimeError(f"Error: timestamp({sim.time_step_nbr}) cannot be greater than simulation.final_time({sim.final_time}))")
         if not np.all(np.diff(timestamps) >= 0):
             raise RuntimeError(f"Error: {clazz}.{key} not in ascending order)")
-        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):            
+        if not np.all(np.abs(timestamps / sim.time_step - np.rint(timestamps/sim.time_step) < 1e-9)):
             raise RuntimeError(f"Error: {clazz}.{key} is inconsistent with simulation.time_step")
 
 
@@ -63,8 +63,8 @@ def validate_timestamps(clazz, **kwargs):
 
 def try_cpp_dep_vers():
     try:
-        from pybindlibs import cpp
-        return cpp.phare_deps()
+        from pyphare.cpp import cpp_lib
+        return cpp_lib().phare_deps()
     except ImportError:
         return {}
 

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -129,7 +129,7 @@ def check_interp_order(**kwargs):
 
 def check_pusher(**kwargs):
     pusher = kwargs.get('particle_pusher', 'modified_boris')
-    if pusher not in ['modified_boris']:
+    if pusher not in ['modified_boris', 'kirov']:
         raise ValueError('Error: invalid pusher ({})'.format(pusher))
     return pusher
 

--- a/pyphare/pyphare/pharesee/particles.py
+++ b/pyphare/pyphare/pharesee/particles.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-from ..core.phare_utilities import refinement_ratio
+from ..core.phare_utilities import refinement_ratio, print_trace
 
 class Particles:
     """
@@ -88,6 +88,8 @@ class Particles:
                 all_assert(self, that)
                 return True
             except AssertionError as ex:
+                print(f"particles.py:Particles::eq failed with:", ex)
+                print_trace()
                 return False
         return False
 
@@ -150,7 +152,8 @@ def all_assert(part1, part2):
 
     np.testing.assert_array_equal(part1.iCells[idx1], part2.iCells[idx2])
 
-    np.testing.assert_allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12)
+    deltol = 1e-6 if any([part.deltas.dtype == np.float32 for part in [part1, part2]] ) else 1e-12
+    np.testing.assert_allclose(part1.deltas[idx1], part2.deltas[idx2], atol=deltol)
 
     np.testing.assert_allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12)
     np.testing.assert_allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12)

--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -15,15 +15,15 @@ def simulator_shutdown():
 
 
 def make_cpp_simulator(dim, interp, nbrRefinedPart, hier):
-    from pybindlibs import cpp
-    make_sim = "make_simulator_" + str(dim) + "_" + str(interp)+ "_" + str(nbrRefinedPart)
-    return getattr(cpp, make_sim)(hier)
+    from pyphare.cpp import cpp_lib
+    make_sim = f"make_simulator_{dim}_{interp}_{nbrRefinedPart}"
+    return getattr(cpp_lib(), make_sim)(hier)
 
 
 def startMPI():
     if "samrai" not in life_cycles:
-        from pybindlibs import cpp
-        life_cycles["samrai"] = cpp.SamraiLifeCycle()
+        from pyphare.cpp import cpp_lib
+        life_cycles["samrai"] = cpp_lib().SamraiLifeCycle()
 
 
 class Simulator:
@@ -47,11 +47,11 @@ class Simulator:
         if self.cpp_sim is not None:
             raise ValueError("Simulator already initialized: requires reset to re-initialize")
         try:
-            from pybindlibs import cpp
+            from pyphare.cpp import cpp_lib
             from pyphare.pharein import populateDict
             startMPI()
             populateDict()
-            self.cpp_hier = cpp.make_hierarchy()
+            self.cpp_hier = cpp_lib().make_hierarchy()
 
             self.cpp_sim = make_cpp_simulator(
               self.simulation.ndim, self.simulation.interp_order, self.simulation.refined_particle_nbr, self.cpp_hier
@@ -79,7 +79,7 @@ class Simulator:
                          self.timeStep())
 
     def run(self):
-        from pybindlibs import cpp
+        from pyphare.cpp import cpp_lib
         self._check_init()
         perf = []
         end_time = self.cpp_sim.endTime()
@@ -91,7 +91,7 @@ class Simulator:
             ticktock = tock-tick
             perf.append(ticktock)
             t = self.cpp_sim.currentTime()
-            if cpp.mpi_rank() == 0:
+            if cpp_lib().mpi_rank() == 0:
                 print("t = {:8.5f}  -  {:6.5f}sec  - total {:7.4}sec".format(t, ticktock, np.sum(perf)))
 
         print("mean advance time = {}".format(np.mean(perf)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel
 ddt
 mpi4py
 h5py

--- a/res/cmake/dep.cmake
+++ b/res/cmake/dep.cmake
@@ -1,5 +1,8 @@
 
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # SAMRAI build option
 include("${PHARE_PROJECT_DIR}/res/cmake/dep/samrai.cmake")
 

--- a/res/cmake/dep/highfive.cmake
+++ b/res/cmake/dep/highfive.cmake
@@ -27,6 +27,7 @@ if(HighFive)
     ${HIGHFIVE_SRC}/include
     ${CMAKE_BINARY_DIR}/subprojects/highfive/include # configured include for version info
   )
+  set(HIGHFIVE_UNIT_TESTS OFF) # silence warning
   set(HIGHFIVE_USE_BOOST OFF)
   set(HIGHFIVE_BUILD_DOCS OFF) # conflicts with phare doc target
   add_subdirectory(${HIGHFIVE_SRC})

--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -94,7 +94,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
   if(DEFINED GTEST_ROOT)
     set(GTEST_ROOT ${GTEST_ROOT} CACHE PATH "Path to googletest")
     find_package(GTest REQUIRED)
-    set(GTEST_LIBS GTest::GTest GTest::Main)
+    set(GTEST_LIBS GTest::GTest GTest::Main Threads::Threads)
   else()
     set(GTEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/subprojects/googletest)
 
@@ -106,7 +106,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
     set(GTEST_INCLUDE_DIRS
       $<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>)
-    set(GTEST_LIBS gtest gmock)
+    set(GTEST_LIBS gtest gmock Threads::Threads)
 
   endif()
 

--- a/src/core/ThreadPool.h
+++ b/src/core/ThreadPool.h
@@ -1,0 +1,113 @@
+// modified https://github.com/progschj/ThreadPool
+
+#ifndef THREAD_POOL_H
+#define THREAD_POOL_H
+
+#include <vector>
+#include <queue>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <future>
+#include <functional>
+#include <stdexcept>
+
+namespace EXT
+{
+class ThreadPool
+{
+public:
+    ThreadPool(size_t);
+    template<class F, class... Args>
+    auto enqueue(F&& f, Args&&... args) -> std::future<typename std::result_of<F(Args...)>::type>;
+    ~ThreadPool();
+
+    void sync()
+    {
+        while (running_ > 0)
+            std::this_thread::yield();
+    }
+
+    auto size() const { return workers.size(); }
+
+private:
+    // need to keep track of threads so we can join them
+    std::vector<std::thread> workers;
+    // the task queue
+    std::queue<std::function<void()>> tasks;
+
+    // synchronization
+    std::mutex queue_mutex;
+    std::condition_variable condition;
+    bool stop;
+
+    std::atomic<std::uint16_t> running_{0};
+};
+
+// the constructor just launches some amount of workers
+inline ThreadPool::ThreadPool(size_t threads)
+    : stop(false)
+{
+    auto worker = [this](std::size_t i) {
+        auto& _stop = this->stop;
+        for (;;)
+        {
+            std::function<void()> task;
+
+            {
+                std::unique_lock<std::mutex> lock(this->queue_mutex);
+                this->condition.wait(lock, [&] { return _stop || !this->tasks.empty(); });
+                if (this->stop && this->tasks.empty())
+                    return;
+                task = std::move(this->tasks.front());
+                this->tasks.pop();
+            }
+
+            task();
+            running_--;
+        }
+    };
+
+    for (size_t i = 0; i < threads; ++i)
+        workers.emplace_back(worker, i);
+}
+
+// add new work item to the pool
+template<class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+    -> std::future<typename std::result_of<F(Args...)>::type>
+{
+    using return_type = typename std::result_of<F(Args...)>::type;
+
+    auto task = std::make_shared<std::packaged_task<return_type()>>(
+        std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+    std::future<return_type> res = task->get_future();
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+
+        // don't allow enqueueing after stopping the pool
+        if (stop)
+            throw std::runtime_error("enqueue on stopped ThreadPool");
+
+        tasks.emplace([task]() { (*task)(); });
+        running_++;
+    }
+    condition.notify_one();
+    return res;
+}
+
+// the destructor joins all threads
+inline ThreadPool::~ThreadPool()
+{
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex);
+        stop = true;
+    }
+    condition.notify_all();
+    for (std::thread& worker : workers)
+        worker.join();
+}
+} // namespace EXT
+#endif

--- a/src/core/data/ions/particle_initializers/maxwellian_particle_initializer.h
+++ b/src/core/data/ions/particle_initializers/maxwellian_particle_initializer.h
@@ -144,7 +144,7 @@ void MaxwellianParticleInitializer<ParticleArray, GridLayout>::loadParticles(
     };
 
 
-    auto deltas = [](auto& pos, auto& gen) -> std::array<float, dimension> {
+    auto deltas = [](auto& pos, auto& gen) -> std::array<double, dimension> {
         if constexpr (dimension == 1)
             return {pos(gen)};
         if constexpr (dimension == 2)
@@ -172,7 +172,7 @@ void MaxwellianParticleInitializer<ParticleArray, GridLayout>::loadParticles(
 
     auto const [n, V, Vth] = fns();
     auto randGen           = getRNG(rngSeed_);
-    ParticleDeltaDistribution deltaDistrib;
+    ParticleDeltaDistribution<double> deltaDistrib;
 
     for (std::size_t flatCellIdx = 0; flatCellIdx < ndCellIndices.size(); flatCellIdx++)
     {

--- a/src/core/data/particles/particle.h
+++ b/src/core/data/particles/particle.h
@@ -41,9 +41,9 @@ struct Particle
     double weight;
     double charge;
 
-    std::array<int, dim> iCell   = ConstArray<int, dim>();
-    std::array<float, dim> delta = ConstArray<float, dim>();
-    std::array<double, 3> v      = ConstArray<double, 3>();
+    std::array<int, dim> iCell    = ConstArray<int, dim>();
+    std::array<double, dim> delta = ConstArray<double, dim>();
+    std::array<double, 3> v       = ConstArray<double, 3>();
 
     double Ex = 0, Ey = 0, Ez = 0;
     double Bx = 0, By = 0, Bz = 0;
@@ -59,7 +59,7 @@ struct ParticleView
     double& weight;
     double& charge;
     std::array<int, dim>& iCell;
-    std::array<float, dim>& delta;
+    std::array<double, dim>& delta;
     std::array<double, 3>& v;
 };
 
@@ -85,8 +85,8 @@ struct ContiguousParticles
     {
     }
 
-    template<typename Container_int, typename Container_float, typename Container_double>
-    ContiguousParticles(Container_int&& _iCell, Container_float&& _delta,
+    template<typename Container_int, typename Container_double>
+    ContiguousParticles(Container_int&& _iCell, Container_double&& _delta,
                         Container_double&& _weight, Container_double&& _charge,
                         Container_double&& _v)
         : iCell{_iCell}
@@ -152,7 +152,7 @@ struct ContiguousParticles
     auto cend() const { return iterator(this); }
 
     container_t<int> iCell;
-    container_t<float> delta;
+    container_t<double> delta;
     container_t<double> weight, charge, v;
 };
 

--- a/src/core/data/particles/particle_array.h
+++ b/src/core/data/particles/particle_array.h
@@ -26,6 +26,11 @@ public:
     {
     }
 
+    ParticleArray(ParticleArray const& copy)
+        : particles(copy.particles)
+    {
+    }
+
     ParticleArray(std::size_t size, Particle_t&& particle)
         : particles(size, particle)
     {

--- a/src/core/data/vecfield/vecfield.h
+++ b/src/core/data/vecfield/vecfield.h
@@ -135,7 +135,14 @@ namespace core
             throw std::runtime_error("Error - VecField not usable");
         }
 
-
+        auto getComponents()
+        {
+            return std::forward_as_tuple(*components_[0], *components_[1], *components_[2]);
+        }
+        auto getComponents() const
+        {
+            return std::forward_as_tuple(*components_[0], *components_[1], *components_[2]);
+        }
 
 
         Field<NdArrayImpl, typename PhysicalQuantity::Scalar> const&

--- a/src/core/numerics/ion_updater/lol_ion_updater.h
+++ b/src/core/numerics/ion_updater/lol_ion_updater.h
@@ -1,0 +1,248 @@
+#ifndef PHARE_CORE_LOL_ION_UPDATER_H
+#define PHARE_CORE_LOL_ION_UPDATER_H
+
+#include "core/utilities/box/box.h"
+#include "core/numerics/interpolator/interpolator.h"
+#include "core/numerics/pusher/pusher.h"
+
+
+#include "core/numerics/pusher/pusher_factory.h"
+#include "core/numerics/boundary_condition/boundary_condition.h"
+#include "core/numerics/moments/moments.h"
+
+#include "core/data/ions/ions.h"
+
+#include "initializer/data_provider.h"
+
+
+#include "core/numerics/ion_updater/ion_updater.h" // for enum class UpdaterMode
+
+#include <memory>
+
+
+// TODO alpha coef for interpolating new and old levelGhost should be given somehow...
+
+
+namespace PHARE::core
+{
+template<typename Ions, typename Electromag, typename GridLayout>
+// temporary name
+class LOL_IonUpdater
+{
+public:
+    static constexpr auto dimension    = GridLayout::dimension;
+    static constexpr auto interp_order = GridLayout::interp_order;
+
+    using Box               = PHARE::core::Box<int, dimension>;
+    using Interpolator      = PHARE::core::Interpolator<dimension, interp_order>;
+    using VecField          = typename Ions::vecfield_type;
+    using ParticleArray     = typename Ions::particle_array_type;
+    using PartIterator      = typename ParticleArray::iterator;
+    using BoundaryCondition = PHARE::core::BoundaryCondition<dimension, interp_order>;
+    using Pusher = PHARE::core::KirovPusher<dimension, PartIterator, Electromag, Interpolator,
+                                            BoundaryCondition, GridLayout>;
+
+    static std::size_t get_threads(PHARE::initializer::PHAREDict const& dict)
+    {
+        if (dict["pusher"].contains("threads"))
+            return dict["pusher"]["threads"].template to<std::size_t>();
+        return 1;
+    }
+
+public:
+    LOL_IonUpdater(PHARE::initializer::PHAREDict const& dict)
+        : pusher_threads_{get_threads(dict)}
+        , pusher_{std::make_unique<Pusher>(pusher_threads_)}
+    //, pusher_{makePusher(dict["pusher"]["name"].template to<std::string>())}
+    {
+        assert(pusher_threads_ > 0);
+    }
+
+    void updatePopulations(Ions& ions, Electromag const& em, GridLayout const& layout, double dt,
+                           UpdaterMode = UpdaterMode::particles_and_moments);
+
+
+    void updateIons(Ions& ions, GridLayout const& layout);
+
+
+private:
+    constexpr static auto makePusher
+        = PHARE::core::PusherFactory::makePusher<dimension, PartIterator, Electromag, Interpolator,
+                                                 BoundaryCondition, GridLayout>;
+
+
+    void updateMomentsOnly_(Ions& ions, Electromag const& em, GridLayout const& layout);
+
+    void updateAll_(Ions& ions, Electromag const& em, GridLayout const& layout);
+
+    std::size_t pusher_threads_ = 1;
+    std::unique_ptr<Pusher> pusher_;
+    Interpolator interpolator_;
+};
+
+
+
+
+template<typename Ions, typename Electromag, typename GridLayout>
+void LOL_IonUpdater<Ions, Electromag, GridLayout>::updatePopulations(Ions& ions,
+                                                                     Electromag const& em,
+                                                                     GridLayout const& layout,
+                                                                     double dt, UpdaterMode mode)
+{
+    resetMoments(ions);
+    pusher_->setMeshAndTimeStep(layout.meshSize(), dt);
+
+    if (mode == UpdaterMode::moments_only)
+    {
+        updateMomentsOnly_(ions, em, layout);
+    }
+    else
+    {
+        updateAll_(ions, em, layout);
+    }
+}
+
+
+
+template<typename Ions, typename Electromag, typename GridLayout>
+void LOL_IonUpdater<Ions, Electromag, GridLayout>::updateIons(Ions& ions, GridLayout const& layout)
+{
+    fixMomentGhosts(ions, layout);
+    ions.computeDensity();
+    ions.computeBulkVelocity();
+}
+
+
+
+template<typename Ions, typename Electromag, typename GridLayout>
+/**
+ * @brief LOL_IonUpdater<Ions, Electromag, GridLayout>::updateMomentsOnly_
+   evolves moments from time n to n+1 without updating particles, which stay at time n
+ */
+void LOL_IonUpdater<Ions, Electromag, GridLayout>::updateMomentsOnly_(Ions& ions,
+                                                                      Electromag const& em,
+                                                                      GridLayout const& layout)
+{
+    auto domainBox = layout.AMRBox();
+
+    auto inDomainBox = [&domainBox](auto const& part) {
+        auto cell = cellAsPoint(part);
+        return core::isIn(cell, domainBox);
+    };
+
+    auto constexpr partGhostWidth = GridLayout::ghostWidthForParticles();
+    auto ghostBox{domainBox};
+    ghostBox.grow(partGhostWidth);
+
+    auto ghostSelector = [&ghostBox, &domainBox](auto const& part) {
+        auto cell = cellAsPoint(part);
+        return core::isIn(cell, ghostBox) and !core::isIn(cell, domainBox);
+    };
+
+
+    for (auto& pop : ions)
+    {
+        // first push all domain particles
+        // push them while still inDomainBox
+        // accumulate those inDomainBox
+
+        {
+            auto copy  = pop.domainParticles();
+            auto range = makeRange(copy);
+
+            auto newEnd = pusher_->move(range, em, pop.mass(), interpolator_, inDomainBox, layout);
+
+            interpolator_(std::begin(copy), newEnd, pop.density(), pop.flux(), layout);
+        }
+
+
+        // then push patch and level ghost particles
+        // push those in the ghostArea (i.e. stop pushing if they're not out of it)
+        // some will leave the ghost area
+        // deposit moments on those which leave to go inDomainBox
+
+        auto pushAndAccumulateGhosts = [&](auto const& ghost_particles) {
+            auto copy  = ghost_particles;
+            auto range = makeRange(copy);
+
+            auto firstGhostOut
+                = pusher_->move(range, em, pop.mass(), interpolator_, ghostSelector, layout);
+
+            auto endInDomain = std::partition(firstGhostOut, std::end(copy), inDomainBox);
+
+            interpolator_(firstGhostOut, endInDomain, pop.density(), pop.flux(), layout);
+        };
+
+        pushAndAccumulateGhosts(pop.patchGhostParticles());
+        pushAndAccumulateGhosts(pop.levelGhostParticles());
+    }
+}
+
+
+template<typename Ions, typename Electromag, typename GridLayout>
+/**
+ * @brief LOL_IonUpdater<Ions, Electromag, GridLayout>::updateMomentsOnly_
+   evolves moments and particles from time n to n+1
+ */
+void LOL_IonUpdater<Ions, Electromag, GridLayout>::updateAll_(Ions& ions, Electromag const& em,
+                                                              GridLayout const& layout)
+{
+    auto constexpr partGhostWidth = GridLayout::ghostWidthForParticles();
+    auto domainBox                = layout.AMRBox();
+    auto ghostBox{domainBox};
+    ghostBox.grow(partGhostWidth);
+
+    auto ghostSelector = [&ghostBox, &domainBox](auto const& part) {
+        auto cell = cellAsPoint(part);
+        return core::isIn(cell, ghostBox) and !core::isIn(cell, domainBox);
+    };
+
+    auto inDomainSelector
+        = [&domainBox](auto const& part) { return core::isIn(cellAsPoint(part), domainBox); };
+
+
+    // push domain particles, erase from array those leaving domain
+    // push patch and level ghost particles that are in ghost area (==ghost box without domain)
+    // copy patch and ghost particles out of ghost area that are in domain, in particle array
+    // finally all particles in domain are to be interpolated on mesh.
+
+
+    for (auto& pop : ions)
+    {
+        auto& domainParticles = pop.domainParticles();
+
+        auto domainPartRange = makeRange(domainParticles);
+
+        auto firstOutside = pusher_->move(domainPartRange, em, pop.mass(), interpolator_,
+                                          inDomainSelector, layout);
+
+        domainParticles.erase(firstOutside, std::end(domainParticles));
+
+
+        auto pushAndCopyInDomain = [&](auto& particleArray) {
+            auto range = makeRange(particleArray);
+
+            auto firstOutGhostBox
+                = pusher_->move(range, em, pop.mass(), interpolator_, ghostSelector, layout);
+
+            std::copy_if(firstOutGhostBox, std::end(particleArray),
+                         std::back_inserter(domainParticles), inDomainSelector);
+
+            particleArray.erase(firstOutGhostBox, std::end(particleArray));
+        };
+
+
+        pushAndCopyInDomain(pop.patchGhostParticles());
+        pushAndCopyInDomain(pop.levelGhostParticles());
+
+        interpolator_(std::begin(domainParticles), std::end(domainParticles), pop.density(),
+                      pop.flux(), layout);
+    }
+}
+
+
+
+} // namespace PHARE::core
+
+
+#endif // ION_UPDATER_H

--- a/src/core/numerics/pusher/boris.h
+++ b/src/core/numerics/pusher/boris.h
@@ -25,7 +25,7 @@ namespace core
         using ParticleSelector = typename Super::ParticleSelector;
         using ParticleRange    = Range<ParticleIterator>;
 
-        /** see Pusher::move() domentation*/
+        /** see Pusher::move() documentation*/
         ParticleIterator move(ParticleRange const& rangeIn, ParticleRange& rangeOut,
                               Electromag const& emFields, double mass, Interpolator& interpolator,
                               ParticleSelector const& particleIsNotLeaving, BoundaryCondition& bc,
@@ -67,7 +67,7 @@ namespace core
         }
 
 
-        /** see Pusher::move() domentation*/
+        /** see Pusher::move() documentation*/
         ParticleIterator move(ParticleRange const& rangeIn, ParticleRange& rangeOut,
                               Electromag const& emFields, double mass, Interpolator& interpolator,
                               ParticleSelector const& particleIsNotLeaving,
@@ -100,7 +100,7 @@ namespace core
         }
 
 
-        /** see Pusher::move() domentation*/
+        /** see Pusher::move() documentation*/
         virtual void setMeshAndTimeStep(std::array<double, dim> ms, double ts) override
         {
             std::transform(std::begin(ms), std::end(ms), std::begin(halfDtOverDl_),

--- a/src/core/numerics/pusher/kirov.h
+++ b/src/core/numerics/pusher/kirov.h
@@ -1,0 +1,333 @@
+#ifndef PHARE_CORE_PUSHER_KIROV_H
+#define PHARE_CORE_PUSHER_KIROV_H
+
+
+#include "core/ThreadPool.h"
+
+#include <array>
+#include <cmath>
+#include <thread>
+#include <cstddef>
+#include <iostream>
+
+#include "core/numerics/pusher/pusher.h"
+#include "core/utilities/range/range.h"
+#include "core/logger.h"
+
+namespace PHARE::core
+{
+template<std::size_t dim, typename ParticleIterator, typename Electromag, typename Interpolator,
+         typename BoundaryCondition, typename GridLayout, typename ThreadPool_t = EXT::ThreadPool>
+class KirovPusher
+    : public Pusher<dim, ParticleIterator, Electromag, Interpolator, BoundaryCondition, GridLayout>
+{
+public:
+    using Super
+        = Pusher<dim, ParticleIterator, Electromag, Interpolator, BoundaryCondition, GridLayout>;
+    using ParticleSelector = typename Super::ParticleSelector;
+    using ParticleRange    = Range<ParticleIterator>;
+
+    KirovPusher(std::size_t threads = 1)
+        : pool_{threads - 1}
+    {
+        assert(threads > 0);
+    }
+
+    /** see Pusher::move() documentation*/
+    ParticleIterator move(ParticleRange const& rangeIn, ParticleRange& rangeOut,
+                          Electromag const& emFields, double mass, Interpolator& interpolator,
+                          ParticleSelector const& particleIsNotLeaving, BoundaryCondition& bc,
+                          GridLayout const& layout) override
+    {
+        // push the particles of half a step
+        // rangeIn : t=n, rangeOut : t=n+1/Z
+        // get a pointer on the first particle of rangeOut that leaves the patch
+        auto firstLeaving = pushStep_(rangeIn, rangeOut, particleIsNotLeaving, PushStep::PrePush);
+
+        // apply boundary condition on the particles in [firstLeaving, rangeOut.end[
+        // that actually leave through a physical boundary condition
+        // get a pointer on the new end of rangeOut. Particles passed newEnd
+        // are those that have left the patch through a non-physical boundary
+        // they should be discarded now
+        auto newEnd = bc.applyOutgoingParticleBC(firstLeaving, rangeOut.end());
+
+        rangeOut = makeRange(rangeOut.begin(), std::move(newEnd));
+
+        // get electromagnetic fields interpolated on the particles of rangeOut
+        // stop at newEnd.
+        interpolator(rangeOut.begin(), rangeOut.end(), emFields, layout);
+
+        // get the particle velocity from t=n to t=n+1
+        accelerate_(rangeOut, rangeOut, mass);
+
+        // now advance the particles from t=n+1/2 to t=n+1 using v_{n+1} just calculated
+        // and get a pointer to the first leaving particle
+        firstLeaving = pushStep_(rangeOut, rangeOut, particleIsNotLeaving, PushStep::PostPush);
+
+        // apply BC on the leaving particles that leave through physical BC
+        // and get pointer on new End, discarding particles leaving elsewhere
+        newEnd = bc.applyOutgoingParticleBC(firstLeaving, rangeOut.end());
+
+        rangeOut = makeRange(rangeOut.begin(), std::move(newEnd));
+
+        return rangeOut.end();
+    }
+
+
+    /** see Pusher::move() documentation*/
+    ParticleIterator move(ParticleRange const& rangeIn, ParticleRange& rangeOut,
+                          Electromag const& emFields, double mass, Interpolator& interpolator,
+                          ParticleSelector const& particleIsNotLeaving,
+                          GridLayout const& layout) override
+    {
+        PHARE_LOG_SCOPE("Kirov::move_no_bc");
+
+        // push the particles of half a step
+        // rangeIn : t=n, rangeOut : t=n+1/2
+        // get a pointer on the first particle of rangeOut that leaves the patch
+        auto firstLeaving = pushStep_(rangeIn, rangeOut, particleIsNotLeaving, PushStep::PrePush);
+
+        rangeOut = makeRange(rangeOut.begin(), std::move(firstLeaving));
+
+        // get electromagnetic fields interpolated on the particles of rangeOut
+        // stop at newEnd.
+        interpolator(rangeOut.begin(), rangeOut.end(), emFields, layout);
+
+        // get the particle velocity from t=n to t=n+1
+        accelerate_(rangeOut, rangeOut, mass);
+
+        // now advance the particles from t=n+1/2 to t=n+1 using v_{n+1} just calculated
+        // and get a pointer to the first leaving particle
+        firstLeaving = pushStep_(rangeOut, rangeOut, particleIsNotLeaving, PushStep::PostPush);
+
+        rangeOut = makeRange(rangeOut.begin(), std::move(firstLeaving));
+
+        return rangeOut.end();
+    }
+
+
+    template<typename Particle_t>
+    bool move_in_place(Particle_t& particle, Electromag const& emFields, Interpolator& interpolator,
+                       ParticleSelector const& particleIsNotLeaving, GridLayout const& layout)
+    {
+        advancePosition_(particle);
+
+        if (particleIsNotLeaving(particle))
+        {
+            interpolator.meshToParticle(particle, emFields, layout);
+
+            accelerate_(particle);
+
+            advancePosition_(particle);
+
+            return particleIsNotLeaving(particle);
+        }
+        return false;
+    }
+
+
+    /** see Pusher::move() documentation*/
+    auto move(ParticleRange& range, Electromag const& emFields, double mass,
+              Interpolator& interpolator, ParticleSelector const& particleIsNotLeaving,
+              GridLayout const& layout) /*override*/
+    {
+        PHARE_LOG_SCOPE("Kirov::move_in_place_no_bc");
+
+        accelerate_setup(mass);
+
+        std::vector<bool> particlesAreNotLeaving(range.size(), false);
+
+        auto _move = [&](std::size_t const from, std::size_t const to) {
+            for (std::size_t i = from; i < to; ++i)
+                particlesAreNotLeaving[i]
+                    = move_in_place(range[i], emFields, interpolator, particleIsNotLeaving, layout);
+        };
+
+        std::size_t perThread = range.size() / (pool_.size() + 1);
+        for (std::size_t i = 0; i < pool_.size(); ++i)
+            pool_.enqueue([&, ix = i]() {
+                auto from = ix * perThread;
+                auto to   = from + perThread;
+                _move(from, to);
+            });
+
+        _move(pool_.size() * perThread, range.size()); // should start at 0 for cache?
+
+        pool_.sync();
+
+        auto firstLeaving
+            = std::partition(std::begin(range), std::end(range), [&](auto const& part) {
+                  return particlesAreNotLeaving[&part - &(*range.begin())];
+              });
+
+        return makeRange(range.begin(), std::move(firstLeaving)).end();
+    }
+
+
+
+
+    /** see Pusher::move() documentation*/
+    virtual void setMeshAndTimeStep(std::array<double, dim> ms, double ts) override
+    {
+        std::transform(std::begin(ms), std::end(ms), std::begin(halfDtOverDl_),
+                       [ts](double const& x) { return 0.5 * ts / x; });
+        dt_ = ts;
+    }
+
+
+
+private:
+    enum class PushStep { PrePush, PostPush };
+
+    /** move the particle partIn of half a time step and store it in partOut
+     */
+    template<typename ParticleIter>
+    void advancePosition_(ParticleIter& particle)
+    {
+        advancePosition_(particle, particle);
+    }
+
+    template<typename ParticleIter>
+    void advancePosition_(ParticleIter const& partIn, ParticleIter& partOut)
+    {
+        // push the particle
+        for (std::size_t iDim = 0; iDim < dim; ++iDim)
+        {
+            float delta
+                = partIn.delta[iDim] + static_cast<float>(halfDtOverDl_[iDim] * partIn.v[iDim]);
+
+            float iCell = std::floor(delta);
+            if (std::abs(delta) > 2)
+            {
+                throw std::runtime_error("Error, particle moves more than 1 cell, delta >2");
+            }
+            partOut.delta[iDim] = delta - iCell;
+            partOut.iCell[iDim] = static_cast<int>(iCell + partIn.iCell[iDim]);
+        }
+    }
+
+
+
+    /** advance the particles in rangeIn of half a time step and store them
+     * in rangeOut.
+     * @return the function returns and iterator on the first leaving particle, as
+     * detected by the ParticleSelector
+     */
+    template<typename ParticleRangeIn, typename ParticleRangeOut>
+    auto pushStep_(ParticleRangeIn const& rangeIn, ParticleRangeOut& rangeOut,
+                   ParticleSelector const& particleIsNotLeaving, PushStep step)
+    {
+        auto currentOut = rangeOut.begin();
+
+        for (auto& currentIn : rangeIn)
+        {
+            if (step == PushStep::PrePush)
+            {
+                currentOut->charge = currentIn.charge;
+                currentOut->weight = currentIn.weight;
+                currentOut->v      = currentIn.v;
+            }
+            // push the particle
+            advancePosition_(currentIn, *currentOut);
+            currentOut++;
+        }
+
+        // now all particles have been pushed
+        // those not satisfying the predicate after the push
+        // are found in [newEnd:end[
+        // those for which pred is true are in [firstOut,newEnd[
+        return std::partition(std::begin(rangeOut), std::end(rangeOut), particleIsNotLeaving);
+    }
+
+
+
+    void accelerate_setup(double mass) { dto2m_ = 0.5 * dt_ / mass; }
+
+    template<typename ParticleRangeIn, typename ParticleRangeOut>
+    void accelerate_(ParticleRangeIn inputParticles, ParticleRangeOut outputParticles, double mass)
+    {
+        accelerate_setup(mass);
+
+        auto currentOut = outputParticles.begin();
+
+        for (auto const& currentIn : inputParticles)
+        {
+            accelerate_(currentIn, *currentOut);
+            ++currentOut;
+        }
+    }
+
+
+    /** Accelerate the particles in rangeIn and put the new velocity in rangeOut
+     */
+    template<typename Particle_t>
+    void accelerate_(Particle_t& particle)
+    {
+        accelerate_(particle, particle);
+    }
+
+    template<typename Particle_t>
+    void accelerate_(Particle_t const& currentIn, Particle_t& currentOut)
+    {
+        double coef1 = currentIn.charge * dto2m_;
+
+        // We now apply the 3 steps of the BORIS PUSHER
+
+        // 1st half push of the electric field
+        double velx1 = currentIn.v[0] + coef1 * currentIn.Ex;
+        double vely1 = currentIn.v[1] + coef1 * currentIn.Ey;
+        double velz1 = currentIn.v[2] + coef1 * currentIn.Ez;
+
+
+        // preparing variables for magnetic rotation
+        double const rx = coef1 * currentIn.Bx;
+        double const ry = coef1 * currentIn.By;
+        double const rz = coef1 * currentIn.Bz;
+
+        double const rx2  = rx * rx;
+        double const ry2  = ry * ry;
+        double const rz2  = rz * rz;
+        double const rxry = rx * ry;
+        double const rxrz = rx * rz;
+        double const ryrz = ry * rz;
+
+        double const invDet = 1. / (1. + rx2 + ry2 + rz2);
+
+        // preparing rotation matrix due to the magnetic field
+        // m = invDet*(I + r*r - r x I) - I where x denotes the cross product
+        double const mxx = 1. + rx2 - ry2 - rz2;
+        double const mxy = 2. * (rxry + rz);
+        double const mxz = 2. * (rxrz - ry);
+
+        double const myx = 2. * (rxry - rz);
+        double const myy = 1. + ry2 - rx2 - rz2;
+        double const myz = 2. * (ryrz + rx);
+
+        double const mzx = 2. * (rxrz + ry);
+        double const mzy = 2. * (ryrz - rx);
+        double const mzz = 1. + rz2 - rx2 - ry2;
+
+        // magnetic rotation
+        double const velx2 = (mxx * velx1 + mxy * vely1 + mxz * velz1) * invDet;
+        double const vely2 = (myx * velx1 + myy * vely1 + myz * velz1) * invDet;
+        double const velz2 = (mzx * velx1 + mzy * vely1 + mzz * velz1) * invDet;
+
+        // 2nd half push of the electric field / Update particle velocity
+        currentOut.v[0] = velx2 + coef1 * currentIn.Ex;
+        currentOut.v[1] = vely2 + coef1 * currentIn.Ey;
+        currentOut.v[2] = velz2 + coef1 * currentIn.Ez;
+    }
+
+
+
+
+    std::array<double, dim> halfDtOverDl_;
+    double dt_;
+
+    double dto2m_; // not thread safe, cannot // multiple pops at the same time
+    ThreadPool_t pool_;
+};
+
+} // namespace PHARE::core
+
+#endif

--- a/src/core/numerics/pusher/pusher_factory.h
+++ b/src/core/numerics/pusher/pusher_factory.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "boris.h"
+#include "kirov.h"
 #include "pusher.h"
 
 namespace PHARE
@@ -17,11 +18,23 @@ namespace core
     public:
         template<std::size_t dim, typename ParticleIterator, typename Electromag,
                  typename Interpolator, typename BoundaryCondition, typename GridLayout>
-        static auto makePusher(std::string pusherName)
+        static std::unique_ptr<
+            Pusher<dim, ParticleIterator, Electromag, Interpolator, BoundaryCondition, GridLayout>>
+        makePusher(std::string pusherName)
         {
+            // /*TORM */ return std::make_unique<KirovPusher<
+            //     dim, ParticleIterator, Electromag, Interpolator, BoundaryCondition,
+            //     GridLayout>>();
+
             if (pusherName == "modified_boris")
             {
                 return std::make_unique<BorisPusher<dim, ParticleIterator, Electromag, Interpolator,
+                                                    BoundaryCondition, GridLayout>>();
+            }
+
+            if (pusherName == "kirov")
+            {
+                return std::make_unique<KirovPusher<dim, ParticleIterator, Electromag, Interpolator,
                                                     BoundaryCondition, GridLayout>>();
             }
 

--- a/src/core/utilities/range/range.h
+++ b/src/core/utilities/range/range.h
@@ -38,6 +38,9 @@ namespace core
 
         std::size_t size() const { return std::distance(first_, last_); }
 
+        auto& operator[](std::size_t i) { return *(first_ + i); }
+        auto& operator[](std::size_t i) const { return *(first_ + i); }
+
     private:
         Iterator first_;
         Iterator last_;

--- a/src/diagnostic/detail/h5typewriter.h
+++ b/src/diagnostic/detail/h5typewriter.h
@@ -99,16 +99,14 @@ protected:
         h5Writer_.writeAttributeDict(file, fileAttributes, "/");
     }
 
-    void writeIonPopAttributes_(HighFive::File& file)
+    template<typename ParticlePopulation>
+    void writeIonPopAttributes_(HighFive::File& file, ParticlePopulation const& pop)
     {
         auto& h5Writer = this->h5Writer_;
 
-        for (auto& pop : h5Writer.modelView().getIons())
-        {
-            Attributes popAttributes;
-            popAttributes["pop_mass"] = pop.mass();
-            h5Writer.writeAttributeDict(file, popAttributes, "/");
-        }
+        Attributes popAttributes;
+        popAttributes["pop_mass"] = pop.mass();
+        h5Writer.writeAttributeDict(file, popAttributes, "/");
     }
 
     void writeGhostsAttr_(HighFive::File& file, std::string path, std::size_t ghosts, bool null)

--- a/src/diagnostic/detail/h5writer.h
+++ b/src/diagnostic/detail/h5writer.h
@@ -17,6 +17,11 @@
 #include "core/utilities/types.h"
 
 
+#if !defined(PHARE_DIAG_DOUBLES)
+#error // PHARE_DIAG_DOUBLES not defined
+#endif
+
+
 namespace PHARE::diagnostic::h5
 {
 template<typename H5Writer>
@@ -31,6 +36,8 @@ class ParticlesDiagnosticWriter;
 template<typename ModelView>
 class Writer : public PHARE::diagnostic::IWriter
 {
+    using FloatType = std::conditional_t<PHARE_DIAG_DOUBLES, double, float>;
+
     static constexpr std::size_t timestamp_precision = 10;
 
 public:
@@ -107,10 +114,12 @@ public:
     static void createDataSet(HiFile& h5, std::string const& path, std::size_t size)
     {
         if constexpr (std::is_same_v<Type, double>) // force doubles for floats for storage
-            This::createDatasetsPerMPI<float>(h5, path, size);
+            This::createDatasetsPerMPI<FloatType>(h5, path, size);
         else
             This::createDatasetsPerMPI<Type>(h5, path, size);
     }
+
+
 
     template<typename Array, typename String>
     static void writeDataSet(HiFile& h5, String path, Array const* const array)

--- a/src/diagnostic/detail/types/electromag.h
+++ b/src/diagnostic/detail/types/electromag.h
@@ -25,6 +25,7 @@ public:
     using Super::checkCreateFileFor_;
     using Attributes = typename Super::Attributes;
     using GridLayout = typename H5Writer::GridLayout;
+    using FloatType  = typename H5Writer::FloatType;
 
     ElectromagDiagnosticWriter(H5Writer& h5Writer)
         : Super{h5Writer}
@@ -103,7 +104,7 @@ void ElectromagDiagnosticWriter<H5Writer>::initDataSets(
         for (auto& [id, type] : core::Components::componentMap)
         {
             auto vFPath = path + "/" + key + "_" + id;
-            h5Writer.template createDataSet<float>(
+            h5Writer.template createDataSet<FloatType>(
                 h5file, vFPath, null ? 0 : attr[key][id].template to<std::size_t>());
 
             this->writeGhostsAttr_(
@@ -163,8 +164,8 @@ void ElectromagDiagnosticWriter<H5Writer>::writeAttributes(
         patchAttributes,
     std::size_t maxLevel)
 {
-    writeAttributes_(diagnostic, fileData_.at(diagnostic.quantity)->file(), fileAttributes, patchAttributes,
-                     maxLevel);
+    writeAttributes_(diagnostic, fileData_.at(diagnostic.quantity)->file(), fileAttributes,
+                     patchAttributes, maxLevel);
 }
 
 

--- a/src/diagnostic/detail/types/fluid.h
+++ b/src/diagnostic/detail/types/fluid.h
@@ -31,6 +31,7 @@ public:
     using Super::checkCreateFileFor_;
     using Attributes = typename Super::Attributes;
     using GridLayout = typename H5Writer::GridLayout;
+    using FloatType  = typename H5Writer::FloatType;
 
     FluidDiagnosticWriter(H5Writer& h5Writer)
         : Super{h5Writer}
@@ -145,15 +146,15 @@ void FluidDiagnosticWriter<H5Writer>::initDataSets(
 
     auto initDS = [&](auto& path, auto& attr, std::string key, auto null) {
         auto dsPath = path + key;
-        h5Writer.template createDataSet<float>(file, dsPath,
-                                               null ? 0 : attr[key].template to<std::size_t>());
+        h5Writer.template createDataSet<FloatType>(file, dsPath,
+                                                   null ? 0 : attr[key].template to<std::size_t>());
         writeGhosts(dsPath, attr, key, null);
     };
     auto initVF = [&](auto& path, auto& attr, std::string key, auto null) {
         for (auto& [id, type] : core::Components::componentMap)
         {
             auto vFPath = path + key + "_" + id;
-            h5Writer.template createDataSet<float>(
+            h5Writer.template createDataSet<FloatType>(
                 file, vFPath, null ? 0 : attr[key][id].template to<std::size_t>());
             writeGhosts(vFPath, attr[key], id, null);
         }

--- a/src/diagnostic/detail/types/fluid.h
+++ b/src/diagnostic/detail/types/fluid.h
@@ -225,9 +225,21 @@ void FluidDiagnosticWriter<H5Writer>::writeAttributes(
         patchAttributes,
     std::size_t maxLevel)
 {
-    auto& h5file = fileData_.at(diagnostic.quantity)->file();
+    auto& h5Writer = this->h5Writer_;
+    auto& h5file   = fileData_.at(diagnostic.quantity)->file();
 
-    writeIonPopAttributes_(h5file);
+    auto checkWrite = [&](auto& tree, std::string qty, auto const& pop) {
+        if (diagnostic.quantity == tree + qty)
+            this->writeIonPopAttributes_(h5file, pop);
+    };
+
+    for (auto& pop : h5Writer.modelView().getIons())
+    {
+        std::string tree = "/ions/pop/" + pop.name() + "/";
+        checkWrite(tree, "density", pop);
+        checkWrite(tree, "flux", pop);
+    }
+
     writeAttributes_(diagnostic, h5file, fileAttributes, patchAttributes, maxLevel);
 }
 

--- a/src/diagnostic/detail/types/particle.h
+++ b/src/diagnostic/detail/types/particle.h
@@ -39,6 +39,7 @@ public:
     static constexpr auto interpOrder = H5Writer::interpOrder;
     using Attributes                  = typename Super::Attributes;
     using Packer                      = core::ParticlePacker<dimension>;
+    using FloatType                   = typename H5Writer::FloatType;
 
     ParticlesDiagnosticWriter(H5Writer& h5Writer)
         : Super{h5Writer}

--- a/src/diagnostic/detail/types/particle.h
+++ b/src/diagnostic/detail/types/particle.h
@@ -209,9 +209,22 @@ void ParticlesDiagnosticWriter<H5Writer>::writeAttributes(
         patchAttributes,
     std::size_t maxLevel)
 {
-    auto& h5file = fileData_.at(diagnostic.quantity)->file();
+    auto& h5Writer = this->h5Writer_;
+    auto& h5file   = fileData_.at(diagnostic.quantity)->file();
 
-    writeIonPopAttributes_(h5file);
+    auto checkWrite = [&](auto& tree, std::string pType, auto const& pop) {
+        if (diagnostic.quantity == tree + pType)
+            this->writeIonPopAttributes_(h5file, pop);
+    };
+
+    for (auto& pop : h5Writer.modelView().getIons())
+    {
+        std::string tree = "/ions/pop/" + pop.name() + "/";
+        checkWrite(tree, "domain", pop);
+        checkWrite(tree, "levelGhost", pop);
+        checkWrite(tree, "patchGhost", pop);
+    }
+
     writeAttributes_(diagnostic, h5file, fileAttributes, patchAttributes, maxLevel);
 }
 

--- a/src/diagnostic/diagnostics.h
+++ b/src/diagnostic/diagnostics.h
@@ -8,6 +8,10 @@
 #error // PHARE_HAS_HIGHFIVE expected to be defined as bool
 #endif
 
+#if !defined(PHARE_DIAG_DOUBLES)
+#define PHARE_DIAG_DOUBLES false
+#endif
+
 #if PHARE_HAS_HIGHFIVE
 #include "highfive/H5Version.hpp"
 #define _PHARE_WITH_HIGHFIVE(...) __VA_ARGS__

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -11,3 +11,14 @@ set_target_properties(cpp
 )
 # this is on by default "pybind11_add_module" but can interfere with coverage so we disable it if coverage is enabled
 set_property(TARGET cpp PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  pybind11_add_module(cpp_dbg cpp_simulator.cpp)
+  target_link_libraries(cpp_dbg PUBLIC phare_simulator)
+  target_compile_options(cpp_dbg PRIVATE ${PHARE_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE} -DPHARE_DIAG_DOUBLES=1 -DPHARE_CPP_MOD_NAME=cpp_dbg)
+  set_target_properties(cpp_dbg
+      PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pybindlibs"
+  )
+  set_property(TARGET cpp_dbg PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})
+endif (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/python3/cpp_simulator.cpp
+++ b/src/python3/cpp_simulator.cpp
@@ -26,6 +26,12 @@
 #include "python3/patch_level.h"
 #include "python3/data_wrangler.h"
 
+
+#if !defined(PHARE_CPP_MOD_NAME)
+#define PHARE_CPP_MOD_NAME cpp
+#endif
+
+
 namespace py = pybind11;
 
 namespace PHARE::pydata
@@ -181,7 +187,7 @@ auto samrai_version()
 
 
 
-PYBIND11_MODULE(cpp, m)
+PYBIND11_MODULE(PHARE_CPP_MOD_NAME, m)
 {
     py::class_<SamraiLifeCycle, std::shared_ptr<SamraiLifeCycle>>(m, "SamraiLifeCycle")
         .def(py::init<>())

--- a/src/python3/particles.h
+++ b/src/python3/particles.h
@@ -17,7 +17,7 @@ template<std::size_t dim, typename PyArrayTuple>
 core::ContiguousParticlesView<dim> contiguousViewFrom(PyArrayTuple const& py_particles)
 {
     return {makeSpan<int>(std::get<0>(py_particles)),     // iCell
-            makeSpan<float>(std::get<1>(py_particles)),   // delta
+            makeSpan<double>(std::get<1>(py_particles)),  // delta
             makeSpan<double>(std::get<2>(py_particles)),  // weight
             makeSpan<double>(std::get<3>(py_particles)),  // charge
             makeSpan<double>(std::get<4>(py_particles))}; // v
@@ -26,11 +26,11 @@ core::ContiguousParticlesView<dim> contiguousViewFrom(PyArrayTuple const& py_par
 template<std::size_t dim>
 pyarray_particles_t makePyArrayTuple(std::size_t const size)
 {
-    return std::make_tuple(py_array_t<int>(size * dim),   // iCell
-                           py_array_t<float>(size * dim), // delta
-                           py_array_t<double>(size),      // weight
-                           py_array_t<double>(size),      // charge
-                           py_array_t<double>(size * 3)); // v
+    return std::make_tuple(py_array_t<int>(size * dim),    // iCell
+                           py_array_t<double>(size * dim), // delta
+                           py_array_t<double>(size),       // weight
+                           py_array_t<double>(size),       // charge
+                           py_array_t<double>(size * 3));  // v
 }
 
 

--- a/src/python3/pybind_def.h
+++ b/src/python3/pybind_def.h
@@ -17,11 +17,11 @@ template<typename T>
 using py_array_t = pybind11::array_t<T, pybind11::array::c_style | pybind11::array::forcecast>;
 
 
-using pyarray_particles_t = std::tuple<py_array_t<int32_t>, py_array_t<float>, py_array_t<double>,
+using pyarray_particles_t = std::tuple<py_array_t<int32_t>, py_array_t<double>, py_array_t<double>,
                                        py_array_t<double>, py_array_t<double>>;
 
 using pyarray_particles_crt
-    = std::tuple<py_array_t<int32_t> const&, py_array_t<float> const&, py_array_t<double> const&,
+    = std::tuple<py_array_t<int32_t> const&, py_array_t<double> const&, py_array_t<double> const&,
                  py_array_t<double> const&, py_array_t<double> const&>;
 
 template<typename PyArrayInfo>

--- a/src/simulator/CMakeLists.txt
+++ b/src/simulator/CMakeLists.txt
@@ -19,5 +19,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   phare_initializer
   phare_amr # for mpicc
   phare_diagnostic
+  Threads::Threads
   )
 

--- a/src/solver/solvers/solver_ppc.h
+++ b/src/solver/solvers/solver_ppc.h
@@ -30,6 +30,8 @@
 #include "core/data/grid/gridlayout_utils.h"
 
 
+#include "core/numerics/ion_updater/lol_ion_updater.h"
+
 #include <iomanip>
 
 namespace PHARE::solver
@@ -60,7 +62,7 @@ private:
     PHARE::core::Faraday<GridLayout> faraday_;
     PHARE::core::Ampere<GridLayout> ampere_;
     PHARE::core::Ohm<GridLayout> ohm_;
-    PHARE::core::IonUpdater<Ions, Electromag, GridLayout> ionUpdater_;
+    PHARE::core::LOL_IonUpdater<Ions, Electromag, GridLayout> ionUpdater_;
 
 
 

--- a/tests/core/data/particles/test_interop.cpp
+++ b/tests/core/data/particles/test_interop.cpp
@@ -32,7 +32,7 @@ TYPED_TEST(ParticleListTest, SoAandAoSInterop)
         view.weight = 1 + i;
         view.charge = 1 + i;
         view.iCell  = ConstArray<int, dim>(i);
-        view.delta  = ConstArray<float, dim>(i + 1);
+        view.delta  = ConstArray<double, dim>(i + 1);
         view.v      = ConstArray<double, 3>(view.weight + 2);
         EXPECT_EQ(std::copy(view), view);
     }

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -710,7 +710,7 @@ struct ACollectionOfParticles_2d : public ::testing::Test
             {
                 auto& part  = particles.emplace_back();
                 part.iCell  = {i, j};
-                part.delta  = ConstArray<float, dim>(.5);
+                part.delta  = ConstArray<double, dim>(.5);
                 part.weight = 1.;
                 part.v[0]   = +2.;
                 part.v[1]   = -1.;

--- a/tests/core/numerics/ion_updater/CMakeLists.txt
+++ b/tests/core/numerics/ion_updater/CMakeLists.txt
@@ -2,19 +2,27 @@ cmake_minimum_required (VERSION 3.9)
 
 project(test-updater)
 
-set(SOURCES test_updater.cpp)
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+function(_add_ion_updater_test src_name)
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-  ${GTEST_INCLUDE_DIRS}
+  add_executable(${src_name} ${src_name}.cpp)
+
+  target_include_directories(${src_name} PRIVATE
+    ${GTEST_INCLUDE_DIRS}
   )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
-  phare_core
-  phare_simulator
-  ${GTEST_LIBS})
+  target_link_directories(${src_name} PRIVATE
+    ${HDF5_LIBRARY_PATH}
+  )
 
-add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+  target_link_libraries(${src_name} PRIVATE
+    phare_core
+    phare_simulator
+    ${GTEST_LIBS})
 
+  add_no_mpi_phare_test(${src_name} ${CMAKE_CURRENT_BINARY_DIR})
 
+endfunction(_add_ion_updater_test)
+
+_add_ion_updater_test(test_updater)
+_add_ion_updater_test(test_lol_updater)

--- a/tests/core/numerics/ion_updater/test_lol_updater.cpp
+++ b/tests/core/numerics/ion_updater/test_lol_updater.cpp
@@ -1,0 +1,1041 @@
+#include "gtest/gtest.h"
+
+#include "phare_core.h"
+
+#include "core/numerics/ion_updater/lol_ion_updater.h"
+
+using namespace PHARE::core;
+
+
+
+using Param  = std::vector<double> const&;
+using Return = std::shared_ptr<PHARE::core::Span<double>>;
+
+Return density(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 1);
+}
+
+Return vx(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 0);
+}
+
+Return vy(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 0);
+}
+
+Return vz(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 0);
+}
+
+Return vthx(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), .1);
+}
+
+Return vthy(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), .1);
+}
+
+Return vthz(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), .1);
+}
+
+Return bx(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 0);
+}
+
+Return by(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 0);
+}
+
+Return bz(Param x)
+{
+    return std::make_shared<VectorSpan<double>>(x.size(), 0);
+}
+
+
+
+
+int nbrPartPerCell = 1000;
+
+using InitFunctionT = PHARE::initializer::InitFunction<1>;
+
+PHARE::initializer::PHAREDict createDict()
+{
+    PHARE::initializer::PHAREDict dict;
+
+    dict["simulation"]["algo"]["ion_updater"]["pusher"]["name"] = std::string{"modified_boris"};
+
+    dict["ions"]["nbrPopulations"]                          = int{2};
+    dict["ions"]["pop0"]["name"]                            = std::string{"protons"};
+    dict["ions"]["pop0"]["mass"]                            = 1.;
+    dict["ions"]["pop0"]["particle_initializer"]["name"]    = std::string{"maxwellian"};
+    dict["ions"]["pop0"]["particle_initializer"]["density"] = static_cast<InitFunctionT>(density);
+
+    dict["ions"]["pop0"]["particle_initializer"]["bulk_velocity_x"]
+        = static_cast<InitFunctionT>(vx);
+
+    dict["ions"]["pop0"]["particle_initializer"]["bulk_velocity_y"]
+        = static_cast<InitFunctionT>(vy);
+
+    dict["ions"]["pop0"]["particle_initializer"]["bulk_velocity_z"]
+        = static_cast<InitFunctionT>(vz);
+
+
+    dict["ions"]["pop0"]["particle_initializer"]["thermal_velocity_x"]
+        = static_cast<InitFunctionT>(vthx);
+
+    dict["ions"]["pop0"]["particle_initializer"]["thermal_velocity_y"]
+        = static_cast<InitFunctionT>(vthy);
+
+    dict["ions"]["pop0"]["particle_initializer"]["thermal_velocity_z"]
+        = static_cast<InitFunctionT>(vthz);
+
+
+    dict["ions"]["pop0"]["particle_initializer"]["nbr_part_per_cell"] = int{nbrPartPerCell};
+    dict["ions"]["pop0"]["particle_initializer"]["charge"]            = 1.;
+    dict["ions"]["pop0"]["particle_initializer"]["basis"]             = std::string{"cartesian"};
+
+    dict["ions"]["pop1"]["name"]                            = std::string{"alpha"};
+    dict["ions"]["pop1"]["mass"]                            = 1.;
+    dict["ions"]["pop1"]["particle_initializer"]["name"]    = std::string{"maxwellian"};
+    dict["ions"]["pop1"]["particle_initializer"]["density"] = static_cast<InitFunctionT>(density);
+
+    dict["ions"]["pop1"]["particle_initializer"]["bulk_velocity_x"]
+        = static_cast<InitFunctionT>(vx);
+
+    dict["ions"]["pop1"]["particle_initializer"]["bulk_velocity_y"]
+        = static_cast<InitFunctionT>(vy);
+
+    dict["ions"]["pop1"]["particle_initializer"]["bulk_velocity_z"]
+        = static_cast<InitFunctionT>(vz);
+
+
+    dict["ions"]["pop1"]["particle_initializer"]["thermal_velocity_x"]
+        = static_cast<InitFunctionT>(vthx);
+
+    dict["ions"]["pop1"]["particle_initializer"]["thermal_velocity_y"]
+        = static_cast<InitFunctionT>(vthy);
+
+    dict["ions"]["pop1"]["particle_initializer"]["thermal_velocity_z"]
+        = static_cast<InitFunctionT>(vthz);
+
+
+    dict["ions"]["pop1"]["particle_initializer"]["nbr_part_per_cell"] = int{nbrPartPerCell};
+    dict["ions"]["pop1"]["particle_initializer"]["charge"]            = 1.;
+    dict["ions"]["pop1"]["particle_initializer"]["basis"]             = std::string{"cartesian"};
+
+    dict["electromag"]["name"]             = std::string{"EM"};
+    dict["electromag"]["electric"]["name"] = std::string{"E"};
+    dict["electromag"]["magnetic"]["name"] = std::string{"B"};
+
+    dict["electromag"]["magnetic"]["initializer"]["x_component"] = static_cast<InitFunctionT>(bx);
+    dict["electromag"]["magnetic"]["initializer"]["y_component"] = static_cast<InitFunctionT>(by);
+    dict["electromag"]["magnetic"]["initializer"]["z_component"] = static_cast<InitFunctionT>(bz);
+
+    return dict;
+}
+static auto init_dict = createDict();
+
+
+
+template<std::size_t dim, std::size_t interporder>
+struct DimInterp
+{
+    static constexpr auto dimension    = dim;
+    static constexpr auto interp_order = interporder;
+};
+
+
+
+// the Electromag and Ions used in this test
+// need their resources pointers (Fields and ParticleArrays) to set manually
+// to buffers. ElectromagBuffer and IonsBuffer encapsulate these buffers
+
+
+
+template<std::size_t dim, std::size_t interp_order>
+struct ElectromagBuffers
+{
+    using PHARETypes = PHARE::core::PHARE_Types<dim, interp_order>;
+    using Field      = typename PHARETypes::Field_t;
+    using GridLayout = typename PHARETypes::GridLayout_t;
+    using Electromag = typename PHARETypes::Electromag_t;
+
+    Field Bx, By, Bz;
+    Field Ex, Ey, Ez;
+
+    ElectromagBuffers(GridLayout const& layout)
+        : Bx{"EM_B_x", HybridQuantity::Scalar::Bx, layout.allocSize(HybridQuantity::Scalar::Bx)}
+        , By{"EM_B_y", HybridQuantity::Scalar::By, layout.allocSize(HybridQuantity::Scalar::By)}
+        , Bz{"EM_B_z", HybridQuantity::Scalar::Bz, layout.allocSize(HybridQuantity::Scalar::Bz)}
+        , Ex{"EM_E_x", HybridQuantity::Scalar::Ex, layout.allocSize(HybridQuantity::Scalar::Ex)}
+        , Ey{"EM_E_x", HybridQuantity::Scalar::Ey, layout.allocSize(HybridQuantity::Scalar::Ey)}
+        , Ez{"EM_E_x", HybridQuantity::Scalar::Ez, layout.allocSize(HybridQuantity::Scalar::Ez)}
+    {
+    }
+
+    ElectromagBuffers(ElectromagBuffers const& source, GridLayout const& layout)
+        : Bx{"EM_B_x", HybridQuantity::Scalar::Bx, layout.allocSize(HybridQuantity::Scalar::Bx)}
+        , By{"EM_B_y", HybridQuantity::Scalar::By, layout.allocSize(HybridQuantity::Scalar::By)}
+        , Bz{"EM_B_z", HybridQuantity::Scalar::Bz, layout.allocSize(HybridQuantity::Scalar::Bz)}
+        , Ex{"EM_E_x", HybridQuantity::Scalar::Ex, layout.allocSize(HybridQuantity::Scalar::Ex)}
+        , Ey{"EM_E_x", HybridQuantity::Scalar::Ey, layout.allocSize(HybridQuantity::Scalar::Ey)}
+        , Ez{"EM_E_x", HybridQuantity::Scalar::Ez, layout.allocSize(HybridQuantity::Scalar::Ez)}
+    {
+        Bx.copyData(source.Bx);
+        By.copyData(source.By);
+        Bz.copyData(source.Bz);
+
+        Ex.copyData(source.Ex);
+        Ey.copyData(source.Ey);
+        Ez.copyData(source.Ez);
+    }
+
+
+    void setBuffers(Electromag& EM)
+    {
+        EM.B.setBuffer("EM_B_x", &Bx);
+        EM.B.setBuffer("EM_B_y", &By);
+        EM.B.setBuffer("EM_B_z", &Bz);
+
+        EM.E.setBuffer("EM_E_x", &Ex);
+        EM.E.setBuffer("EM_E_y", &Ey);
+        EM.E.setBuffer("EM_E_z", &Ez);
+    }
+};
+
+
+
+
+template<std::size_t dim, std::size_t interp_order>
+struct IonsBuffers
+{
+    using PHARETypes                 = PHARE::core::PHARE_Types<dim, interp_order>;
+    using Field                      = typename PHARETypes::Field_t;
+    using GridLayout                 = typename PHARETypes::GridLayout_t;
+    using Ions                       = typename PHARETypes::Ions_t;
+    using ParticleArray              = typename PHARETypes::ParticleArray_t;
+    using ParticleInitializerFactory = typename PHARETypes::ParticleInitializerFactory;
+
+    Field ionDensity;
+    Field protonDensity;
+    Field alphaDensity;
+    Field protonFx;
+    Field protonFy;
+    Field protonFz;
+    Field alphaFx;
+    Field alphaFy;
+    Field alphaFz;
+    Field Vx;
+    Field Vy;
+    Field Vz;
+
+    ParticleArray protonDomain;
+    ParticleArray protonPatchGhost;
+    ParticleArray protonLevelGhost;
+    ParticleArray protonLevelGhostOld;
+    ParticleArray protonLevelGhostNew;
+
+    ParticleArray alphaDomain;
+    ParticleArray alphaPatchGhost;
+    ParticleArray alphaLevelGhost;
+    ParticleArray alphaLevelGhostOld;
+    ParticleArray alphaLevelGhostNew;
+
+    ParticlesPack<ParticleArray> protonPack;
+    ParticlesPack<ParticleArray> alphaPack;
+
+    IonsBuffers(GridLayout const& layout)
+        : ionDensity{"rho", HybridQuantity::Scalar::rho,
+                     layout.allocSize(HybridQuantity::Scalar::rho)}
+        , protonDensity{"protons_rho", HybridQuantity::Scalar::rho,
+                        layout.allocSize(HybridQuantity::Scalar::rho)}
+        , alphaDensity{"alpha_rho", HybridQuantity::Scalar::rho,
+                       layout.allocSize(HybridQuantity::Scalar::rho)}
+        , protonFx{"protons_flux_x", HybridQuantity::Scalar::Vx,
+                   layout.allocSize(HybridQuantity::Scalar::Vx)}
+        , protonFy{"protons_flux_y", HybridQuantity::Scalar::Vy,
+                   layout.allocSize(HybridQuantity::Scalar::Vy)}
+        , protonFz{"protons_flux_z", HybridQuantity::Scalar::Vz,
+                   layout.allocSize(HybridQuantity::Scalar::Vz)}
+        , alphaFx{"alpha_flux_x", HybridQuantity::Scalar::Vx,
+                  layout.allocSize(HybridQuantity::Scalar::Vx)}
+        , alphaFy{"alpha_flux_y", HybridQuantity::Scalar::Vy,
+                  layout.allocSize(HybridQuantity::Scalar::Vy)}
+        , alphaFz{"alpha_flux_z", HybridQuantity::Scalar::Vz,
+                  layout.allocSize(HybridQuantity::Scalar::Vz)}
+        , Vx{"bulkVel_x", HybridQuantity::Scalar::Vx, layout.allocSize(HybridQuantity::Scalar::Vx)}
+        , Vy{"bulkVel_y", HybridQuantity::Scalar::Vy, layout.allocSize(HybridQuantity::Scalar::Vy)}
+        , Vz{"bulkVel_z", HybridQuantity::Scalar::Vz, layout.allocSize(HybridQuantity::Scalar::Vz)}
+
+    {
+        protonPack.domainParticles        = &protonDomain;
+        protonPack.patchGhostParticles    = &protonPatchGhost;
+        protonPack.levelGhostParticles    = &protonLevelGhost;
+        protonPack.levelGhostParticlesOld = &protonLevelGhostOld;
+        protonPack.levelGhostParticlesNew = &protonLevelGhostNew;
+        alphaPack.domainParticles         = &alphaDomain;
+        alphaPack.patchGhostParticles     = &alphaPatchGhost;
+        alphaPack.levelGhostParticles     = &alphaLevelGhost;
+        alphaPack.levelGhostParticlesOld  = &alphaLevelGhostOld;
+        alphaPack.levelGhostParticlesNew  = &alphaLevelGhostNew;
+    }
+
+
+    IonsBuffers(IonsBuffers const& source, GridLayout const& layout)
+        : ionDensity{"rho", HybridQuantity::Scalar::rho,
+                     layout.allocSize(HybridQuantity::Scalar::rho)}
+        , protonDensity{"protons_rho", HybridQuantity::Scalar::rho,
+                        layout.allocSize(HybridQuantity::Scalar::rho)}
+        , alphaDensity{"alpha_rho", HybridQuantity::Scalar::rho,
+                       layout.allocSize(HybridQuantity::Scalar::rho)}
+        , protonFx{"protons_flux_x", HybridQuantity::Scalar::Vx,
+                   layout.allocSize(HybridQuantity::Scalar::Vx)}
+        , protonFy{"protons_flux_y", HybridQuantity::Scalar::Vy,
+                   layout.allocSize(HybridQuantity::Scalar::Vy)}
+        , protonFz{"protons_flux_z", HybridQuantity::Scalar::Vz,
+                   layout.allocSize(HybridQuantity::Scalar::Vz)}
+        , alphaFx{"alpha_flux_x", HybridQuantity::Scalar::Vx,
+                  layout.allocSize(HybridQuantity::Scalar::Vx)}
+        , alphaFy{"alpha_flux_y", HybridQuantity::Scalar::Vy,
+                  layout.allocSize(HybridQuantity::Scalar::Vy)}
+        , alphaFz{"alpha_flux_z", HybridQuantity::Scalar::Vz,
+                  layout.allocSize(HybridQuantity::Scalar::Vz)}
+        , Vx{"bulkVel_x", HybridQuantity::Scalar::Vx, layout.allocSize(HybridQuantity::Scalar::Vx)}
+        , Vy{"bulkVel_y", HybridQuantity::Scalar::Vy, layout.allocSize(HybridQuantity::Scalar::Vy)}
+        , Vz{"bulkVel_z", HybridQuantity::Scalar::Vz, layout.allocSize(HybridQuantity::Scalar::Vz)}
+        , protonDomain{source.protonDomain}
+        , protonPatchGhost{source.protonPatchGhost}
+        , protonLevelGhost{source.protonLevelGhost}
+        , protonLevelGhostOld{source.protonLevelGhostOld}
+        , protonLevelGhostNew{source.protonLevelGhostNew}
+        , alphaDomain{source.alphaDomain}
+        , alphaPatchGhost{source.alphaPatchGhost}
+        , alphaLevelGhost{source.alphaLevelGhost}
+        , alphaLevelGhostOld{source.alphaLevelGhostOld}
+        , alphaLevelGhostNew{source.alphaLevelGhostNew}
+
+    {
+        ionDensity.copyData(source.ionDensity);
+        protonDensity.copyData(source.protonDensity);
+        alphaDensity.copyData(source.alphaDensity);
+
+        protonFx.copyData(source.protonFx);
+        protonFy.copyData(source.protonFy);
+        protonFz.copyData(source.protonFz);
+
+        alphaFx.copyData(source.alphaFx);
+        alphaFy.copyData(source.alphaFy);
+        alphaFz.copyData(source.alphaFz);
+
+        Vx.copyData(source.Vx);
+        Vy.copyData(source.Vy);
+        Vz.copyData(source.Vz);
+
+        protonPack.domainParticles        = &protonDomain;
+        protonPack.patchGhostParticles    = &protonPatchGhost;
+        protonPack.levelGhostParticles    = &protonLevelGhost;
+        protonPack.levelGhostParticlesOld = &protonLevelGhostOld;
+        protonPack.levelGhostParticlesNew = &protonLevelGhostNew;
+        alphaPack.domainParticles         = &alphaDomain;
+        alphaPack.patchGhostParticles     = &alphaPatchGhost;
+        alphaPack.levelGhostParticles     = &alphaLevelGhost;
+        alphaPack.levelGhostParticlesOld  = &alphaLevelGhostOld;
+        alphaPack.levelGhostParticlesNew  = &alphaLevelGhostNew;
+    }
+
+    void setBuffers(Ions& ions)
+    {
+        ions.setBuffer("rho", &ionDensity);
+        auto& v = ions.velocity();
+        v.setBuffer("bulkVel_x", &Vx);
+        v.setBuffer("bulkVel_y", &Vy);
+        v.setBuffer("bulkVel_z", &Vz);
+
+        auto& populations = ions.getRunTimeResourcesUserList();
+
+        populations[0].setBuffer("protons_rho", &protonDensity);
+        populations[0].flux().setBuffer("protons_flux_x", &protonFx);
+        populations[0].flux().setBuffer("protons_flux_y", &protonFy);
+        populations[0].flux().setBuffer("protons_flux_z", &protonFz);
+
+
+        populations[0].setBuffer("protons", &protonPack);
+
+        populations[1].setBuffer("alpha_rho", &alphaDensity);
+        populations[1].flux().setBuffer("alpha_flux_x", &alphaFx);
+        populations[1].flux().setBuffer("alpha_flux_y", &alphaFy);
+        populations[1].flux().setBuffer("alpha_flux_z", &alphaFz);
+
+
+        populations[1].setBuffer("alpha", &alphaPack);
+    }
+};
+
+
+
+
+template<typename DimInterpT>
+struct LOL_IonUpdaterTest : public ::testing::Test
+{
+    static constexpr auto dim          = DimInterpT::dimension;
+    static constexpr auto interp_order = DimInterpT::interp_order;
+    using PHARETypes                   = PHARE::core::PHARE_Types<dim, interp_order>;
+    using Ions                         = typename PHARETypes::Ions_t;
+    using Electromag                   = typename PHARETypes::Electromag_t;
+    using GridLayout    = typename PHARE::core::GridLayout<GridLayoutImplYee<dim, interp_order>>;
+    using ParticleArray = typename PHARETypes::ParticleArray_t;
+    using ParticleInitializerFactory = typename PHARETypes::ParticleInitializerFactory;
+
+    using LOL_IonUpdater = typename PHARE::core::LOL_IonUpdater<Ions, Electromag, GridLayout>;
+
+
+    double dt{0.01};
+
+    // grid configuration
+    std::array<int, dim> ncells;
+    GridLayout layout;
+
+
+    // data for electromagnetic fields
+    using Field    = typename PHARETypes::Field_t;
+    using VecField = typename PHARETypes::VecField_t;
+
+    ElectromagBuffers<dim, interp_order> emBuffers;
+    IonsBuffers<dim, interp_order> ionsBuffers;
+
+    Electromag EM{init_dict["electromag"]};
+    Ions ions{init_dict["ions"]};
+
+
+
+    LOL_IonUpdaterTest()
+        : ncells{100}
+        , layout{{0.1}, {100u}, {{0.}}}
+        , emBuffers{layout}
+        , ionsBuffers{layout}
+    {
+        emBuffers.setBuffers(EM);
+        ionsBuffers.setBuffers(ions);
+
+
+        // ok all resources pointers are set to buffers
+        // now let's initialize Electromag fields to user input functions
+        // and ion population particles to user supplied moments
+
+
+        EM.initialize(layout);
+        for (auto& pop : ions)
+        {
+            auto const& info         = pop.particleInitializerInfo();
+            auto particleInitializer = ParticleInitializerFactory::create(info);
+            particleInitializer->loadParticles(pop.domainParticles(), layout);
+        }
+
+
+        // now all domain particles are loaded we need to manually insert
+        // ghost particles (this is in reality SAMRAI's job)
+        // these are needed if we want all used nodes to be complete
+
+
+        // in 1D we assume left border is touching the level border
+        // and right is touching another patch
+        // so on the left no patchGhost but levelGhost(and old and new)
+        // on the right no levelGhost but patchGhosts
+
+
+        for (auto& pop : ions)
+        {
+            if constexpr (dim == 1)
+            {
+                int firstPhysCell = layout.physicalStartIndex(QtyCentering::dual, Direction::X);
+                int lastPhysCell  = layout.physicalEndIndex(QtyCentering::dual, Direction::X);
+                auto firstAMRCell = layout.localToAMR(Point{firstPhysCell});
+                auto lastAMRCell  = layout.localToAMR(Point{lastPhysCell});
+
+                // we need to put levelGhost particles in the cell just to the
+                // left of the first cell. In reality these particles should
+                // come from splitting particles of the next coarser level
+                // in this test we just copy those of the first cell
+                // we also assume levelGhostOld and New are the same particles
+                // for simplicity
+
+                auto& domainPart        = pop.domainParticles();
+                auto& levelGhostPartOld = pop.levelGhostParticlesOld();
+                auto& levelGhostPartNew = pop.levelGhostParticlesNew();
+                auto& levelGhostPart    = pop.levelGhostParticles();
+                auto& patchGhostPart    = pop.patchGhostParticles();
+
+
+                std::copy_if(std::begin(domainPart), std::end(domainPart),
+                             std::back_inserter(levelGhostPartOld),
+                             [&firstAMRCell](auto const& particle) {
+                                 if constexpr (interp_order == 1)
+                                 {
+                                     return particle.iCell[0] == firstAMRCell[0];
+                                 }
+                                 else if constexpr (interp_order == 2 or interp_order == 3)
+                                 {
+                                     return (particle.iCell[0] == firstAMRCell[0])
+                                            || (particle.iCell[0] == firstAMRCell[0] + 1);
+                                 }
+                             });
+
+                // copies need to be put in the ghost cell
+                // we have copied particles be now their iCell needs to be udpated
+                // our choice is :
+                //
+                // first order:
+                //
+                //   ghost| domain...
+                // [-----]|[-----][-----][-----][-----][-----]
+                //     ^      v
+                //     |      |
+                //     -------|
+                //
+                // second and third order:
+
+                //   ghost        | domain...
+                // [-----]|[-----][-----][-----][-----][-----][-----]
+                //     ^      ^       v     v
+                //     |      |       |     |
+                //     -------|-------|     |
+                //            ---------------
+                std::transform(std::begin(levelGhostPartOld), std::end(levelGhostPartOld),
+                               std::begin(levelGhostPartOld), [](auto& part) {
+                                   if constexpr (interp_order == 2 or interp_order == 3)
+                                   {
+                                       part.iCell[0] = part.iCell[0] - 2;
+                                   }
+                                   else if constexpr (interp_order == 1)
+                                   {
+                                       part.iCell[0] = part.iCell[0] - 1;
+                                   }
+                                   return part;
+                               });
+
+
+                std::copy(std::begin(levelGhostPartOld), std::end(levelGhostPartOld),
+                          std::back_inserter(levelGhostPartNew));
+
+
+                std::copy(std::begin(levelGhostPartOld), std::end(levelGhostPartOld),
+                          std::back_inserter(levelGhostPart));
+
+
+                // now let's create patchGhostParticles on the right of the domain
+                // by copying those on the last cell
+
+                std::copy_if(std::begin(domainPart), std::end(domainPart),
+                             std::back_inserter(patchGhostPart),
+                             [&lastAMRCell](auto const& particle) {
+                                 if constexpr (interp_order == 1)
+                                 {
+                                     return particle.iCell[0] == lastAMRCell[0];
+                                 }
+                                 else if constexpr (interp_order == 2 or interp_order == 3)
+                                 {
+                                     return (particle.iCell[0] == lastAMRCell[0])
+                                            || (particle.iCell[0] == lastAMRCell[0] - 1);
+                                 }
+                             });
+
+
+                std::transform(std::begin(patchGhostPart), std::end(patchGhostPart),
+                               std::begin(patchGhostPart), [](auto& part) {
+                                   if constexpr (interp_order == 2 or interp_order == 3)
+                                   {
+                                       part.iCell[0] = part.iCell[0] + 2;
+                                   }
+                                   else if constexpr (interp_order == 1)
+                                   {
+                                       part.iCell[0] = part.iCell[0] + 1;
+                                   }
+                                   return part;
+                               });
+
+
+            } // end 1D
+        }     // end pop loop
+        PHARE::core::depositParticles(ions, layout, Interpolator<dim, interp_order>{},
+                                      PHARE::core::DomainDeposit{});
+
+        PHARE::core::depositParticles(ions, layout, Interpolator<dim, interp_order>{},
+                                      PHARE::core::PatchGhostDeposit{});
+
+        PHARE::core::depositParticles(ions, layout, Interpolator<dim, interp_order>{},
+                                      PHARE::core::LevelGhostDeposit{});
+
+
+        ions.computeDensity();
+        ions.computeBulkVelocity();
+    } // end Ctor
+
+
+
+    void fillIonsMomentsGhosts()
+    {
+        using Interpolator = typename LOL_IonUpdater::Interpolator;
+        Interpolator interpolate;
+
+        for (auto& pop : this->ions)
+        {
+            interpolate(std::begin(pop.patchGhostParticles()), std::end(pop.patchGhostParticles()),
+                        pop.density(), pop.flux(), layout);
+
+            double alpha = 0.5;
+            interpolate(std::begin(pop.levelGhostParticlesNew()),
+                        std::end(pop.levelGhostParticlesNew()), pop.density(), pop.flux(), layout,
+                        /*coef = */ alpha);
+
+
+            interpolate(std::begin(pop.levelGhostParticlesOld()),
+                        std::end(pop.levelGhostParticlesOld()), pop.density(), pop.flux(), layout,
+                        /*coef = */ (1. - alpha));
+        }
+    }
+
+
+
+    void checkMomentsHaveEvolved(IonsBuffers<dim, interp_order> const& ionsBufferCpy)
+    {
+        auto& populations = this->ions.getRunTimeResourcesUserList();
+
+        auto& protonDensity = populations[0].density();
+        auto& protonFx      = populations[0].flux().getComponent(Component::X);
+        auto& protonFy      = populations[0].flux().getComponent(Component::Y);
+        auto& protonFz      = populations[0].flux().getComponent(Component::Z);
+
+        auto& alphaDensity = populations[1].density();
+        auto& alphaFx      = populations[1].flux().getComponent(Component::X);
+        auto& alphaFy      = populations[1].flux().getComponent(Component::Y);
+        auto& alphaFz      = populations[1].flux().getComponent(Component::Z);
+
+        auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);
+        auto ix1 = this->layout.physicalEndIndex(QtyCentering::primal, Direction::X);
+
+        auto nonZero = [&](auto const& field) {
+            auto sum = 0.;
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                sum += std::abs(field(ix));
+            }
+            EXPECT_GT(sum, 0.);
+        };
+
+        auto check = [&](auto const& newField, auto const& originalField) {
+            nonZero(newField);
+            nonZero(originalField);
+            for (auto ix = ix0; ix <= ix1; ++ix)
+            {
+                auto evolution = std::abs(newField(ix) - originalField(ix));
+                EXPECT_TRUE(
+                    evolution
+                    > 0.0); //  should check that moments are still compatible with user inputs also
+                if (evolution <= 0.0)
+                    std::cout << "after update : " << newField(ix)
+                              << " before update : " << originalField(ix)
+                              << " evolution : " << evolution << " ix : " << ix << "\n";
+            }
+        };
+
+        check(protonDensity, ionsBufferCpy.protonDensity);
+        check(protonFx, ionsBufferCpy.protonFy);
+        check(protonFy, ionsBufferCpy.protonFy);
+        check(protonFz, ionsBufferCpy.protonFz);
+
+        check(alphaDensity, ionsBufferCpy.alphaDensity);
+        check(alphaFx, ionsBufferCpy.alphaFy);
+        check(alphaFy, ionsBufferCpy.alphaFy);
+        check(alphaFz, ionsBufferCpy.alphaFz);
+
+        check(ions.density(), ionsBufferCpy.ionDensity);
+        check(ions.velocity().getComponent(Component::X), ionsBufferCpy.Vx);
+        check(ions.velocity().getComponent(Component::Y), ionsBufferCpy.Vy);
+        check(ions.velocity().getComponent(Component::Z), ionsBufferCpy.Vz);
+    }
+
+
+
+    void checkDensityIsAsPrescribed()
+    {
+        auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);
+        auto ix1 = this->layout.physicalEndIndex(QtyCentering::primal, Direction::X);
+
+        auto check = [&](auto const& density, auto const& function) {
+            std::vector<std::size_t> ixes;
+            std::vector<double> x;
+
+            for (auto ix = ix0; ix < ix1; ++ix)
+            {
+                ixes.emplace_back(ix);
+                x.emplace_back(layout.cellCenteredCoordinates(ix)[0]);
+            }
+
+            auto functionXPtr = function(x); // keep alive
+            EXPECT_EQ(functionXPtr->size(), (ix1 - ix0));
+
+            auto& functionX = *functionXPtr;
+
+            for (std::size_t i = 0; i < functionX.size(); i++)
+            {
+                auto ix   = ixes[i];
+                auto diff = std::abs(density(ix) - functionX[i]);
+
+                EXPECT_GE(0.07, diff);
+
+                if (diff >= 0.07)
+                    std::cout << "actual : " << density(ix) << " prescribed : " << functionX[i]
+                              << " diff : " << diff << " ix : " << ix << "\n";
+            }
+        };
+
+        auto& populations   = this->ions.getRunTimeResourcesUserList();
+        auto& protonDensity = populations[0].density();
+        auto& alphaDensity  = populations[1].density();
+
+        check(protonDensity, density);
+        check(alphaDensity, density);
+    }
+};
+
+
+
+using DimInterps = ::testing::Types<DimInterp<1, 1>, DimInterp<1, 2>, DimInterp<1, 3>>;
+
+
+TYPED_TEST_SUITE(LOL_IonUpdaterTest, DimInterps);
+
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, ionUpdaterTakesPusherParamsFromPHAREDictAtConstruction)
+{
+    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater ionUpdater{
+        init_dict["simulation"]["algo"]["ion_updater"]};
+}
+
+
+// the following 3 tests are testing the fixture is well configured.
+
+
+TYPED_TEST(LOL_IonUpdaterTest, loadsDomainPatchAndLevelGhostParticles)
+{
+    auto check = [this](std::size_t nbrGhostCells, auto& pop) {
+        EXPECT_EQ(this->layout.nbrCells()[0] * nbrPartPerCell, pop.domainParticles().size());
+        EXPECT_EQ(nbrGhostCells * nbrPartPerCell, pop.patchGhostParticles().size());
+        EXPECT_EQ(nbrGhostCells * nbrPartPerCell, pop.levelGhostParticlesOld().size());
+        EXPECT_EQ(nbrGhostCells * nbrPartPerCell, pop.levelGhostParticlesNew().size());
+        EXPECT_EQ(nbrGhostCells * nbrPartPerCell, pop.levelGhostParticles().size());
+    };
+
+
+    if constexpr (TypeParam::dimension == 1)
+    {
+        for (auto& pop : this->ions)
+        {
+            if constexpr (TypeParam::interp_order == 1)
+            {
+                check(1, pop);
+            }
+            else if constexpr (TypeParam::interp_order == 2 or TypeParam::interp_order == 3)
+            {
+                check(2, pop);
+            }
+        }
+    }
+}
+
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, loadsPatchGhostParticlesOnRightGhostArea)
+{
+    int lastPhysCell = this->layout.physicalEndIndex(QtyCentering::dual, Direction::X);
+    auto lastAMRCell = this->layout.localToAMR(Point{lastPhysCell});
+
+    if constexpr (TypeParam::dimension == 1)
+    {
+        for (auto& pop : this->ions)
+        {
+            if constexpr (TypeParam::interp_order == 1)
+            {
+                for (auto const& part : pop.patchGhostParticles())
+                {
+                    EXPECT_EQ(lastAMRCell[0] + 1, part.iCell[0]);
+                }
+            }
+            else if constexpr (TypeParam::interp_order == 2 or TypeParam::interp_order == 3)
+            {
+                typename LOL_IonUpdaterTest<TypeParam>::ParticleArray copy{
+                    pop.patchGhostParticles()};
+                auto firstInOuterMostCell = std::partition(
+                    std::begin(copy), std::end(copy), [&lastAMRCell](auto const& particle) {
+                        return particle.iCell[0] == lastAMRCell[0] + 1;
+                    });
+                EXPECT_EQ(nbrPartPerCell, std::distance(std::begin(copy), firstInOuterMostCell));
+                EXPECT_EQ(nbrPartPerCell, std::distance(firstInOuterMostCell, std::end(copy)));
+            }
+        }
+    }
+}
+
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, loadsLevelGhostParticlesOnLeftGhostArea)
+{
+    int firstPhysCell = this->layout.physicalStartIndex(QtyCentering::dual, Direction::X);
+    auto firstAMRCell = this->layout.localToAMR(Point{firstPhysCell});
+
+    if constexpr (TypeParam::dimension == 1)
+    {
+        for (auto& pop : this->ions)
+        {
+            if constexpr (TypeParam::interp_order == 1)
+            {
+                for (auto const& part : pop.levelGhostParticles())
+                {
+                    EXPECT_EQ(firstAMRCell[0] - 1, part.iCell[0]);
+                }
+            }
+            else if constexpr (TypeParam::interp_order == 2 or TypeParam::interp_order == 3)
+            {
+                typename LOL_IonUpdaterTest<TypeParam>::ParticleArray copy{
+                    pop.levelGhostParticles()};
+                auto firstInOuterMostCell = std::partition(
+                    std::begin(copy), std::end(copy), [&firstAMRCell](auto const& particle) {
+                        return particle.iCell[0] == firstAMRCell[0] - 1;
+                    });
+                EXPECT_EQ(nbrPartPerCell, std::distance(std::begin(copy), firstInOuterMostCell));
+                EXPECT_EQ(nbrPartPerCell, std::distance(firstInOuterMostCell, std::end(copy)));
+            }
+        }
+    }
+}
+
+
+
+
+// start of PHARE TESTS
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, particlesUntouchedInMomentOnlyMode)
+{
+    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater ionUpdater{
+        init_dict["simulation"]["algo"]["ion_updater"]};
+
+    IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
+
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
+
+
+    auto& populations = this->ions.getRunTimeResourcesUserList();
+
+    auto checkIsUnTouched = [](auto const& original, auto const& cpy) {
+        // no particles should have moved, so none should have left the domain
+        EXPECT_EQ(cpy.size(), original.size());
+        for (std::size_t iPart = 0; iPart < original.size(); ++iPart)
+        {
+            EXPECT_EQ(cpy[iPart].iCell[0], original[iPart].iCell[0]);
+            EXPECT_DOUBLE_EQ(cpy[iPart].delta[0], original[iPart].delta[0]);
+
+            for (std::size_t iDir = 0; iDir < 3; ++iDir)
+            {
+                EXPECT_DOUBLE_EQ(cpy[iPart].v[iDir], original[iPart].v[iDir]);
+            }
+        }
+    };
+
+    checkIsUnTouched(populations[0].domainParticles(), ionsBufferCpy.protonDomain);
+    checkIsUnTouched(populations[0].patchGhostParticles(), ionsBufferCpy.protonPatchGhost);
+    checkIsUnTouched(populations[0].levelGhostParticles(), ionsBufferCpy.protonLevelGhost);
+    checkIsUnTouched(populations[0].levelGhostParticlesOld(), ionsBufferCpy.protonLevelGhostOld);
+    checkIsUnTouched(populations[0].levelGhostParticlesNew(), ionsBufferCpy.protonLevelGhostNew);
+
+    checkIsUnTouched(populations[1].domainParticles(), ionsBufferCpy.alphaDomain);
+    checkIsUnTouched(populations[1].patchGhostParticles(), ionsBufferCpy.alphaPatchGhost);
+    checkIsUnTouched(populations[1].levelGhostParticles(), ionsBufferCpy.alphaLevelGhost);
+    checkIsUnTouched(populations[1].levelGhostParticlesOld(), ionsBufferCpy.alphaLevelGhost);
+    checkIsUnTouched(populations[1].levelGhostParticlesNew(), ionsBufferCpy.alphaLevelGhost);
+}
+
+
+
+
+// TYPED_TEST(LOL_IonUpdaterTest, particlesAreChangedInParticlesAndMomentsMode)
+//{
+//    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater
+//    ionUpdater{init_dict["simulation"]["pusher"]};
+//
+//    IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
+//
+//    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+//                                 UpdaterMode::particles_and_moments);
+//
+//    this->fillIonsMomentsGhosts();
+//
+//    ionUpdater.updateIons(this->ions, this->layout);
+//
+//    auto& populations = this->ions.getRunTimeResourcesUserList();
+//
+//    EXPECT_NE(ionsBufferCpy.protonDomain.size(), populations[0].domainParticles().size());
+//    EXPECT_NE(ionsBufferCpy.alphaDomain.size(), populations[1].domainParticles().size());
+//
+//    // cannot think of anything else to check than checking that the number of particles
+//    // in the domain have changed after them having been pushed.
+//}
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, momentsAreChangedInParticlesAndMomentsMode)
+{
+    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater ionUpdater{
+        init_dict["simulation"]["algo"]["ion_updater"]};
+
+    IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
+
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::particles_and_moments);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
+
+    this->checkMomentsHaveEvolved(ionsBufferCpy);
+    this->checkDensityIsAsPrescribed();
+}
+
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, momentsAreChangedInMomentsOnlyMode)
+{
+    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater ionUpdater{
+        init_dict["simulation"]["algo"]["ion_updater"]};
+
+    IonsBuffers ionsBufferCpy{this->ionsBuffers, this->layout};
+
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
+
+    this->checkMomentsHaveEvolved(ionsBufferCpy);
+    this->checkDensityIsAsPrescribed();
+}
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, thatNoNaNsExistOnPhysicalNodesMoments)
+{
+    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater ionUpdater{
+        init_dict["simulation"]["algo"]["ion_updater"]};
+
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
+
+    auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);
+    auto ix1 = this->layout.physicalEndIndex(QtyCentering::primal, Direction::X);
+
+    for (auto& pop : this->ions)
+    {
+        for (auto ix = ix0; ix <= ix1; ++ix)
+        {
+            auto& density = pop.density();
+            auto& flux    = pop.flux();
+
+            auto& fx = flux.getComponent(Component::X);
+            auto& fy = flux.getComponent(Component::Y);
+            auto& fz = flux.getComponent(Component::Z);
+
+            EXPECT_FALSE(std::isnan(density(ix)));
+            EXPECT_FALSE(std::isnan(fx(ix)));
+            EXPECT_FALSE(std::isnan(fy(ix)));
+            EXPECT_FALSE(std::isnan(fz(ix)));
+        }
+    }
+}
+
+
+
+TYPED_TEST(LOL_IonUpdaterTest, thatUnusedMomentNodesAreNaN)
+{
+    typename LOL_IonUpdaterTest<TypeParam>::LOL_IonUpdater ionUpdater{
+        init_dict["simulation"]["algo"]["ion_updater"]};
+
+    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
+                                 UpdaterMode::moments_only);
+
+    this->fillIonsMomentsGhosts();
+
+    ionUpdater.updateIons(this->ions, this->layout);
+
+
+    auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);
+    auto ix1 = this->layout.physicalEndIndex(QtyCentering::primal, Direction::X);
+    auto ix2 = this->layout.ghostEndIndex(QtyCentering::primal, Direction::X);
+
+    for (auto& pop : this->ions)
+    {
+        for (auto ix = 0u; ix < ix0 - 1; ++ix) // leftGhostNodes
+        {
+            auto& density = pop.density();
+            auto& flux    = pop.flux();
+
+            auto& fx = flux.getComponent(Component::X);
+            auto& fy = flux.getComponent(Component::Y);
+            auto& fz = flux.getComponent(Component::Z);
+
+            EXPECT_TRUE(std::isnan(density(ix)));
+            EXPECT_TRUE(std::isnan(fx(ix)));
+            EXPECT_TRUE(std::isnan(fy(ix)));
+            EXPECT_TRUE(std::isnan(fz(ix)));
+        }
+
+        for (auto ix = ix1 + 1 + 1; ix <= ix2; ++ix)
+        {
+            auto& density = pop.density();
+            auto& flux    = pop.flux();
+
+            auto& fx = flux.getComponent(Component::X);
+            auto& fy = flux.getComponent(Component::Y);
+            auto& fz = flux.getComponent(Component::Z);
+
+            EXPECT_TRUE(std::isnan(density(ix)));
+            EXPECT_TRUE(std::isnan(fx(ix)));
+            EXPECT_TRUE(std::isnan(fy(ix)));
+            EXPECT_TRUE(std::isnan(fz(ix)));
+        }
+    }
+}
+
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/simulator/CMakeLists.txt
+++ b/tests/simulator/CMakeLists.txt
@@ -20,6 +20,8 @@ if(HighFive)
 
   add_python3_test(test_diagnostic_timestamps test_diagnostic_timestamps.py ${CMAKE_CURRENT_BINARY_DIR})
 
+  add_python3_test(pusher_kirov    test_kirov.py           ${CMAKE_CURRENT_BINARY_DIR})
+
 endif()
 
 add_python3_test(data-wrangler        data_wrangler.py        ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/simulator/data_wrangler.py
+++ b/tests/simulator/data_wrangler.py
@@ -3,7 +3,8 @@
 # formatted with black
 
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 from tests.simulator import populate_simulation
 import numpy as np
 from pyphare.simulator.simulator import Simulator

--- a/tests/simulator/refined_particle_nbr.py
+++ b/tests/simulator/refined_particle_nbr.py
@@ -2,7 +2,8 @@
 #
 # formatted with black
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 import os, sys, unittest, yaml
 import numpy as np

--- a/tests/simulator/refinement_boxes.py
+++ b/tests/simulator/refinement_boxes.py
@@ -2,7 +2,8 @@
 #
 # formatted with black
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 import unittest, os, pyphare.pharein as ph
 from datetime import datetime, timezone

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -1,5 +1,6 @@
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 from pyphare.simulator.simulator import Simulator, startMPI
 from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
@@ -390,6 +391,13 @@ class AdvanceTest(unittest.TestCase):
                         # overlap box must be shifted by -offset to select data in the patches
                         part1 = copy(pd1.dataset.select(boxm.shift(box, -offsets[0])))
                         part2 = copy(pd2.dataset.select(boxm.shift(box, -offsets[1])))
+
+                        def contains_duplicates(X):
+                            return len(np.unique(X)) != len(X)
+
+                        if contains_duplicates(part1.deltas) and contains_duplicates(part2.deltas):
+                            # https://github.com/PHAREHUB/PHARE/issues/513
+                            continue
 
                         idx1 = np.argsort(part1.iCells + part1.deltas)
                         idx2 = np.argsort(part2.iCells + part2.deltas)

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -7,10 +7,10 @@ from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
 from pyphare.pharein import MaxwellianFluidModel
 from pyphare.pharein.diagnostics import ParticleDiagnostics, FluidDiagnostics, ElectromagDiagnostics
 from pyphare.pharein import ElectronModel
-from pyphare.pharein.simulation import Simulation
+from pyphare.pharein.simulation import Simulation, supported_dimensions
 from pyphare.pharesee.geometry import level_ghost_boxes, hierarchy_overlaps
 from pyphare.core.gridlayout import yee_element_is_primal
-from pyphare.pharesee.particles import aggregate as aggregate_particles
+from pyphare.pharesee.particles import aggregate as aggregate_particles, any_assert as particles_any_assert
 import pyphare.core.box as boxm
 from pyphare.core.box import Box, Box1D
 import numpy as np
@@ -18,7 +18,6 @@ import unittest
 from ddt import ddt, data, unpack
 
 
-# AdvanceTest.test_field_level_ghosts_via_subcycles_and_coarser_interpolation_1
 
 @ddt
 class AdvanceTest(unittest.TestCase):
@@ -77,13 +76,13 @@ class AdvanceTest(unittest.TestCase):
             return 1/density(x)*(K - b2(x)*0.5)
 
         def vx(x):
-            return 0.
+            return 0.1
 
         def vy(x):
-            return 0.
+            return 0.1
 
         def vz(x):
-            return 0.
+            return 0.1
 
         def vthx(x):
             return T(x)
@@ -136,7 +135,7 @@ class AdvanceTest(unittest.TestCase):
                                     write_timestamps=timestamps,
                                     population_name=pop)
 
-        Simulator(global_vars.sim).initialize().run()
+        Simulator(global_vars.sim).run()
 
         eb_hier = None
         if qty in ["e", "eb"]:
@@ -392,31 +391,76 @@ class AdvanceTest(unittest.TestCase):
                         part1 = copy(pd1.dataset.select(boxm.shift(box, -offsets[0])))
                         part2 = copy(pd2.dataset.select(boxm.shift(box, -offsets[1])))
 
-                        def contains_duplicates(X):
-                            return len(np.unique(X)) != len(X)
-
-                        if contains_duplicates(part1.deltas) and contains_duplicates(part2.deltas):
-                            # https://github.com/PHAREHUB/PHARE/issues/513
-                            continue
-
                         idx1 = np.argsort(part1.iCells + part1.deltas)
                         idx2 = np.argsort(part2.iCells + part2.deltas)
 
-                        # if there is an overlap, there should be particles
-                        # in these cells
+                        # if there is an overlap, there should be particles in these cells
                         assert(len(idx1) >0)
                         assert(len(idx2) >0)
+                        assert(len(idx1) == len(idx2))
 
                         print("respectively {} and {} in overlaped patchdatas".format(len(idx1), len(idx2)))
 
                         # particle iCells are in their patch AMR space
                         # so we need to shift them by +offset to move them to the box space
-                        np.testing.assert_array_equal(part1.iCells[idx1]+offsets[0], part2.iCells[idx2]+offsets[1])
 
-                        self.assertTrue(np.allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12))
-                        self.assertTrue(np.allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12))
-                        self.assertTrue(np.allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12))
-                        self.assertTrue(np.allclose(part1.v[idx1,2], part2.v[idx2,2], atol=1e-12))
+                        # find difference in case of duplicates
+                        tmp = (part1.v[idx1,0] - part2.v[idx2,0])
+                        cell = np.where(tmp > 0)[0]
+                        duplicate_found = len(cell)
+                        if duplicate_found:
+                            cell = cell[0]
+
+                            assert dim == 1, "not sure this works in 2d"
+                            def pop_indicis(parts, idx):
+                                return parts.pop(np.unique(np.concatenate(
+                                  np.asarray([np.where(parts.deltas == part_delta)[0] for part_delta in [
+                                      parts.deltas[idx][cell - 1], parts.deltas[idx][cell], parts.deltas[idx][cell + 1]
+                                ]])).ravel()))
+
+                            particles_any_assert(pop_indicis(part1, idx1), pop_indicis(part2, idx2))
+
+                            # redo after removing indexes
+                            idx1 = np.argsort(part1.iCells + part1.deltas)
+                            idx2 = np.argsort(part2.iCells + part2.deltas)
+
+                        np.testing.assert_array_equal(part1.iCells[idx1]+offsets[0], part2.iCells[idx2]+offsets[1])
+                        np.testing.assert_allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12)
+                        np.testing.assert_allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12)
+                        np.testing.assert_allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12)
+                        np.testing.assert_allclose(part1.v[idx1,2], part2.v[idx2,2], atol=1e-12)
+
+
+
+
+
+
+    def test_L0_particle_number_conservation(self):
+        nbr_part_per_cell=100
+        cells=120
+        time_step_nbr=10
+        time_step=0.001
+
+        # to2d
+        for ndim in [1]:
+            n_particles = nbr_part_per_cell * (cells ** ndim)
+            for interp_order in [1, 2, 3]:
+                diag_outputs=f"phare_L0_particle_number_conservation_{ndim}_{interp_order}"
+                datahier = self.getHierarchy(interp_order, None, "particles", diag_outputs=diag_outputs,
+                                          time_step=time_step, time_step_nbr=time_step_nbr,
+                                          nbr_part_per_cell=nbr_part_per_cell, cells=cells)
+                for time_step_idx in range(time_step_nbr + 1):
+                    coarsest_time =  time_step_idx * time_step
+                    n_particles_at_t = 0
+                    for patch in datahier.level(0, coarsest_time).patches:
+                        n_particles_at_t += patch.patch_datas["protons_particles"].dataset[patch.box].size()
+                    self.assertEqual(n_particles, n_particles_at_t)
+
+
+
+
+
+
 
     @data(
       {"L0": [Box1D(10, 20)]},

--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -1,7 +1,8 @@
 
 #!/usr/bin/env python3
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 from tests.diagnostic import dump_all_diags
 from tests.simulator import populate_simulation
 from pyphare.pharein import ElectronModel

--- a/tests/simulator/test_diagnostics.py
+++ b/tests/simulator/test_diagnostics.py
@@ -2,7 +2,9 @@
 #!/usr/bin/env python3
 
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
+
 from tests.diagnostic import dump_all_diags
 from tests.simulator import populate_simulation
 from pyphare.pharein import ElectronModel

--- a/tests/simulator/test_diagnostics.py
+++ b/tests/simulator/test_diagnostics.py
@@ -66,7 +66,8 @@ def setup_model(ppc=100):
 
     model = ph.MaxwellianFluidModel(
         bx=bx, by=by, bz=bz,
-        protons={"charge": 1, "density": density, **vvv, "nbr_part_per_cell":ppc, "init": {"seed": 1337}}
+        protons={"mass":1, "charge": 1, "density": density, **vvv, "nbr_part_per_cell":ppc, "init": {"seed": 1337}},
+        alpha={"mass":4, "charge": 1, "density": density, **vvv, "nbr_part_per_cell":ppc, "init": {"seed": 2334}},
     )
     ElectronModel(closure="isothermal", Te=0.12)
     return model
@@ -171,7 +172,14 @@ class DiagnosticsTest(unittest.TestCase):
                 if h5_filepath.endswith("domain.h5"):
                     particle_files += 1
                     self.assertTrue("pop_mass" in h5_file.attrs)
-                    self.assertTrue(h5_file.attrs[ "pop_mass"] == 1)
+
+                    if "protons" in h5_filepath:
+                        self.assertTrue(h5_file.attrs[ "pop_mass"] == 1)
+                    elif "alpha" in h5_filepath:
+                        self.assertTrue(h5_file.attrs[ "pop_mass"] == 4)
+                    else:
+                        raise RuntimeError("Unknown population")
+
                     self.assertGreater(len(hier.level(0).patches), 0)
 
                     for patch in hier.level(0).patches:

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -1,5 +1,6 @@
 
-from pybindlibs import cpp
+from pyphare.cpp import cpp_lib
+cpp = cpp_lib()
 
 from pyphare.simulator.simulator import Simulator, startMPI
 from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
@@ -515,7 +516,7 @@ class InitializationTest(unittest.TestCase):
 
     def _test_patch_ghost_on_refined_level_case(self, has_patch_ghost, **kwargs):
         import pyphare.pharein as ph
-        from pybindlibs import cpp
+
         from pyphare.simulator.simulator import startMPI
 
         startMPI()

--- a/tests/simulator/test_kirov.py
+++ b/tests/simulator/test_kirov.py
@@ -1,0 +1,628 @@
+
+from pybindlibs import cpp
+
+from pyphare.simulator.simulator import Simulator, startMPI
+from pyphare.pharesee.hierarchy import hierarchy_from, merge_particles
+from pyphare.pharein import MaxwellianFluidModel
+from pyphare.pharein.diagnostics import ParticleDiagnostics, FluidDiagnostics, ElectromagDiagnostics
+from pyphare.pharein import ElectronModel
+from pyphare.pharein.simulation import Simulation
+from pyphare.pharesee.geometry import level_ghost_boxes, hierarchy_overlaps
+from pyphare.core.gridlayout import yee_element_is_primal
+from pyphare.pharesee.particles import aggregate as aggregate_particles
+import pyphare.core.box as boxm
+from pyphare.core.box import Box, Box1D
+import numpy as np
+import unittest
+from ddt import ddt, data, unpack
+
+
+# AdvanceTest.test_field_level_ghosts_via_subcycles_and_coarser_interpolation_1
+
+@ddt
+class AdvanceTest(unittest.TestCase):
+
+    def ddt_test_id(self):
+        return self._testMethodName.split("_")[-1]
+
+    def getHierarchy(self, interp_order, refinement_boxes, qty, nbr_part_per_cell=100,
+                     diag_outputs="phare_outputs",
+                     smallest_patch_size=5, largest_patch_size=20,
+                     cells=120, time_step=0.001, model_init={},
+                     dl=0.1, extra_diag_options={}, time_step_nbr=1, timestamps=None):
+
+        # not to conflict with test_advance.py
+        diag_outputs = f"kirov_{diag_outputs}"
+
+        from pyphare.pharein import global_vars
+        global_vars.sim = None
+        startMPI()
+        extra_diag_options["mode"] = "overwrite"
+        extra_diag_options["dir"] = diag_outputs
+        Simulation(
+            smallest_patch_size=smallest_patch_size,
+            largest_patch_size=largest_patch_size,
+            time_step_nbr=time_step_nbr,
+            time_step=time_step,
+            boundary_types="periodic",
+            cells=cells,
+            dl=dl,
+            interp_order=interp_order,
+            refinement_boxes=refinement_boxes,
+            particle_pusher="kirov",
+            diag_options={"format": "phareh5",
+                          "options": extra_diag_options}
+        )
+
+        def density(x):
+            return 1.
+
+        def S(x,x0,l):
+            return 0.5*(1+np.tanh((x-x0)/l))
+
+        def bx(x):
+            return 1.
+
+        def by(x):
+            L = global_vars.sim.simulation_domain()[0]
+            v1=-1
+            v2=1.
+            return v1 + (v2-v1)*(S(x,L*0.25,1) -S(x, L*0.75, 1))
+
+        def bz(x):
+            return 0.5
+
+        def b2(x):
+            return bx(x)**2 + by(x)**2 + bz(x)**2
+
+        def T(x):
+            K = 1
+            return 1/density(x)*(K - b2(x)*0.5)
+
+        def vx(x):
+            return 0.
+
+        def vy(x):
+            return 0.
+
+        def vz(x):
+            return 0.
+
+        def vthx(x):
+            return T(x)
+
+        def vthy(x):
+            return T(x)
+
+        def vthz(x):
+            return T(x)
+
+
+        MaxwellianFluidModel(bx=bx, by=by, bz=bz,
+                             protons={"charge": 1,
+                                      "density": density,
+                                      "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
+                                      "vthx": vthx, "vthy": vthy, "vthz": vthz,
+                                      "nbr_part_per_cell": nbr_part_per_cell,
+                                      "init": model_init})
+
+        ElectronModel(closure="isothermal", Te=0.12)
+
+        if timestamps is None:
+            timestamps = np.arange(0, global_vars.sim.final_time + global_vars.sim.time_step, global_vars.sim.time_step)
+
+        for quantity in ["E", "B"]:
+            ElectromagDiagnostics(
+                quantity=quantity,
+                write_timestamps=timestamps,
+                compute_timestamps=timestamps
+            )
+
+        for quantity in ["density", "bulkVelocity"]:
+            FluidDiagnostics(
+                quantity=quantity,
+                write_timestamps=timestamps,
+                compute_timestamps=timestamps
+            )
+
+        poplist = ["protons"]
+        for pop in poplist:
+            for quantity in ["density", "flux"]:
+                FluidDiagnostics(quantity=quantity,
+                                 write_timestamps=timestamps,
+                                 compute_timestamps=timestamps,
+                                 population_name=pop)
+
+            for quantity in ['domain', 'levelGhost', 'patchGhost']:
+                ParticleDiagnostics(quantity=quantity,
+                                    compute_timestamps=timestamps,
+                                    write_timestamps=timestamps,
+                                    population_name=pop)
+
+        Simulator(global_vars.sim).initialize().run()
+
+        eb_hier = None
+        if qty in ["e", "eb"]:
+            eb_hier = hierarchy_from(h5_filename=diag_outputs+"/EM_E.h5", hier=eb_hier)
+        if qty in ["b", "eb"]:
+            eb_hier = hierarchy_from(h5_filename=diag_outputs+"/EM_B.h5", hier=eb_hier)
+        if qty in ["e", "b", "eb"]:
+            return eb_hier
+
+        is_particle_type = qty == "particles" or qty == "particles_patch_ghost"
+
+        if is_particle_type:
+            particle_hier = None
+
+        if qty == "particles":
+            particle_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_pop_protons_domain.h5")
+            particle_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_pop_protons_levelGhost.h5", hier=particle_hier)
+
+        if is_particle_type:
+            particle_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_pop_protons_patchGhost.h5", hier=particle_hier)
+
+        if qty == "particles":
+            merge_particles(particle_hier)
+
+        if is_particle_type:
+            return particle_hier
+
+        if qty == "moments":
+            mom_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_density.h5")
+            mom_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_bulkVelocity.h5", hier=mom_hier)
+            mom_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_pop_protons_density.h5", hier=mom_hier)
+            mom_hier = hierarchy_from(h5_filename=diag_outputs+"/ions_pop_protons_flux.h5", hier=mom_hier)
+            return mom_hier
+
+
+
+    def _test_overlaped_fields_are_equal(self, time_step, time_step_nbr, datahier):
+        check=0
+        for time_step_idx in range(time_step_nbr + 1):
+            coarsest_time =  time_step_idx * time_step
+
+            for ilvl, overlaps in hierarchy_overlaps(datahier, coarsest_time).items():
+
+                for overlap in overlaps:
+
+                    pd1, pd2 = overlap["pdatas"]
+                    box      = overlap["box"]
+                    offsets  = overlap["offset"]
+
+                    self.assertEqual(pd1.quantity, pd2.quantity)
+
+                    if pd1.quantity == 'field':
+                        check+=1
+
+                        # we need to transform the AMR overlap box, which is thus
+                        # (because AMR) common to both pd1 and pd2 into local index
+                        # boxes that will allow to slice the data
+
+                        # the patchData ghost box that serves as a reference box
+                        # to transfrom AMR to local indexes first needs to be
+                        # shifted by the overlap offset associated to it
+                        # this is because the overlap box has been calculated from
+                        # the intersection of possibly shifted patch data ghost boxes
+
+                        loc_b1 = boxm.amr_to_local(box, boxm.shift(pd1.ghost_box, offsets[0]))
+                        loc_b2 = boxm.amr_to_local(box, boxm.shift(pd2.ghost_box, offsets[1]))
+
+                        data1 = pd1.dataset
+                        data2 = pd2.dataset
+
+                        slice1 = data1[loc_b1.lower[0]:loc_b1.upper[0] + 1]
+                        slice2 = data2[loc_b2.lower[0]:loc_b2.upper[0] + 1]
+
+                        try:
+                            np.testing.assert_allclose(slice1, slice2, atol=1e-6)
+                        except AssertionError as e:
+                            print("error", coarsest_time, overlap)
+                            raise e
+
+        self.assertGreater(check, time_step_nbr)
+        self.assertEqual(check % time_step_nbr, 0)
+
+
+    @data(
+        {"L0": [Box1D(10, 19)]},
+        {"L0": [Box1D(8, 20)]},
+    )
+    def test_overlaped_fields_are_equal(self, refinement_boxes):
+        dim = refinement_boxes["L0"][0].ndim
+        time_step_nbr=3
+        time_step=0.001
+        diag_outputs=f"phare_overlaped_fields_are_equal_{self.ddt_test_id()}"
+        for interp_order in [1, 2, 3]:
+            datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", diag_outputs=diag_outputs,
+                                      time_step=time_step, time_step_nbr=time_step_nbr)
+            self._test_overlaped_fields_are_equal(time_step, time_step_nbr, datahier)
+
+
+    @data(
+        {"L0": [Box1D(10, 19)]},
+        # {"L0": [Box2D(10, 19)]},
+        # {"L0": [Box3D(10, 19)]},
+    )
+    def test_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts(self, refinement_boxes):
+        from pyphare.pharein.simulation import check_patch_size
+
+        dim = refinement_boxes["L0"][0].ndim
+
+        cells = [30] * dim
+        time_step_nbr=3
+        time_step=0.001
+        diag_outputs=f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts{self.ddt_test_id()}"
+        for interp_order in [1, 2, 3]:
+            largest_patch_size, smallest_patch_size = check_patch_size(interp_order=interp_order, cells=cells)
+            datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", diag_outputs=diag_outputs,
+                                      smallest_patch_size=smallest_patch_size, largest_patch_size=smallest_patch_size,
+                                      time_step=time_step, time_step_nbr=time_step_nbr)
+            self._test_overlaped_fields_are_equal(time_step, time_step_nbr, datahier)
+
+
+
+
+
+    def _test_patch_ghost_particle_are_clone_of_overlaped_patch_domain_particles(self, dim, interp_order, refinement_boxes):
+        print("test_patch_ghost_particle_are_clone_of_overlaped_patch_domain_particles")
+        print("interporder : {}".format(interp_order))
+
+        time_step_nbr=3
+        time_step=0.001
+        diag_outputs=f"phare_patch_ghost_particle_are_clones_{self.ddt_test_id()}"
+        datahier = self.getHierarchy(interp_order, refinement_boxes, "particles", diag_outputs=diag_outputs,
+                                      time_step=time_step, time_step_nbr=time_step_nbr)
+
+        for time_step_idx in range(time_step_nbr + 1):
+            coarsest_time =  time_step_idx * time_step
+
+            overlaps = hierarchy_overlaps(datahier, coarsest_time)
+            for ilvl, lvl_overlaps in overlaps.items():
+                print("level {}".format(ilvl))
+                for overlap in lvl_overlaps:
+
+                    if ilvl != 0: #only root level tested here
+                        continue
+
+                    if "particles"  not in overlap["pdatas"][0].quantity :
+                        continue
+
+                    ref_pd, cmp_pd = overlap["pdatas"]
+
+                    box = overlap["box"]
+                    print("overlap box : {}, reference patchdata box : {}, ghostbox {},"
+                    " comp. patchdata box : {} ghostbox {}".format(box,ref_pd.box,ref_pd.ghost_box,cmp_pd.box, cmp_pd.ghost_box))
+                    offsets = overlap["offset"]
+
+                    # first let's shift the overlap box over the AMR
+                    # indices of the patchdata. The box has been created
+                    # by shifting the patchdata ghost box by 'offset' so here
+                    # the box is shifted by -offset to get over patchdata
+                    shift_refbox, shift_cmpbox = [boxm.shift(box, -off) for off in offsets]
+
+                    # the overlap box overlaps both ghost and domain cells
+                    # we need to extract the domain ones to later select domain
+                    # particles
+                    ovlped_refdom = ref_pd.box * shift_refbox
+                    ovlped_cmpdom = cmp_pd.box * shift_cmpbox
+
+                    # on lvl 0 patches are adjacent
+                    # therefore the overlap box must overlap the
+                    # patchData box. 1 cell in interporder1, 2 cells for higher
+                    assert(ovlped_cmpdom is not None)
+                    assert(ovlped_refdom is not None)
+
+                    refdomain = ref_pd.dataset.select(ovlped_refdom)
+                    cmpdomain = cmp_pd.dataset.select(ovlped_cmpdom)
+
+                    # now get the ghost cells of each patch data overlaped by
+                    # the overlap box. To do this we need to intersect the shifted
+                    # overlap box with the patchdata ghost box, and remove interior cells
+                    # note that in 1D we don't expect remove to return more than 1 box, hence [0]
+                    ovlped_refghost = boxm.remove(ref_pd.ghost_box * shift_refbox, ref_pd.box)[0]
+                    ovlped_cmpghost = boxm.remove(cmp_pd.ghost_box * shift_cmpbox, cmp_pd.box)[0]
+
+                    refghost  = ref_pd.dataset.select(ovlped_refghost)
+                    cmpghost  = cmp_pd.dataset.select(ovlped_cmpghost)
+
+                    print("ghost box {} has {} particles".format(ovlped_refghost, len(refghost.iCells)))
+                    print("ghost box {} has {} particles".format(ovlped_cmpghost, len(cmpghost.iCells)))
+
+                    # before comparing the particles we need to be sure particles of both patchdatas
+                    # are sorted in the same order. We do that by sorting by x position
+                    sort_refdomain_idx = np.argsort(refdomain.iCells + refdomain.deltas)
+                    sort_cmpdomain_idx = np.argsort(cmpdomain.iCells + cmpdomain.deltas)
+                    sort_refghost_idx = np.argsort(refghost.iCells + refghost.deltas)
+                    sort_cmpghost_idx = np.argsort(cmpghost.iCells + cmpghost.deltas)
+
+                    assert(sort_refdomain_idx.size != 0)
+                    assert(sort_cmpdomain_idx.size != 0)
+                    assert(sort_refdomain_idx.size != 0)
+                    assert(sort_cmpghost_idx.size != 0)
+
+                    np.testing.assert_allclose(refdomain.deltas[sort_refdomain_idx], cmpghost.deltas[sort_cmpghost_idx], atol=1e-12)
+                    np.testing.assert_allclose(cmpdomain.deltas[sort_cmpdomain_idx], refghost.deltas[sort_refghost_idx], atol=1e-12)
+
+
+    @data(
+      {"L0": [Box1D(10, 20)]},
+      {"L0": [Box1D(2, 12), Box1D(13, 25)]},
+    )
+    def test_patch_ghost_particle_are_clone_of_overlaped_patch_domain_particles(self, refinement_boxes):
+        dim = refinement_boxes["L0"][0].ndim
+        for interp_order in [1, 2, 3]:
+            self._test_patch_ghost_particle_are_clone_of_overlaped_patch_domain_particles(dim, interp_order=interp_order, refinement_boxes=refinement_boxes)
+
+
+
+    def _test_overlapped_particledatas_have_identical_particles(self, dim, interp_order, refinement_boxes):
+        print("test_overlapped_particledatas_have_identical_particles")
+        print("interporder : {}".format(interp_order))
+        from copy import copy
+
+        time_step_nbr=3
+        time_step=0.001
+        diag_outputs=f"phare_overlapped_particledatas_have_identical_particles_{self.ddt_test_id()}"
+        datahier = self.getHierarchy(interp_order, refinement_boxes, "particles", diag_outputs=diag_outputs,
+                                      time_step=time_step, time_step_nbr=time_step_nbr)
+
+        for time_step_idx in range(time_step_nbr + 1):
+            coarsest_time =  time_step_idx * time_step
+
+            overlaps = hierarchy_overlaps(datahier, coarsest_time)
+
+            for ilvl, lvl in datahier.patch_levels.items():
+
+                print("testing level {}".format(ilvl))
+                for overlap in overlaps[ilvl]:
+
+                    pd1, pd2 = overlap["pdatas"]
+                    box      = overlap["box"]
+                    offsets  = overlap["offset"]
+
+                    self.assertEqual(pd1.quantity, pd2.quantity)
+
+                    if "particles" in pd1.quantity:
+
+                        # the following uses 'offset', we need to remember that offset
+                        # is the quantity by which a patch has been moved to detect
+                        # overlap with the other one.
+                        # so shift by +offset when evaluating patch data in overlap box
+                        # index space, and by -offset when we want to shift box indexes
+                        # to the associated patch index space.
+
+                        # overlap box must be shifted by -offset to select data in the patches
+                        part1 = copy(pd1.dataset.select(boxm.shift(box, -offsets[0])))
+                        part2 = copy(pd2.dataset.select(boxm.shift(box, -offsets[1])))
+
+                        idx1 = np.argsort(part1.iCells + part1.deltas)
+                        idx2 = np.argsort(part2.iCells + part2.deltas)
+
+                        # if there is an overlap, there should be particles
+                        # in these cells
+                        assert(len(idx1) >0)
+                        assert(len(idx2) >0)
+
+                        print("respectively {} and {} in overlaped patchdatas".format(len(idx1), len(idx2)))
+
+                        # particle iCells are in their patch AMR space
+                        # so we need to shift them by +offset to move them to the box space
+                        np.testing.assert_array_equal(part1.iCells[idx1]+offsets[0], part2.iCells[idx2]+offsets[1])
+
+                        self.assertTrue(np.allclose(part1.deltas[idx1], part2.deltas[idx2], atol=1e-12))
+                        self.assertTrue(np.allclose(part1.v[idx1,0], part2.v[idx2,0], atol=1e-12))
+                        self.assertTrue(np.allclose(part1.v[idx1,1], part2.v[idx2,1], atol=1e-12))
+                        self.assertTrue(np.allclose(part1.v[idx1,2], part2.v[idx2,2], atol=1e-12))
+
+    @data(
+      {"L0": [Box1D(10, 20)]},
+      {"L0": [Box1D(2, 12), Box1D(13, 25)]},
+    )
+    def test_overlapped_particledatas_have_identical_particles(self, refinement_boxes):
+        dim = refinement_boxes["L0"][0].ndim
+        for interp_order in [1, 2, 3]:
+            self._test_overlapped_particledatas_have_identical_particles(dim, interp_order, refinement_boxes)
+
+
+
+
+    def _test_field_coarsening_via_subcycles(self, dim, interp_order, refinement_boxes):
+        print("test_field_coarsening_via_subcycles for dim/interp : {}/{}".format(dim, interp_order))
+
+        from tests.amr.data.field.coarsening.test_coarsen_field import coarsen
+        from pyphare.pharein import global_vars
+
+        time_step_nbr=3
+
+        diag_outputs=f"phare_outputs_subcycle_coarsening_{self.ddt_test_id()}"
+        datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", cells=30,
+                                      diag_outputs=diag_outputs, time_step=0.001,
+                                      extra_diag_options={"fine_dump_lvl_max": 10},
+                                      time_step_nbr=time_step_nbr, smallest_patch_size=5,
+                                      largest_patch_size=30)
+
+        lvl_steps = global_vars.sim.level_time_steps
+        print("LEVELSTEPS === ", lvl_steps)
+        assert len(lvl_steps) > 1, "this test makes no sense with only 1 level"
+
+        finestTimeStep = lvl_steps[-1]
+        secondFinestTimeStep = lvl_steps[-2]
+
+        finest_level_step_nbr = global_vars.sim.level_step_nbr[-1]
+        uniqTimes = set([0])
+
+        for step in range(1, finest_level_step_nbr + 1):
+            checkTime = datahier.format_timestamp(finestTimeStep * step)
+            self.assertIn(checkTime, datahier.times())
+            uniqTimes.add(checkTime)
+
+        self.assertEqual(len(uniqTimes), len(datahier.time_hier.items()))
+
+        syncSteps = global_vars.sim.level_step_nbr[-2] # ignore finest subcycles
+
+        # FIX THIS AFTER NO MORE REGRIDS
+        #  SEE: https://github.com/PHAREHUB/PHARE/issues/400
+        assert syncSteps % time_step_nbr == 0 # perfect division
+        startStep = int(syncSteps / time_step_nbr) + 1 # skip first coarsest step due to issue 400
+
+        for step in range(startStep, syncSteps + 1):
+            checkTime = datahier.format_timestamp(secondFinestTimeStep * step)
+            self.assertIn(checkTime, datahier.times())
+            nLevels = datahier.levelNbr(checkTime)
+            self.assertGreaterEqual(nLevels, 2)
+            levelNbrs = datahier.levelNbrs(checkTime)
+            finestLevelNbr = max(levelNbrs)
+            coarsestLevelNbr = min(levelNbrs)
+
+            for coarseLevelNbr in range(coarsestLevelNbr, finestLevelNbr):
+                coarsePatches = datahier.level(coarseLevelNbr, checkTime).patches
+                finePatches = datahier.level(coarseLevelNbr + 1, checkTime).patches
+
+                for coarsePatch in coarsePatches:
+                    for finePatch in finePatches:
+                        lvlOverlap = boxm.refine(coarsePatch.box, 2) * finePatch.box
+                        if lvlOverlap is not None:
+                            for EM in ["E", "B"]:
+                                for xyz in ["x", "y", "z"]:
+                                    qty = f"{EM}{xyz}"
+                                    coarse_pd = coarsePatch.patch_datas[qty]
+                                    fine_pd  = finePatch.patch_datas[qty]
+                                    coarseBox = boxm.coarsen(lvlOverlap, 2)
+
+                                    nGhosts = coarse_pd.layout.nbrGhostFor(qty)
+
+                                    coarse_pdDataset = coarse_pd.dataset[:]
+                                    fine_pdDataset = fine_pd.dataset[:]
+
+                                    coarseOffset = coarseBox.lower - coarse_pd.layout.box.lower
+                                    dataBox_lower = coarseOffset + nGhosts
+                                    dataBox = Box(dataBox_lower, dataBox_lower + coarseBox.shape - 1)
+
+                                    afterCoarse = np.copy(coarse_pdDataset)
+                                    afterCoarse[dataBox.lower[0] : dataBox.upper[0] + 1] = 0
+
+                                    coarsen(qty, coarse_pd.layout, fine_pd.layout, coarseBox, fine_pdDataset, afterCoarse)
+                                    np.testing.assert_allclose(coarse_pdDataset, afterCoarse, atol=1e-6)
+
+
+    @data(
+       ({"L0": {"B0": Box1D(10, 19)}}),
+       ({"L0": {"B0": Box1D(10, 14), "B1": Box1D(15, 19)}}),
+       ({"L0": {"B0": Box1D(6, 23)}}),
+       ({"L0": {"B0": Box1D( 2, 12), "B1": Box1D(13, 25)}}),
+       ({"L0": {"B0": Box1D( 5, 20)}, "L1": {"B0": Box1D(15, 19)}}),
+       ({"L0": {"B0": Box1D( 5, 20)}, "L1": {"B0": Box1D(12, 38)}, "L2": {"B0": Box1D(30, 52)} }),
+    )
+    def test_field_coarsening_via_subcycles(self, refinement_boxes):
+        dim = refinement_boxes["L0"]["B0"].ndim
+        self._test_field_coarsening_via_subcycles(dim, interp_order=1, refinement_boxes=refinement_boxes)
+
+
+
+
+    def _test_field_level_ghosts_via_subcycles_and_coarser_interpolation(self, ndim, interp_order, refinement_boxes):
+        """
+          This test runs two virtually identical simulations for one step.
+            L0_datahier has no refined levels
+            L0L1_datahier has one refined level
+
+          This is done to compare L0 values that haven't received the coarsened values of L1 because there is no L1,
+            to the level field ghost of L1 of L0L1_datahier
+
+          The simulations are no longer comparable after the first advance, so this test cannot work beyond that.
+        """
+
+        print("test_field_coarsening_via_subcycles for dim/interp : {}/{}".format(ndim, interp_order))
+
+        from tests.amr.data.field.refine.test_refine_field import refine_time_interpolate
+        from pyphare.pharein import global_vars
+
+        import random
+        rando = random.randint(0, 1e10)
+
+        def _getHier(diag_dir, boxes=[]):
+            return self.getHierarchy(interp_order, boxes, "eb", cells=30,
+                time_step_nbr=1, smallest_patch_size=5, largest_patch_size=30,
+                diag_outputs=diag_dir, extra_diag_options={"fine_dump_lvl_max": 10}, time_step=0.001,
+                model_init={"seed": rando}
+            )
+
+        def assert_time_in_hier(*ts):
+            for t in ts:
+                self.assertIn(L0L1_datahier.format_timestamp(t), L0L1_datahier.times())
+
+        L0_datahier = _getHier(f"phare_lvl_ghost_interpolation_L0_diags_{self.ddt_test_id()}")
+        L0L1_datahier = _getHier(
+          f"phare_lvl_ghost_interpolation_L0L1_diags_{self.ddt_test_id()}", refinement_boxes
+        )
+
+        lvl_steps = global_vars.sim.level_time_steps
+        assert len(lvl_steps) == 2, "this test is only configured for L0 -> L1 refinement comparisons"
+
+        coarse_ilvl = 0
+        fine_ilvl   = 1
+        coarsest_time_before = 0 # init
+        coarsest_time_after = coarsest_time_before + lvl_steps[coarse_ilvl]
+        assert_time_in_hier(coarsest_time_before, coarsest_time_after)
+
+        fine_subcycle_times = []
+        for fine_subcycle in range(global_vars.sim.level_step_nbr[fine_ilvl] + 1):
+            fine_subcycle_time   = coarsest_time_before + (lvl_steps[fine_ilvl] * fine_subcycle)
+            assert_time_in_hier(fine_subcycle_time)
+            fine_subcycle_times += [fine_subcycle_time]
+
+        quantities = [f"{EM}{xyz}" for EM in ["E", "B"] for xyz in ["x", "y", "z"]]
+        interpolated_fields = refine_time_interpolate(
+          L0_datahier, quantities, coarse_ilvl, coarsest_time_before, coarsest_time_after, fine_subcycle_times
+        )
+
+        checks = 0
+        for fine_subcycle_time in fine_subcycle_times:
+            fine_level_qty_ghost_boxes = level_ghost_boxes(L0L1_datahier, quantities, fine_ilvl, fine_subcycle_time)
+            for qty in quantities:
+                for fine_level_ghost_box_data in fine_level_qty_ghost_boxes[qty]:
+                    fine_subcycle_pd = fine_level_ghost_box_data["pdata"]
+                    for fine_level_ghost_box in fine_level_ghost_box_data["boxes"]:
+
+                        # trim the border level ghost nodes from the primal fields to ignore them in comparison checks
+                        fine_level_ghost_boxes = fine_level_ghost_box - boxm.grow(fine_subcycle_pd.box, fine_subcycle_pd.primal_directions())
+                        self.assertEqual(len(fine_level_ghost_boxes), 1) # should not be possibly > 1
+                        self.assertEqual(fine_level_ghost_boxes[0].shape, fine_level_ghost_box.shape - fine_subcycle_pd.primal_directions())
+                        fine_level_ghost_box = fine_level_ghost_boxes[0]
+
+                        upper_dims = fine_level_ghost_box.lower > fine_subcycle_pd.box.upper
+                        for refinedInterpolatedField in interpolated_fields[qty][fine_subcycle_time]:
+                            lvlOverlap = refinedInterpolatedField.box * fine_level_ghost_box
+                            if lvlOverlap is not None:
+
+                                fine_ghostbox_data = fine_subcycle_pd[fine_level_ghost_box]
+                                refinedInterpGhostBox_data = refinedInterpolatedField[fine_level_ghost_box]
+
+                                fine_ds = fine_subcycle_pd.dataset
+                                if fine_level_ghost_box.ndim == 1: # verify selecting start/end of L1 dataset from ghost box
+                                    if upper_dims[0]:
+                                        assert all(fine_ghostbox_data == fine_ds[-fine_ghostbox_data.shape[0]:])
+                                    else:
+                                        assert all(fine_ghostbox_data == fine_ds[:fine_ghostbox_data.shape[0]])
+
+                                assert refinedInterpGhostBox_data.shape == fine_subcycle_pd.ghosts_nbr
+                                assert fine_ghostbox_data.shape == fine_subcycle_pd.ghosts_nbr
+                                np.testing.assert_allclose(fine_ghostbox_data, refinedInterpGhostBox_data, atol=1e-7)
+                                checks += 1
+
+        self.assertGreater(checks, len(refinement_boxes["L0"]) * len(quantities))
+
+
+
+    @data( # only supports a hierarchy with 2 levels
+       ({"L0": [Box1D(5, 9)]}),
+       ({"L0": [Box1D(5, 24)]}),
+       ({"L0": [Box1D(5, 9), Box1D(20, 24)]}),
+    )
+    def test_field_level_ghosts_via_subcycles_and_coarser_interpolation(self, refinement_boxes):
+        dim = refinement_boxes["L0"][0].ndim
+        for interp in [1, 2, 3]:
+            self._test_field_level_ghosts_via_subcycles_and_coarser_interpolation(dim, interp, refinement_boxes)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bench/core/numerics/pusher/CMakeLists.txt
+++ b/tools/bench/core/numerics/pusher/CMakeLists.txt
@@ -2,4 +2,5 @@ cmake_minimum_required (VERSION 3.9)
 
 project(phare_bench_pusher)
 
-add_phare_cpp_benchmark(11 ${PROJECT_NAME} pusher ${CMAKE_CURRENT_BINARY_DIR})
+add_phare_cpp_benchmark(11 ${PROJECT_NAME} boris ${CMAKE_CURRENT_BINARY_DIR})
+add_phare_cpp_benchmark(11 ${PROJECT_NAME} kirov ${CMAKE_CURRENT_BINARY_DIR})

--- a/tools/bench/core/numerics/pusher/boris.cpp
+++ b/tools/bench/core/numerics/pusher/boris.cpp
@@ -1,41 +1,15 @@
 
 #include "benchmark/benchmark.h"
 
-#include "phare_core.h"
-#include "core/numerics/pusher/boris.h"
-#include "core/numerics/ion_updater/ion_updater.h"
+#include "pusher_bench.h"
 
-template<std::size_t dim>
-using Field = PHARE::core::Field<PHARE::core::NdArrayVector<dim>,
-                                 typename PHARE::core::HybridQuantity::Scalar>;
-template<std::size_t dim>
-using VecField
-    = PHARE::core::VecField<PHARE::core::NdArrayVector<dim>, typename PHARE::core::HybridQuantity>;
-
-template<std::size_t dim>
-PHARE::core::Particle<dim> particle()
-{
-    return {//
-            /*.weight = */ 0,
-            /*.charge = */ 1,
-            /*.iCell  = */ PHARE::core::ConstArray<int, dim>(5), // first domain
-            /*.delta  = */ PHARE::core::ConstArray<float, dim>(.01),
-            /*.v      = */ {{0, 10., 0}}};
-}
-
-template<typename GridLayout, typename Quantity, std::size_t dim = GridLayout::dimension>
-Field<dim> field(std::string key, Quantity type, GridLayout const& layout)
-{
-    Field<dim> feeld{key, type, layout.allocSize(type)};
-    std::fill(feeld.begin(), feeld.end(), 1);
-    return feeld;
-}
+using namespace PHARE::core::bench;
 
 template<std::size_t dim, std::size_t interp>
 void push(benchmark::State& state)
 {
     constexpr std::uint32_t cells = 65;
-    constexpr std::uint32_t parts = 1e7;
+    constexpr std::uint32_t parts = 1e8;
 
     using PHARE_Types       = PHARE::core::PHARE_Types<dim, interp>;
     using Interpolator      = PHARE::core::Interpolator<dim, interp>;
@@ -46,36 +20,21 @@ void push(benchmark::State& state)
     using ParticleArray     = typename Ions_t::particle_array_type;
     using PartIterator      = typename ParticleArray::iterator;
 
+
     using BorisPusher_t = PHARE::core::BorisPusher<dim, PartIterator, Electromag_t, Interpolator,
                                                    BoundaryCondition, GridLayout_t>;
 
     Interpolator interpolator;
-    ParticleArray domainParticles{parts, particle<dim>()};
-    ParticleArray tmpDomain{domainParticles.size(), particle<dim>()};
+    ParticleArray domainParticles{parts, particle<dim>(/*icell =*/34)};
 
-    auto rangeIn  = PHARE::core::makeRange(domainParticles);
-    auto rangeOut = PHARE::core::makeRange(tmpDomain);
-
+    auto range    = PHARE::core::makeRange(domainParticles);
     auto meshSize = PHARE::core::ConstArray<double, dim>(1.0 / cells);
     auto nCells   = PHARE::core::ConstArray<std::uint32_t, dim>(cells);
     auto origin   = PHARE::core::Point<double, dim>{PHARE::core::ConstArray<double, dim>(0)};
+
     GridLayout_t layout{meshSize, nCells, origin};
 
-    Field<dim> bx = field("Bx", PHARE::core::HybridQuantity::Scalar::Bx, layout);
-    Field<dim> by = field("By", PHARE::core::HybridQuantity::Scalar::By, layout);
-    Field<dim> bz = field("Bz", PHARE::core::HybridQuantity::Scalar::Bz, layout);
-
-    Field<dim> ex = field("Ex", PHARE::core::HybridQuantity::Scalar::Ex, layout);
-    Field<dim> ey = field("Ey", PHARE::core::HybridQuantity::Scalar::Ey, layout);
-    Field<dim> ez = field("Ez", PHARE::core::HybridQuantity::Scalar::Ez, layout);
-
-    PHARE::core::Electromag<VecField<dim>> emFields{std::string{"EM"}};
-    emFields.B.setBuffer("EM_B_x", &bx);
-    emFields.B.setBuffer("EM_B_y", &by);
-    emFields.B.setBuffer("EM_B_z", &bz);
-    emFields.E.setBuffer("EM_E_x", &ex);
-    emFields.E.setBuffer("EM_E_y", &ey);
-    emFields.E.setBuffer("EM_E_z", &ez);
+    PHARE::core::bench::Electromag<GridLayout_t, VecField<dim>> electromag{layout};
 
     BorisPusher_t pusher;
     pusher.setMeshAndTimeStep(layout.meshSize(), .001);
@@ -83,8 +42,11 @@ void push(benchmark::State& state)
     while (state.KeepRunning())
     {
         pusher.move(
-            /*ParticleRange const&*/ rangeIn, /*ParticleRange&*/ rangeOut,
-            /*Electromag const&*/ emFields, /*double mass*/ 1, /*Interpolator&*/ interpolator,
+            /*ParticleRange const&*/ range,
+            /*ParticleRange&*/ range,
+            /*Electromag const&*/ electromag,
+            /*double mass*/ 1,
+            /*Interpolator&*/ interpolator,
             /*ParticleSelector const&*/ [](auto const& /*part*/) { return true; },
             /*GridLayout const&*/ layout);
     }
@@ -100,6 +62,7 @@ BENCHMARK_TEMPLATE(push, /*dim=*/2, /*interp=*/3)->Unit(benchmark::kMicrosecond)
 BENCHMARK_TEMPLATE(push, /*dim=*/3, /*interp=*/1)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE(push, /*dim=*/3, /*interp=*/2)->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE(push, /*dim=*/3, /*interp=*/3)->Unit(benchmark::kMicrosecond);
+
 
 int main(int argc, char** argv)
 {

--- a/tools/bench/core/numerics/pusher/kirov.cpp
+++ b/tools/bench/core/numerics/pusher/kirov.cpp
@@ -1,0 +1,86 @@
+
+#include "benchmark/benchmark.h"
+#include "pusher_bench.h"
+
+using namespace PHARE::core::bench;
+
+static std::size_t nThreads = 1;
+
+template<std::size_t dim, std::size_t interp>
+void push(benchmark::State& state)
+{
+    constexpr std::uint32_t cells = 65;
+    constexpr std::uint32_t parts = 1e8;
+
+    using PHARE_Types       = PHARE::core::PHARE_Types<dim, interp>;
+    using Interpolator      = PHARE::core::Interpolator<dim, interp>;
+    using BoundaryCondition = PHARE::core::BoundaryCondition<dim, interp>;
+    using Ions_t            = typename PHARE_Types::Ions_t;
+    using Electromag_t      = typename PHARE_Types::Electromag_t;
+    using GridLayout_t      = typename PHARE_Types::GridLayout_t;
+    using ParticleArray     = typename Ions_t::particle_array_type;
+    using PartIterator      = typename ParticleArray::iterator;
+    using ThreadPool        = ::EXT::ThreadPool;
+
+    using KirovPusher_t = PHARE::core::KirovPusher<dim, PartIterator, Electromag_t, Interpolator,
+                                                   BoundaryCondition, GridLayout_t, ThreadPool>;
+
+    Interpolator interpolator;
+    ParticleArray domainParticles{parts, particle<dim>(/*icell =*/34)};
+
+    auto range    = PHARE::core::makeRange(domainParticles);
+    auto meshSize = PHARE::core::ConstArray<double, dim>(1.0 / cells);
+    auto nCells   = PHARE::core::ConstArray<std::uint32_t, dim>(cells);
+    auto origin   = PHARE::core::Point<double, dim>{PHARE::core::ConstArray<double, dim>(0)};
+
+    GridLayout_t layout{meshSize, nCells, origin};
+
+    PHARE::core::bench::Electromag<GridLayout_t, VecField<dim>> electromag{layout};
+
+    KirovPusher_t pusher{nThreads};
+    pusher.setMeshAndTimeStep(layout.meshSize(), .001);
+
+    while (state.KeepRunning())
+    {
+        pusher.move(
+            /*ParticleRange&*/ range,
+            /*Electromag const&*/ electromag,
+            /*double mass*/ 1,
+            /*Interpolator&*/ interpolator,
+            /*ParticleSelector const&*/ [](auto const& /*part*/) { return true; },
+            /*GridLayout const&*/ layout);
+    }
+}
+
+BENCHMARK_TEMPLATE(push, /*dim=*/1, /*interp=*/1)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(push, /*dim=*/1, /*interp=*/2)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(push, /*dim=*/1, /*interp=*/3)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(push, /*dim=*/2, /*interp=*/1)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(push, /*dim=*/2, /*interp=*/2)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(push, /*dim=*/2, /*interp=*/3)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(push, /*dim=*/3, /*interp=*/1)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(push, /*dim=*/3, /*interp=*/2)->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(push, /*dim=*/3, /*interp=*/3)->Unit(benchmark::kMicrosecond);
+
+
+
+void set_env(char** envp)
+{
+    const std::string find = "PHARE_THREADS=";
+    for (char** environ = envp; *environ != 0; environ++)
+        if (std::string env(*environ); env.find(find) != std::string::npos)
+        {
+            std::stringstream sstream(env.substr(find.size()));
+            sstream >> nThreads;
+        }
+    std::cout << __FILE__ << " " << __LINE__ << " WITH PHARE_THREADS=" << nThreads << std::endl;
+}
+
+int main(int argc, char** argv, char** envp)
+{
+    set_env(envp);
+    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/tools/bench/core/numerics/pusher/pusher_bench.h
+++ b/tools/bench/core/numerics/pusher/pusher_bench.h
@@ -1,0 +1,88 @@
+#ifndef PHARE_CORE_PUSHER_BENCH_H
+#define PHARE_CORE_PUSHER_BENCH_H
+
+#include "phare_core.h"
+#include "core/numerics/pusher/boris.h"
+#include "core/numerics/ion_updater/ion_updater.h"
+
+namespace PHARE::core::bench
+{
+template<std::size_t dim>
+using Field = PHARE::core::Field<PHARE::core::NdArrayVector<dim>,
+                                 typename PHARE::core::HybridQuantity::Scalar>;
+template<std::size_t dim>
+using VecField
+    = PHARE::core::VecField<PHARE::core::NdArrayVector<dim>, typename PHARE::core::HybridQuantity>;
+
+
+template<std::size_t dim>
+PHARE::core::Particle<dim> particle(int icell = 5)
+{
+    return {//
+            /*.weight = */ 0,
+            /*.charge = */ 1,
+            /*.iCell  = */ PHARE::core::ConstArray<int, dim>(icell),
+            /*.delta  = */ PHARE::core::ConstArray<float, dim>(.5),
+            /*.v      = */ {{0, 10., 0}}};
+}
+
+template<typename GridLayout, typename Quantity, std::size_t dim = GridLayout::dimension>
+Field<dim> field(std::string key, Quantity type, GridLayout const& layout)
+{
+    Field<dim> feeld{key, type, layout.allocSize(type)};
+    std::fill(feeld.begin(), feeld.end(), 1);
+    return feeld;
+}
+
+
+template<typename GridLayout>
+auto E(GridLayout const& layout)
+{
+    return std::make_tuple(field("Ex", PHARE::core::HybridQuantity::Scalar::Ex, layout),
+                           field("Ey", PHARE::core::HybridQuantity::Scalar::Ey, layout),
+                           field("Ez", PHARE::core::HybridQuantity::Scalar::Ez, layout));
+}
+
+template<typename GridLayout>
+auto B(GridLayout const& layout)
+{
+    return std::make_tuple(field("Bx", PHARE::core::HybridQuantity::Scalar::Bx, layout),
+                           field("By", PHARE::core::HybridQuantity::Scalar::By, layout),
+                           field("Bz", PHARE::core::HybridQuantity::Scalar::Bz, layout));
+}
+
+template<typename GridLayout, std::size_t dim = GridLayout::dimension>
+auto EM(GridLayout const& layout)
+{
+    return std::make_tuple(E(layout), B(layout));
+}
+
+template<typename GridLayout, typename VecFieldT>
+class Electromag : public PHARE::core::Electromag<VecFieldT>
+{
+public:
+    using Super = PHARE::core::Electromag<VecFieldT>;
+
+    Electromag(GridLayout const& layout)
+        : Super{"EM"}
+        , emFields{EM(layout)}
+    {
+        auto& [E, B]       = emFields;
+        auto& [ex, ey, ez] = E;
+        auto& [bx, by, bz] = B;
+
+        Super::B.setBuffer("EM_B_x", &bx);
+        Super::B.setBuffer("EM_B_y", &by);
+        Super::B.setBuffer("EM_B_z", &bz);
+        Super::E.setBuffer("EM_E_x", &ex);
+        Super::E.setBuffer("EM_E_y", &ey);
+        Super::E.setBuffer("EM_E_z", &ez);
+    }
+
+private:
+    decltype(EM(*static_cast<GridLayout*>(0))) emFields;
+};
+
+} // namespace PHARE::core::bench
+
+#endif /*PHARE_CORE_PUSHER_BENCH_H*/

--- a/tools/bench/hi5/write_particles.cpp
+++ b/tools/bench/hi5/write_particles.cpp
@@ -31,7 +31,7 @@ void do_bench(benchmark::State& state)
     };
 
     auto createDataSet_ = [&](auto& hi5, auto const& path, auto const size, auto const& value) {
-        H5Easy::detail::createGroupsToDataSet(hi5.file_, path);
+        h5::createGroupsToDataSet(hi5.file_, path);
         using ValueType = std::decay_t<decltype(value)>;
         if constexpr (h5::is_array_dataset<ValueType, dim>)
             return hi5.file_.template createDataSet<typename ValueType::value_type>(


### PR DESCRIPTION
includes #529 to get rid of the advance test failures

there's probably some bug hidden in there somewhere as the diagnsotics timestamps test fails when threads == 2 from 

```
throw std::runtime_error("Error, particle moves more than 1 cell, delta >2");
```