### PR TITLE
split up cpp pybind to allow reuse 

### DIFF
--- a/pyphare/pyphare/cpp/__init__.py
+++ b/pyphare/pyphare/cpp/__init__.py
@@ -1,13 +1,27 @@
 
+# continue to use override if set
+_cpp_lib_override = None
 
-def cpp_lib():
+def cpp_lib(override=None):
     import importlib
+
+    global _cpp_lib_override
+    if override is not None:
+        _cpp_lib_override = override
+    if _cpp_lib_override is not None:
+        return importlib.import_module(_cpp_lib_override)
+
     if not __debug__:
         return importlib.import_module("pybindlibs.cpp")
     try:
         return importlib.import_module("pybindlibs.cpp_dbg")
     except ImportError as err:
         return importlib.import_module("pybindlibs.cpp")
+
+
+def cpp_etc_lib():
+    import importlib
+    return importlib.import_module("pybindlibs.cpp_etc")
 
 
 def splitter_type(dim, interp, n_particles):

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -63,10 +63,10 @@ class fn_wrapper(py_fn_wrapper):
     def __init__(self, fn):
         super().__init__(fn)
     def __call__(self, *xyz):
-        from pyphare.cpp import cpp_lib
+        from pyphare.cpp import cpp_etc_lib
         # convert numpy array to C++ SubSpan
         # couples vector init functions to C++
-        return cpp_lib().makePyArrayWrapper(super().__call__(*xyz))
+        return cpp_etc_lib().makePyArrayWrapper(super().__call__(*xyz))
 
 
 

--- a/res/cmake/bench.cmake
+++ b/res/cmake/bench.cmake
@@ -50,5 +50,6 @@ if (bench)
   add_subdirectory(tools/bench/core/numerics/pusher)
 
   add_subdirectory(tools/bench/hi5)
+  add_subdirectory(tools/bench/real)
 
 endif()

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -22,3 +22,14 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   )
   set_property(TARGET cpp_dbg PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})
 endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+
+
+pybind11_add_module(cpp_etc cpp_etc.cpp)
+target_link_libraries(cpp_etc PUBLIC phare_simulator)
+target_compile_options(cpp_etc PRIVATE ${PHARE_FLAGS}) # pybind fails with Werror
+set_target_properties(cpp_etc
+    PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pybindlibs"
+)
+# this is on by default "pybind11_add_module" but can interfere with coverage so we disable it if coverage is enabled
+set_property(TARGET cpp_etc PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})

--- a/src/python3/cpp_etc.cpp
+++ b/src/python3/cpp_etc.cpp
@@ -1,0 +1,16 @@
+
+#include "python3/pybind_def.h"
+
+namespace py = pybind11;
+
+namespace PHARE::pydata
+{
+PYBIND11_MODULE(cpp_etc, m)
+{
+    py::class_<core::Span<double>, std::shared_ptr<core::Span<double>>>(m, "Span");
+    py::class_<PyArrayWrapper<double>, std::shared_ptr<PyArrayWrapper<double>>, core::Span<double>>(
+        m, "PyWrapper");
+
+    m.def("makePyArrayWrapper", makePyArrayWrapper<double>);
+}
+} // namespace PHARE::pydata

--- a/src/python3/cpp_simulator.cpp
+++ b/src/python3/cpp_simulator.cpp
@@ -1,244 +1,26 @@
 
-// Philip Deegan comments: IWYU may work on this file, but it takes forever so I never found out.
-//   headers were included manually
-
-#include <vector>
-#include <cstddef>
-
-#include "mpi.h"
-
-#include "core/utilities/mpi_utils.h"
-#include "core/data/particles/particle.h"
-#include "core/utilities/meta/meta_utilities.h"
-#include "amr/wrappers/hierarchy.h"
-#include "phare/phare.h"
-#include "simulator/simulator.h"
-
-#include "pybind11/stl.h"
-#include "pybind11/numpy.h"
-#include "pybind11/chrono.h"
-#include "pybind11/complex.h"
-#include "pybind11/functional.h"
-
-#include "python3/pybind_def.h"
-#include "python3/particles.h"
-#include "python3/patch_data.h"
-#include "python3/patch_level.h"
-#include "python3/data_wrangler.h"
-
+#include "python3/cpp_simulator.h"
 
 #if !defined(PHARE_CPP_MOD_NAME)
 #define PHARE_CPP_MOD_NAME cpp
 #endif
 
-
 namespace py = pybind11;
 
 namespace PHARE::pydata
 {
-template<typename Type, std::size_t dimension>
-void declarePatchData(py::module& m, std::string key)
-{
-    using PatchDataType = PatchData<Type, dimension>;
-    py::class_<PatchDataType>(m, key.c_str())
-        .def_readonly("patchID", &PatchDataType::patchID)
-        .def_readonly("origin", &PatchDataType::origin)
-        .def_readonly("lower", &PatchDataType::lower)
-        .def_readonly("upper", &PatchDataType::upper)
-        .def_readonly("nGhosts", &PatchDataType::nGhosts)
-        .def_readonly("data", &PatchDataType::data);
-}
-
-template<std::size_t dim>
-void declareDim(py::module& m)
-{
-    using CP         = core::ContiguousParticles<dim>;
-    std::string name = "ContiguousParticles_" + std::to_string(dim);
-    py::class_<CP, std::shared_ptr<CP>>(m, name.c_str())
-        .def(py::init<std::size_t>())
-        .def_readwrite("iCell", &CP::iCell)
-        .def_readwrite("delta", &CP::delta)
-        .def_readwrite("weight", &CP::weight)
-        .def_readwrite("charge", &CP::charge)
-        .def_readwrite("v", &CP::v)
-        .def("size", &CP::size);
-
-    name = "PatchData" + name;
-    declarePatchData<CP, dim>(m, name.c_str());
-}
-
-template<typename Simulator, typename PyClass>
-void declareSimulator(PyClass&& sim)
-{
-    sim.def("initialize", &Simulator::initialize)
-        .def("advance", &Simulator::advance)
-        .def("startTime", &Simulator::startTime)
-        .def("currentTime", &Simulator::currentTime)
-        .def("endTime", &Simulator::endTime)
-        .def("timeStep", &Simulator::timeStep)
-        .def("to_str", &Simulator::to_str)
-        .def("domain_box", &Simulator::domainBox)
-        .def("cell_width", &Simulator::cellWidth)
-        .def("dump", &Simulator::dump, py::arg("timestamp"), py::arg("timestep"));
-}
-
-template<typename _dim, typename _interp, typename _nbRefinedPart>
-void declare(py::module& m)
-{
-    constexpr auto dim           = _dim{}();
-    constexpr auto interp        = _interp{}();
-    constexpr auto nbRefinedPart = _nbRefinedPart{}();
-
-
-    std::string type_string = "_" + std::to_string(dim) + "_" + std::to_string(interp) + "_"
-                              + std::to_string(nbRefinedPart);
-
-    using Sim        = Simulator<dim, interp, nbRefinedPart>;
-    std::string name = "Simulator" + type_string;
-    declareSimulator<Sim>(
-        py::class_<Sim, std::shared_ptr<Sim>>(m, name.c_str())
-            .def_property_readonly_static("dims", [](py::object) { return Sim::dimension; })
-            .def_property_readonly_static("interp_order",
-                                          [](py::object) { return Sim::interp_order; })
-            .def_property_readonly_static("refined_particle_nbr",
-                                          [](py::object) { return Sim::nbRefinedPart; }));
-
-
-    name = "make_simulator" + type_string;
-    m.def(name.c_str(), [](std::shared_ptr<PHARE::amr::Hierarchy> const& hier) {
-        return std::shared_ptr<Sim>{std::move(makeSimulator<dim, interp, nbRefinedPart>(hier))};
-    });
-
-
-    using DW = DataWrangler<dim, interp, nbRefinedPart>;
-    name     = "DataWrangler" + type_string;
-    py::class_<DW, std::shared_ptr<DW>>(m, name.c_str())
-        .def(py::init<std::shared_ptr<Sim> const&, std::shared_ptr<amr::Hierarchy> const&>())
-        .def(py::init<std::shared_ptr<ISimulator> const&, std::shared_ptr<amr::Hierarchy> const&>())
-        .def("sync_merge", &DW::sync_merge)
-        .def("getPatchLevel", &DW::getPatchLevel)
-        .def("getNumberOfLevels", &DW::getNumberOfLevels);
-
-    using PL = PatchLevel<dim, interp, nbRefinedPart>;
-    name     = "PatchLevel_" + type_string;
-
-    py::class_<PL, std::shared_ptr<PL>>(m, name.c_str())
-        .def("getEM", &PL::getEM)
-        .def("getE", &PL::getE)
-        .def("getB", &PL::getB)
-        .def("getBx", &PL::getBx)
-        .def("getBy", &PL::getBy)
-        .def("getBz", &PL::getBz)
-        .def("getEx", &PL::getEx)
-        .def("getEy", &PL::getEy)
-        .def("getEz", &PL::getEz)
-        .def("getVix", &PL::getVix)
-        .def("getViy", &PL::getViy)
-        .def("getViz", &PL::getViz)
-        .def("getDensity", &PL::getDensity)
-        .def("getBulkVelocity", &PL::getBulkVelocity)
-        .def("getPopDensities", &PL::getPopDensities)
-        .def("getPopFluxes", &PL::getPopFlux)
-        .def("getFx", &PL::getFx)
-        .def("getFy", &PL::getFy)
-        .def("getFz", &PL::getFz)
-        .def("getParticles", &PL::getParticles, py::arg("userPopName") = "all");
-
-    using _Splitter
-        = PHARE::amr::Splitter<_dim, _interp, core::RefinedParticlesConst<nbRefinedPart>>;
-    name = "Splitter" + type_string;
-    py::class_<_Splitter, std::shared_ptr<_Splitter>>(m, name.c_str())
-        .def(py::init<>())
-        .def_property_readonly_static("weight", [](py::object) { return _Splitter::weight; })
-        .def_property_readonly_static("delta", [](py::object) { return _Splitter::delta; });
-
-    name = "split_pyarray_particles" + type_string;
-    m.def(name.c_str(), splitPyArrayParticles<_Splitter>);
-}
-
-
-template<typename Dimension, typename InterpOrder, typename... NbRefinedParts>
-void declare(py::module& m, std::tuple<Dimension, InterpOrder, NbRefinedParts...> const&)
-{
-    core::apply(std::tuple<NbRefinedParts...>{}, [&](auto& nbRefinedPart) {
-        declare<Dimension, InterpOrder, std::decay_t<decltype(nbRefinedPart)>>(m);
-    });
-}
-
-
-
-auto pybind_version()
-{
-    std::stringstream ss;
-    ss << PYBIND11_VERSION_MAJOR << ".";
-    ss << PYBIND11_VERSION_MINOR << ".";
-    ss << PHARE_TO_STR(PYBIND11_VERSION_PATCH);
-    return ss.str();
-}
-
-auto samrai_version()
-{
-    std::stringstream ss;
-    ss << SAMRAI_VERSION_MAJOR << ".";
-    ss << SAMRAI_VERSION_MINOR << ".";
-    ss << SAMRAI_VERSION_PATCHLEVEL;
-    return ss.str();
-}
-
-
-
 PYBIND11_MODULE(PHARE_CPP_MOD_NAME, m)
 {
-    py::class_<SamraiLifeCycle, std::shared_ptr<SamraiLifeCycle>>(m, "SamraiLifeCycle")
-        .def(py::init<>())
-        .def("reset", &SamraiLifeCycle::reset);
-
-    py::class_<PHARE::amr::Hierarchy, std::shared_ptr<PHARE::amr::Hierarchy>>(m, "AMRHierarchy");
-
-    declareSimulator<ISimulator>(
-        py::class_<ISimulator, std::shared_ptr<ISimulator>>(m, "ISimulator")
-            .def("interp_order", &ISimulator::interporder)
-            .def("dump", &ISimulator::dump, py::arg("timestamp"), py::arg("timestep")));
-
-    m.def("make_hierarchy", []() { return PHARE::amr::Hierarchy::make(); });
-    m.def("make_simulator", [](std::shared_ptr<PHARE::amr::Hierarchy>& hier) {
-        return std::shared_ptr<ISimulator>{std::move(PHARE::getSimulator(hier))};
-    });
-
-    m.def("mpi_size", []() { return core::mpi::size(); });
-    m.def("mpi_rank", []() { return core::mpi::rank(); });
+    declare_essential(m);
 
     declareDim<1>(m);
     declareDim<2>(m);
     declareDim<3>(m);
 
-    core::apply(core::possibleSimulators(), [&](auto const& simType) { declare(m, simType); });
+    core::apply(core::possibleSimulators(), [&](auto const& simType) { declare_all(m, simType); });
 
     declarePatchData<std::vector<double>, 1>(m, "PatchDataVectorDouble_1D");
     declarePatchData<std::vector<double>, 2>(m, "PatchDataVectorDouble_2D");
     declarePatchData<std::vector<double>, 3>(m, "PatchDataVectorDouble_3D");
-
-    py::class_<core::Span<double>, std::shared_ptr<core::Span<double>>>(m, "Span");
-    py::class_<PyArrayWrapper<double>, std::shared_ptr<PyArrayWrapper<double>>, core::Span<double>>(
-        m, "PyWrapper");
-
-    m.def("makePyArrayWrapper", makePyArrayWrapper<double>);
-
-    m.def("phare_deps", []() {
-        std::unordered_map<std::string, std::string> versions{{"pybind", pybind_version()},
-                                                              {"samrai", samrai_version()}};
-        _PHARE_WITH_HIGHFIVE(versions["highfive"] = PHARE_TO_STR(HIGHFIVE_VERSION));
-        return versions;
-    });
 }
-
-
 } // namespace PHARE::pydata
-
-
-// https://stackoverflow.com/a/51061314/795574
-// ASAN detects leaks by default, even in system/third party libraries
-const char* __asan_default_options()
-{
-    return "detect_leaks=0";
-}

--- a/src/python3/cpp_simulator.h
+++ b/src/python3/cpp_simulator.h
@@ -1,0 +1,223 @@
+#ifndef PHARE_PYTHON_CPP_SIMULATOR_H
+#define PHARE_PYTHON_CPP_SIMULATOR_H
+
+#include <vector>
+#include <cstddef>
+
+#include "mpi.h"
+
+#include "core/utilities/mpi_utils.h"
+#include "core/data/particles/particle.h"
+#include "core/utilities/meta/meta_utilities.h"
+#include "amr/wrappers/hierarchy.h"
+#include "phare/phare.h"
+#include "simulator/simulator.h"
+
+#include "pybind11/stl.h"
+#include "pybind11/numpy.h"
+#include "pybind11/chrono.h"
+#include "pybind11/complex.h"
+#include "pybind11/functional.h"
+
+#include "python3/pybind_def.h"
+#include "python3/particles.h"
+#include "python3/patch_data.h"
+#include "python3/patch_level.h"
+#include "python3/data_wrangler.h"
+
+
+namespace py = pybind11;
+
+namespace PHARE::pydata
+{
+auto pybind_version()
+{
+    std::stringstream ss;
+    ss << PYBIND11_VERSION_MAJOR << ".";
+    ss << PYBIND11_VERSION_MINOR << ".";
+    ss << PHARE_TO_STR(PYBIND11_VERSION_PATCH);
+    return ss.str();
+}
+
+auto samrai_version()
+{
+    std::stringstream ss;
+    ss << SAMRAI_VERSION_MAJOR << ".";
+    ss << SAMRAI_VERSION_MINOR << ".";
+    ss << SAMRAI_VERSION_PATCHLEVEL;
+    return ss.str();
+}
+
+
+template<typename Type, std::size_t dimension>
+void declarePatchData(py::module& m, std::string key)
+{
+    using PatchDataType = PatchData<Type, dimension>;
+    py::class_<PatchDataType>(m, key.c_str())
+        .def_readonly("patchID", &PatchDataType::patchID)
+        .def_readonly("origin", &PatchDataType::origin)
+        .def_readonly("lower", &PatchDataType::lower)
+        .def_readonly("upper", &PatchDataType::upper)
+        .def_readonly("nGhosts", &PatchDataType::nGhosts)
+        .def_readonly("data", &PatchDataType::data);
+}
+
+template<std::size_t dim>
+void declareDim(py::module& m)
+{
+    using CP         = core::ContiguousParticles<dim>;
+    std::string name = "ContiguousParticles_" + std::to_string(dim);
+    py::class_<CP, std::shared_ptr<CP>>(m, name.c_str())
+        .def(py::init<std::size_t>())
+        .def_readwrite("iCell", &CP::iCell)
+        .def_readwrite("delta", &CP::delta)
+        .def_readwrite("weight", &CP::weight)
+        .def_readwrite("charge", &CP::charge)
+        .def_readwrite("v", &CP::v)
+        .def("size", &CP::size);
+
+    name = "PatchData" + name;
+    declarePatchData<CP, dim>(m, name.c_str());
+}
+
+template<typename Simulator, typename PyClass>
+void declareSimulator(PyClass&& sim)
+{
+    sim.def("initialize", &Simulator::initialize)
+        .def("advance", &Simulator::advance)
+        .def("startTime", &Simulator::startTime)
+        .def("currentTime", &Simulator::currentTime)
+        .def("endTime", &Simulator::endTime)
+        .def("timeStep", &Simulator::timeStep)
+        .def("to_str", &Simulator::to_str)
+        .def("domain_box", &Simulator::domainBox)
+        .def("cell_width", &Simulator::cellWidth)
+        .def("dump", &Simulator::dump, py::arg("timestamp"), py::arg("timestep"));
+}
+
+template<typename _dim, typename _interp, typename _nbRefinedPart>
+void declare_etc(py::module& m)
+{
+    constexpr auto dim           = _dim{}();
+    constexpr auto interp        = _interp{}();
+    constexpr auto nbRefinedPart = _nbRefinedPart{}();
+
+    std::string type_string = "_" + std::to_string(dim) + "_" + std::to_string(interp) + "_"
+                              + std::to_string(nbRefinedPart);
+
+    using Sim        = Simulator<dim, interp, nbRefinedPart>;
+    using DW         = DataWrangler<dim, interp, nbRefinedPart>;
+    std::string name = "DataWrangler" + type_string;
+    py::class_<DW, std::shared_ptr<DW>>(m, name.c_str())
+        .def(py::init<std::shared_ptr<Sim> const&, std::shared_ptr<amr::Hierarchy> const&>())
+        .def(py::init<std::shared_ptr<ISimulator> const&, std::shared_ptr<amr::Hierarchy> const&>())
+        .def("sync_merge", &DW::sync_merge)
+        .def("getPatchLevel", &DW::getPatchLevel)
+        .def("getNumberOfLevels", &DW::getNumberOfLevels);
+
+    using PL = PatchLevel<dim, interp, nbRefinedPart>;
+    name     = "PatchLevel_" + type_string;
+
+    py::class_<PL, std::shared_ptr<PL>>(m, name.c_str())
+        .def("getEM", &PL::getEM)
+        .def("getE", &PL::getE)
+        .def("getB", &PL::getB)
+        .def("getBx", &PL::getBx)
+        .def("getBy", &PL::getBy)
+        .def("getBz", &PL::getBz)
+        .def("getEx", &PL::getEx)
+        .def("getEy", &PL::getEy)
+        .def("getEz", &PL::getEz)
+        .def("getVix", &PL::getVix)
+        .def("getViy", &PL::getViy)
+        .def("getViz", &PL::getViz)
+        .def("getDensity", &PL::getDensity)
+        .def("getBulkVelocity", &PL::getBulkVelocity)
+        .def("getPopDensities", &PL::getPopDensities)
+        .def("getPopFluxes", &PL::getPopFlux)
+        .def("getFx", &PL::getFx)
+        .def("getFy", &PL::getFy)
+        .def("getFz", &PL::getFz)
+        .def("getParticles", &PL::getParticles, py::arg("userPopName") = "all");
+
+    using _Splitter
+        = PHARE::amr::Splitter<_dim, _interp, core::RefinedParticlesConst<nbRefinedPart>>;
+    name = "Splitter" + type_string;
+    py::class_<_Splitter, std::shared_ptr<_Splitter>>(m, name.c_str())
+        .def(py::init<>())
+        .def_property_readonly_static("weight", [](py::object) { return _Splitter::weight; })
+        .def_property_readonly_static("delta", [](py::object) { return _Splitter::delta; });
+
+    name = "split_pyarray_particles" + type_string;
+    m.def(name.c_str(), splitPyArrayParticles<_Splitter>);
+}
+
+template<typename _dim, typename _interp, typename _nbRefinedPart>
+void declare_sim(py::module& m)
+{
+    constexpr auto dim           = _dim{}();
+    constexpr auto interp        = _interp{}();
+    constexpr auto nbRefinedPart = _nbRefinedPart{}();
+
+    std::string type_string = "_" + std::to_string(dim) + "_" + std::to_string(interp) + "_"
+                              + std::to_string(nbRefinedPart);
+
+    using Sim        = Simulator<dim, interp, nbRefinedPart>;
+    std::string name = "Simulator" + type_string;
+    declareSimulator<Sim>(
+        py::class_<Sim, std::shared_ptr<Sim>>(m, name.c_str())
+            .def_property_readonly_static("dims", [](py::object) { return Sim::dimension; })
+            .def_property_readonly_static("interp_order",
+                                          [](py::object) { return Sim::interp_order; })
+            .def_property_readonly_static("refined_particle_nbr",
+                                          [](py::object) { return Sim::nbRefinedPart; }));
+
+    name = "make_simulator" + type_string;
+    m.def(name.c_str(), [](std::shared_ptr<PHARE::amr::Hierarchy> const& hier) {
+        return std::shared_ptr<Sim>{std::move(makeSimulator<dim, interp, nbRefinedPart>(hier))};
+    });
+}
+
+template<typename Dimension, typename InterpOrder, typename... NbRefinedParts>
+void declare_all(py::module& m, std::tuple<Dimension, InterpOrder, NbRefinedParts...> const&)
+{
+    core::apply(std::tuple<NbRefinedParts...>{}, [&](auto& nbRefinedPart) {
+        declare_sim<Dimension, InterpOrder, std::decay_t<decltype(nbRefinedPart)>>(m);
+        declare_etc<Dimension, InterpOrder, std::decay_t<decltype(nbRefinedPart)>>(m);
+    });
+}
+
+void declare_essential(py::module& m)
+{
+    py::class_<SamraiLifeCycle, std::shared_ptr<SamraiLifeCycle>>(m, "SamraiLifeCycle")
+        .def(py::init<>())
+        .def("reset", &SamraiLifeCycle::reset);
+
+    py::class_<PHARE::amr::Hierarchy, std::shared_ptr<PHARE::amr::Hierarchy>>(m, "AMRHierarchy");
+    m.def("make_hierarchy", []() { return PHARE::amr::Hierarchy::make(); });
+
+    m.def("mpi_size", []() { return core::mpi::size(); });
+    m.def("mpi_rank", []() { return core::mpi::rank(); });
+
+    m.def("phare_deps", []() {
+        std::unordered_map<std::string, std::string> versions{{"pybind", pybind_version()},
+                                                              {"samrai", samrai_version()}};
+        _PHARE_WITH_HIGHFIVE(versions["highfive"] = PHARE_TO_STR(HIGHFIVE_VERSION));
+        return versions;
+    });
+}
+
+
+} // namespace PHARE::pydata
+
+
+// https://stackoverflow.com/a/51061314/795574
+// ASAN detects leaks by default, even in system/third party libraries
+inline const char* __asan_default_options()
+{
+    return "detect_leaks=0";
+}
+
+
+
+#endif /*PHARE_PYTHON_CPP_SIMULATOR_H*/

--- a/tests/initializer/init_functions.h
+++ b/tests/initializer/init_functions.h
@@ -61,21 +61,6 @@ Return bz(Param x)
     return std::make_shared<core::VectorSpan<double>>(x);
 }
 
-Return ex(Param x)
-{
-    return std::make_shared<core::VectorSpan<double>>(x);
-}
-
-Return ey(Param x)
-{
-    return std::make_shared<core::VectorSpan<double>>(x);
-}
-
-Return ez(Param x)
-{
-    return std::make_shared<core::VectorSpan<double>>(x);
-}
-
 
 } // namespace PHARE::initializer::test_fn::func_1d
 
@@ -135,20 +120,6 @@ Return bz(Param x, Param y)
     return std::make_shared<core::VectorSpan<double>>(x);
 }
 
-Return ex(Param x, Param y)
-{
-    return std::make_shared<core::VectorSpan<double>>(x);
-}
-
-Return ey(Param x, Param y)
-{
-    return std::make_shared<core::VectorSpan<double>>(x);
-}
-
-Return ez(Param x, Param y)
-{
-    return std::make_shared<core::VectorSpan<double>>(x);
-}
 
 } // namespace PHARE::initializer::test_fn::func_2d
 

--- a/tools/bench/functional/.gitignore
+++ b/tools/bench/functional/.gitignore
@@ -1,1 +1,1 @@
-uniform
+generated

--- a/tools/bench/real/CMakeLists.txt
+++ b/tools/bench/real/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(phare_real_bench)
+
+pybind11_add_module(cpp_sim_2_1_4 sim/sim_2_1_4.cpp)
+target_link_libraries(cpp_sim_2_1_4 PUBLIC phare_simulator)
+target_compile_options(cpp_sim_2_1_4 PRIVATE ${PHARE_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE}) # pybind fails with Werror
+set_target_properties(cpp_sim_2_1_4
+    PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pybindlibs"
+)
+# this is on by default "pybind11_add_module" but can interfere with coverage so we disable it if coverage is enabled
+set_property(TARGET cpp_sim_2_1_4 PROPERTY INTERPROCEDURAL_OPTIMIZATION ${PHARE_INTERPROCEDURAL_OPTIMIZATION})
+

--- a/tools/bench/real/bench_harris.py
+++ b/tools/bench/real/bench_harris.py
@@ -1,0 +1,85 @@
+
+
+import numpy as np
+from pyphare.cpp import cpp_lib # must be first
+cpp_lib("pybindlibs.cpp_sim_2_1_4")
+import pyphare.pharein as ph
+
+seed = 133333333337
+cells, dl = 100, .2
+patch_sizes = [50,100]
+diag_outputs="tools/bench/real/harris/outputs"
+
+def density(x, y):
+    L = ph.global_vars.sim.simulation_domain()[1]
+    return 0.2 + 1./np.cosh((y-L*0.3)/0.5)**2 + 1./np.cosh((y-L*0.7)/0.5)**2
+
+def by(x, y):
+    sim = ph.global_vars.sim
+    Lx = sim.simulation_domain()[0]
+    Ly = sim.simulation_domain()[1]
+    w1, w2 = 0.2, 1.0
+    x0 = (x - 0.5 * Lx)
+    y1 = (y - 0.3 * Ly)
+    y2 = (y - 0.7 * Ly)
+    w3 = np.exp(-(x0*x0 + y1*y1) / (w2*w2))
+    w4 = np.exp(-(x0*x0 + y2*y2) / (w2*w2))
+    w5 = 2.0*w1/w2
+    return (w5 * x0 * w3) + ( -w5 * x0 * w4)
+
+def S(y, y0, l): return 0.5*(1. + np.tanh((y-y0)/l))
+def bx(x, y):
+    sim = ph.global_vars.sim
+    Lx = sim.simulation_domain()[0]
+    Ly = sim.simulation_domain()[1]
+    w1, w2 = 0.2, 1.0
+    x0 = (x - 0.5 * Lx)
+    y1 = (y - 0.3 * Ly)
+    y2 = (y - 0.7 * Ly)
+    w3 = np.exp(-(x0*x0 + y1*y1) / (w2*w2))
+    w4 = np.exp(-(x0*x0 + y2*y2) / (w2*w2))
+    w5 = 2.0*w1/w2
+    v1, v2 = -1, 1.
+    return v1 + (v2-v1)*(S(y,Ly*0.3,0.5) -S(y, Ly*0.7, 0.5)) + (-w5*y1*w3) + (+w5*y2*w4)
+
+def bz(x, y): return 0.
+def b2(x, y): return bx(x,y)**2 + by(x, y)**2 + bz(x, y)**2
+def T(x, y):  return 1./density(x, y)*(1 - b2(x, y)*0.5)
+def vxyz(x, y): return 0.
+def vthxyz(x, y): return np.sqrt(T(x, y))
+
+def config():
+    ph.Simulation(# strict=True,
+        smallest_patch_size=patch_sizes[0], largest_patch_size=patch_sizes[1],
+        time_step_nbr=10, time_step=0.001,
+        cells=[cells] * 2, dl=[dl] * 2,
+        resistivity=0.001, hyper_resistivity=0.001,
+        diag_options={"format": "phareh5", "options": {"dir": diag_outputs, "mode":"overwrite"}},
+        refinement_boxes={},
+    )
+    ph.MaxwellianFluidModel( bx=bx, by=by, bz=bz,
+        protons={"charge": 1, "density": density, "init":{"seed": seed},
+          **{ "nbr_part_per_cell":100,
+            "vbulkx": vxyz, "vbulky": vxyz, "vbulkz": vxyz,
+            "vthx": vthxyz, "vthy": vthxyz, "vthz": vthxyz,
+          }
+        },
+    )
+    ph.ElectronModel(closure="isothermal", Te=0.0)
+
+    from tests.diagnostic import all_timestamps
+    timestamps = all_timestamps(ph.global_vars.sim)
+    timestamps = np.asarray([timestamps[0], timestamps[-1]])
+    for quantity in ["E", "B"]:
+        ph.ElectromagDiagnostics(
+            quantity=quantity,
+            write_timestamps=timestamps,
+            compute_timestamps=timestamps,
+        )
+
+if ph.PHARE_EXE or __name__=="__main__":
+    config()
+
+if __name__=="__main__":
+    from pyphare.simulator.simulator import Simulator
+    Simulator(ph.global_vars.sim).run()

--- a/tools/bench/real/sim/sim_2_1_4.cpp
+++ b/tools/bench/real/sim/sim_2_1_4.cpp
@@ -1,0 +1,16 @@
+
+
+#include "python3/cpp_simulator.h"
+
+namespace PHARE::pydata
+{
+PYBIND11_MODULE(cpp_sim_2_1_4, m)
+{
+    using dim          = std::integral_constant<std::size_t, 2>;
+    using interp       = std::integral_constant<std::size_t, 1>;
+    using nbRefinePart = std::integral_constant<std::size_t, 4>;
+
+    declare_essential(m);
+    declare_sim<dim, interp, nbRefinePart>(m);
+}
+} // namespace PHARE::pydata


### PR DESCRIPTION
add simple simulator pybind lib for assessing future changes

usage:

```
(cd build && cmake -Dbench=ON ..)
ninja -C build cpp_etc dictator cpp_sim_2_1_4
export PYTHONPATH=${PWD}:${PWD}/build:${PWD}/pyphare
python3 -Ou tools/bench/real/bench_harris.py
```