### PR TITLE
improve plotting

### DIFF
--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -58,6 +58,34 @@ class YeeCentering(object):
         self.centerY = yee_centering["y"]
         self.centerZ = yee_centering["z"]
 
+
+def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts=False):
+
+    assert direction in direction_to_dim, f"direction ({direction} not supported)"
+    assert qty in yee_centering[direction] or qty in yee_centering_lower[direction], f"qty ({qty} not supported)"
+    if qty in yee_centering_lower[direction] and qty not in yee_centering[direction]:
+        qty = qty[0].upper() + qty[1:]
+
+    centering = yee_centering[direction][qty]
+
+    offset = 0
+    dim = direction_to_dim[direction]
+    if withGhosts:
+        size = nbrCells[dim] + (nbrGhosts * 2)
+    else:
+        size = nbrCells[dim]
+
+    if centering == 'dual':
+        offset = 0.5*dl[dim]
+    else:
+        size += 1
+
+    if withGhosts:
+        return origin[dim] - nbrGhosts * dl[dim] + np.arange(size) * dl[dim] + offset
+    else:
+        return origin[dim] + np.arange(size) * dl[dim] + offset
+
+
 class GridLayout(object):
 
     def __init__(self, box=Box(0,0), origin=0, dl=0.1, interp_order=1):
@@ -240,24 +268,12 @@ class GridLayout(object):
         :param direction: can only be a single one
         """
 
-        assert direction in direction_to_dim, f"direction ({direction} not supported)"
-        assert qty in yee_centering[direction] or qty in yee_centering_lower[direction], f"qty ({qty} not supported)"
         if qty in yee_centering_lower[direction] and qty not in yee_centering[direction]:
             qty = qty[0].upper() + qty[1:]
 
-        centering = yee_centering[direction][qty]
-        nbrGhosts = self.nbrGhosts(self.interp_order, centering)
+        return yeeCoordsFor(self.origin, self.nbrGhosts(self.interp_order, yee_centering[direction][qty]),
+                            self.dl, self.box.shape, qty, direction, withGhosts=True)
 
-        offset = 0
-        dim = direction_to_dim[direction]
-        size = self.box.shape[dim] + (nbrGhosts * 2)
-
-        if centering == 'dual':
-            offset = 0.5*self.dl[dim]
-        else:
-            size += 1
-
-        return self.origin[dim] - nbrGhosts * self.dl[dim] + np.arange(size) * self.dl[dim] + offset
 
 
 

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -973,6 +973,7 @@ def compute_hier_from(h, compute):
 
      caveat: routine only works in 1D so far.
     """
+    assert(len(h.time_hier) == 1) # only single time hierarchies now
     patch_levels = {}
     for ilvl, lvl in h.patch_levels.items():
         patches = {}
@@ -991,7 +992,9 @@ def compute_hier_from(h, compute):
 
         patch_levels[ilvl] = PatchLevel(ilvl, patches[ilvl])
 
-    return PatchHierarchy(patch_levels, h.domain_box, refinement_ratio)
+    t = list(h.time_hier.keys())[0]
+    return PatchHierarchy(patch_levels, h.domain_box, refinement_ratio,
+                          time=t)
 
 
 

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -255,6 +255,13 @@ def finest_field_plot(run_path, qty, **kwargs):
             time = times[0]
         interpolator, finest_coords = r.GetNi(time, merged=True,\
                                               interp=interp)[qty]
+    elif qty in ("Jx", "Jy", "Jz"):
+        file = os.path.join(run_path, "EM_B.h5")
+        if time is None:
+            times = get_times_from_h5(file)
+            time = times[0]
+        interpolator, finest_coords = r.GetJ(time, merged=True,\
+                                              interp=interp)[qty]
     else:
         # ___ TODO : should also include the files for a given population
         raise ValueError("qty should be in ['Bx', 'By', 'Bz', 'Ex', 'Ey', 'Ez', 'Fx', 'Fy', 'Fz', 'Vx', 'Vy', 'Vz', 'rho']")

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -218,6 +218,7 @@ def finest_field_plot(run_path, qty, **kwargs):
     from pyphare.pharesee.hierarchy import get_times_from_h5
     from pyphare.pharesee.run import Run
     from mpl_toolkits.axes_grid1 import make_axes_locatable
+    import pyphare.core.gridlayout as gridlayout
 
     r = Run(run_path)
 
@@ -270,14 +271,28 @@ def finest_field_plot(run_path, qty, **kwargs):
         ax.plot(finest_coords[0], interpolator(finest_coords[0]),\
                 drawstyle=drawstyle)
     elif dim == 2:
-        X, Y = np.meshgrid(finest_coords[0], finest_coords[1])
+
+
+        x = finest_coords[0]
+        y = finest_coords[1]
+        dx = x[1] - x[0]
+        dy = y[1] - y[0]
+
+        # pcolormesh considers DATA_ij to be the center of the pixel
+        # and X,Y are the corners so XY need to be made 1 value larger
+        # and shifted around DATA_ij
+        x -= dx/2
+        x= np.append(x, x[-1]+dx)
+        y -= dy/2
+        y= np.append(y, y[-1]+dy)
+
+        X, Y = np.meshgrid(x, y)
         DATA = interpolator(X, Y)
 
         vmin = kwargs.get("vmin", np.nanmin(DATA))
         vmax = kwargs.get("vmax", np.nanmax(DATA))
         cmap = kwargs.get("cmap", 'Spectral_r')
-
-        im = ax.pcolormesh(finest_coords[0], finest_coords[1],
+        im = ax.pcolormesh(x,y,
                    DATA,
                    cmap = cmap,
                    vmin = vmin,

--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -24,16 +24,70 @@ def _current1d(by, bz, xby, xbz):
     jz[-1]=jz[-2]
     return jy, jz
 
+def _current2d(bx, by, bz, dx, dy):
+    # jx = dyBz
+    # jy = -dxBz
+    # jz = dxBy - dyBx
+    # the following hard-codes yee layout
+    # which is not true in general
+    # we should at some point provide proper
+    # derivation routines in the gridlayout
+    jx = np.zeros(by.shape)
+    jy = np.zeros(bx.shape)
+    jz = np.zeros((bx.shape[0], by.shape[1]))
+
+    jx[:,1:-1] = (bz[:,1:] - bz[:,:-1])/dy
+    jy[1:-1,:] = -(bz[1:,:] - bz[:-1,:])/dx
+    jz[1:-1,1:-1] = (by[1:, 1:-1] - by[:-1 , 1:-1])/dx - (bx[1:-1 , 1:] - bx[1:-1, :-1])/dy
+
+    jy[0,:]  = jy[1,:]
+    jy[:,0]  = jy[:,1]
+    jy[-1,:] = jy[-2,:]
+    jy[:,-1] = jy[:,-2]
+
+    jz[0,:]  = jz[1,:]
+    jz[:,0]  = jz[:,1]
+    jz[-1,:] = jz[-2,:]
+    jz[:,-1] = jz[:,-2]
+
+    jx[0,:]  = jx[1,:]
+    jx[:,0]  = jx[:,1]
+    jx[-1,:] = jx[-2,:]
+    jx[:,-1] = jx[:,-2]
+
+    return jx, jy, jz
+
+
 
 def _compute_current(patch):
-    By = patch.patch_datas["By"].dataset[:]
-    xby  = patch.patch_datas["By"].x
-    Bz = patch.patch_datas["Bz"].dataset[:]
-    xbz  = patch.patch_datas["Bz"].x
-    Jy, Jz =  _current1d(By, Bz, xby, xbz)
-    return ({"name":"Jy", "data":Jy,"centering":"primal"},
-            {"name":"Jz", "data":Jz,"centering":"primal"})
+    if patch.box.ndim ==1 : 
+        By = patch.patch_datas["By"].dataset[:]
+        xby  = patch.patch_datas["By"].x
+        Bz = patch.patch_datas["Bz"].dataset[:]
+        xbz  = patch.patch_datas["Bz"].x
+        Jy, Jz =  _current1d(By, Bz, xby, xbz)
+        return ({"name":"Jy", "data":Jy,"centering":"primal"},
+                {"name":"Jz", "data":Jz,"centering":"primal"})
 
+    elif patch.box.ndim ==2 :
+        Bx = patch.patch_datas["Bx"].dataset[:]
+        By = patch.patch_datas["By"].dataset[:]
+        Bz = patch.patch_datas["Bz"].dataset[:]
+
+        dx,dy  = patch.dl
+
+        Jx, Jy, Jz =  _current2d(Bx, By, Bz, dx, dy)
+        #return ({"name":"Jx", "data":Jx,"centering":"primal"},
+        #        {"name":"Jy", "data":Jy,"centering":"primal"},
+        #        {"name":"Jz", "data":Jz,"centering":"primal"})
+
+
+        components = ("Jx", "Jy", "Jz")
+        centering = {component:[patch.layout.centering[direction][component] for direction in ("X", "Y")] for component in components}
+
+        return ({"name":"Jx", "data":Jx, "centering":centering["Jx"]},
+                {"name":"Jy", "data":Jy, "centering":centering["Jy"]},
+                {"name":"Jz", "data":Jz,"centering":centering["Jz"]})
 
 def make_interpolator(data, coords, interp, domain, dl, qty, nbrGhosts):
     """

--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -58,7 +58,7 @@ def make_interpolator(data, coords, interp, domain, dl, qty, nbrGhosts):
 
         nx = 1+int(domain[0]/dl[0])
 
-        x = yeeCoordsFor([0]*dim, [nbrGhosts]*dim, dl, [nx],  qty, "x")
+        x = yeeCoordsFor([0]*dim, nbrGhosts, dl, [nx],  qty, "x")
         finest_coords = (x,)
 
     elif dim == 2:
@@ -73,8 +73,8 @@ def make_interpolator(data, coords, interp, domain, dl, qty, nbrGhosts):
             raise ValueError("interp can only be 'nearest' or 'bilinear'")
 
         nCells = [1+int(d/dl) for d,dl in zip(domain, dl)]
-        x = yeeCoordsFor([0]*dim, [5]*dim, dl, nCells,  qty, "x")
-        y = yeeCoordsFor([0]*dim, [5]*dim, dl, nCells,  qty, "y")
+        x = yeeCoordsFor([0]*dim, nbrGhosts, dl, nCells,  qty, "x")
+        y = yeeCoordsFor([0]*dim, nbrGhosts, dl, nCells,  qty, "y")
         #x = np.arange(0, domain[0]+dl[0], dl[0])
         #y = np.arange(0, domain[1]+dl[1], dl[1])
         finest_coords = (x, y)


### PR DESCRIPTION
- extracts yeeCoordsFor from the instance layout since we may want to use that without a proper instance
- move hierarchy.plot() to plot1d since it was only 1d and add a hierarchy.plot2d(). hierarchy.plot() now calls either one depending on ndim.

the 2d plot method plots plots ONE level (default root), in contrast to plotting.plot() which plots the finest data available.
Typical use case is for expert users who do not just want to see the "best" (finest) data available but data per level.

the mechanism is : loop on patches and pcolormesh each of them one after the other, on the same plot.

example : 

```python
r033 = Run("some_run_path")

qty="By"
t=0.8
vmin=-0.1
vmax=0.1

fig,(ax1,ax2) = plt.subplots(ncols=2)

# this returns a Hierarchy
Bh = r033.GetB(t)

# now we 2D plot 
Bh.plot(qty="By", level=0, ax=ax1, vmin=vmin, vmax=vmax)
Bh.plot(qty="By", level=1, ax=ax2, vmin=vmin, vmax=vmax)

ax1.set_xlim((13,28))
ax1.set_ylim((1,10))

# draw patch boundaries
for ax in (ax1,ax2):
    for patch in Bh.patch_levels[1].patches:
        pdat = patch.patch_datas["By"]
        dx,dy = pdat.layout.dl
        r = Rectangle((patch.layout.box.lower[0]*dx, patch.layout.box.lower[1]*dy),
                       patch.layout.box.shape[0]*dx, patch.layout.box.shape[1]*dy, 
                       fc="none", ec="b", alpha=0.4, lw=0.8)

        ax.add_patch(r)
``` 


this produces : 

![image](https://user-images.githubusercontent.com/3200931/132527969-93304a5a-d96b-4ca4-a79a-f83a8da20c82.png)



