### PR TITLE
erase leaving domain particles even in first move

### DIFF
--- a/src/core/numerics/ion_updater/ion_updater.h
+++ b/src/core/numerics/ion_updater/ion_updater.h
@@ -145,6 +145,7 @@ void IonUpdater<Ions, Electromag, GridLayout>::updateAndDepositDomain_(Ions& ion
         auto newEnd
             = pusher_->move(inRange, outRange, em, pop.mass(), interpolator_, inDomainBox, layout);
 
+        domain.erase(newEnd, std::end(domain));
         interpolator_(std::begin(domain), newEnd, pop.density(), pop.flux(), layout);
 
         // then push patch and level ghost particles


### PR DESCRIPTION
The first move pushes particles in particles arrays that will be reset to before move before the second move.
As a result we did not bother erasing domain particles that leave the domain after pushing domain in that first phase.

The first move thus does:

particle array : [......domain particles in domain........]

move domain, keep those which left, between newEnd and end : 

particle array : [......domain particles in domain........ // ..... former domain that left.....]

push patch ghost and copy in domain those which entered : 
[......domain particles in domain........ // ..... former domain that left..... // ... patchGhost entered into domain.....]


This PR suggests to erase leaving domain particles so that : 

before move particle array : [......domain particles in domain........]
After move : particle array : [......domain particles in domain........]
After patch ghost move and copy : particle array : [......domain particles in domain........ // ..... patch ghost entered ....]

Erase does not cause a perf penalty since there is no reallocation, just the end is moved to the new size.
On the other hand, if we later map domain particles to cells, having a particle array that contains particles that are outside will force us to either map them anyway (which is not good for perf) or handle several ranges which is complicated...



