### PR TITLE
Range maker/replacer/refiller

### DIFF
--- a/res/cmake/def.cmake
+++ b/res/cmake/def.cmake
@@ -4,7 +4,9 @@ set (PHARE_FLAGS ${PHARE_FLAGS})
 set (PHARE_WERROR_FLAGS ${PHARE_FLAGS} ${PHARE_WERROR_FLAGS})
 set (PHARE_PYTHONPATH "${CMAKE_BINARY_DIR}:${CMAKE_SOURCE_DIR}/pyphare")
 
-set (PHARE_BASE_LIBS )
+find_package(Threads REQUIRED)
+
+set (PHARE_BASE_LIBS Threads::Threads)
 
 # Link Time Optimisation flags - is disabled if coverage is enabled
 set (PHARE_INTERPROCEDURAL_OPTIMIZATION FALSE)

--- a/src/core/utilities/range/range.hpp
+++ b/src/core/utilities/range/range.hpp
@@ -10,13 +10,14 @@ namespace core
     template<typename Iterator>
     struct Range
     {
+        using iterator          = Iterator;
         using iterator_category = typename Iterator::iterator_category;
         using value_type        = typename Iterator::value_type;
         using difference_type   = typename Iterator::difference_type;
         using reference         = typename Iterator::reference;
         using pointer           = typename Iterator::pointer;
 
-
+        Range() = default;
 
         template<class Container>
         explicit Range(Container const& c)
@@ -44,7 +45,7 @@ namespace core
     };
 
     template<typename Iterator>
-    Range<Iterator> makeRange(Iterator&& begin, Iterator&& last)
+    Range<Iterator> makeRange(Iterator begin, Iterator last)
     {
         return Range<Iterator>{std::forward<Iterator>(begin), std::forward<Iterator>(last)};
     }

--- a/src/core/utilities/range/range_replacer.hpp
+++ b/src/core/utilities/range/range_replacer.hpp
@@ -1,0 +1,239 @@
+#ifndef PHARE_CORE_UTILITITES_RANGE_REPLACER_HPP
+#define PHARE_CORE_UTILITITES_RANGE_REPLACER_HPP
+
+
+#include <vector>
+#include <iterator>
+#include <cstddef>
+#include <iterator>
+#include <algorithm>
+
+
+#include "core/utilities/range/ranges.hpp"
+
+
+namespace PHARE::core
+{
+template<typename Container, typename RangeType>
+struct SyncInfo
+{
+    SyncInfo(Container& container_, RangeType&& range_)
+        : container{container_}
+        , range{range_}
+    {
+    }
+
+    Container& container;
+    RangeType range;
+    std::size_t offset{};
+};
+
+template<typename Container>
+class RangeSynchrotron
+{
+    using iterator         = typename Container::iterator;
+    using value_type       = typename Container::value_type;
+    using RangeSyncInfo_t  = SyncInfo<Container, Range<iterator>>;
+    using VectorSyncInfo_t = SyncInfo<Container, Container>;
+    using RangeSyncVec_t   = std::vector<std::unique_ptr<RangeSyncInfo_t>>;
+    using VectorSyncVec_t  = std::vector<std::unique_ptr<VectorSyncInfo_t>>;
+
+public:
+    ~RangeSynchrotron() { sync(); }
+
+    void sync()
+    {
+        _erase(to_erase_list_per_thread);
+        _add(to_add_list_per_thread);
+        _add(to_add_copy_list_per_thread);
+        _erase(to_erase_src_list_per_thread);
+    }
+
+    RangeSynchrotron(std::uint16_t n_threads_ = 1)
+        : n_threads{n_threads_}
+        , to_add_list_per_thread(n_threads)
+        , to_add_copy_list_per_thread(n_threads)
+        , to_erase_list_per_thread(n_threads)
+        , to_erase_src_list_per_thread(n_threads)
+    {
+    }
+
+    void add(std::uint16_t const thread_idx, Container& container, Range<iterator>&& range,
+             bool copy = false)
+    {
+        if (copy)
+            to_add_copy_list_per_thread[thread_idx].emplace_back(std::make_unique<VectorSyncInfo_t>(
+                container, Container{range.begin(), range.end()}));
+        else
+            to_add_list_per_thread[thread_idx].emplace_back(
+                std::make_unique<RangeSyncInfo_t>(container, std::forward<Range<iterator>>(range)));
+    }
+
+    void erase(std::uint16_t const thread_idx, Container& container, std::size_t const offset,
+               Range<iterator>&& range, bool src = false)
+    {
+        auto& list_per_thread = src ? to_erase_src_list_per_thread : to_erase_list_per_thread;
+
+        list_per_thread[thread_idx]
+            .emplace_back(
+                std::make_unique<RangeSyncInfo_t>(container, std::forward<Range<iterator>>(range)))
+            ->offset
+            = offset;
+    }
+
+    std::uint16_t const n_threads = 1;
+
+private:
+    template<typename AddType>
+    void static _add(AddType& list_per_thread)
+    {
+        for (auto& to_add_list : list_per_thread)
+        {
+            for (auto& to_add : to_add_list)
+                std::copy(to_add->range.begin(), to_add->range.end(),
+                          std::back_inserter(to_add->container));
+
+            to_add_list.clear();
+        }
+    }
+
+    // erases must be in reverse, i.e. container.end() to container.begin()
+    void static _erase(std::vector<RangeSyncVec_t>& list_per_thread)
+    { // assumption is higher threads have higher offsets
+        for (auto it = list_per_thread.rbegin(); it < list_per_thread.rend(); ++it)
+        {
+            auto& to_erase_list = *it;
+
+            std::sort(to_erase_list.begin(), to_erase_list.end(), // highest offset first
+                      [](auto const& a, auto const& b) { return a->offset > b->offset; });
+
+            for (auto& to_erase : to_erase_list)
+                to_erase->container.erase(to_erase->container.begin() + to_erase->offset,
+                                          to_erase->container.begin() + to_erase->offset
+                                              + to_erase->range.size());
+
+            to_erase_list.clear();
+        }
+    }
+
+    std::vector<RangeSyncVec_t> to_add_list_per_thread;
+    std::vector<VectorSyncVec_t> to_add_copy_list_per_thread;
+    std::vector<RangeSyncVec_t> to_erase_list_per_thread;
+    std::vector<RangeSyncVec_t> to_erase_src_list_per_thread;
+};
+
+template<typename Container>
+class RangeReplacer
+{
+public:
+    using RangeSynchrotron_t = RangeSynchrotron<Container>;
+    using iterator           = typename Container::iterator;
+    using Range_t            = Range<iterator>;
+    using PartitionInfo      = std::vector<std::pair<std::size_t, std::size_t>>;
+
+    RangeReplacer(Container& dst_, RangeSynchrotron_t& synchrotron,
+                  std::uint16_t const thread_idx_ = 0)
+        : dst{dst_}
+        , synchrotron_{synchrotron}
+        , thread_idx{thread_idx_}
+    {
+    }
+
+    auto static make_unique(Container& dst, RangeSynchrotron_t& synchrotron,
+                            std::uint16_t const thread_idx = 0)
+    {
+        return std::make_unique<RangeReplacer<Container>>(dst, synchrotron, thread_idx);
+    }
+
+    void replace(Container& src, Range_t src_range, bool copy_src = false, bool erase_src = false)
+    {
+        auto src_size  = src_range.size();
+        auto src_begin = src_range.begin();
+
+        for (auto& partition_pair : replaceable)
+        {
+            if (src_size == 0)
+                break;
+
+            auto& [offset, n_replaceable] = partition_pair;
+
+            if (n_replaceable > 0)
+            {
+                auto replaceable = src_size > n_replaceable ? n_replaceable : src_size;
+
+                std::copy(src_begin, src_begin + replaceable, dst.begin() + offset);
+                src_size -= replaceable;
+                n_replaceable -= replaceable;
+                src_begin += replaceable;
+                offset += replaceable;
+            }
+        }
+
+        if (src_size > 0)
+        {
+            synchrotron_.add(thread_idx, dst, makeRange(src_begin, src_range.end()), copy_src);
+        }
+
+        if (erase_src)
+        {
+            std::size_t offset = std::distance(src.begin(), src_range.begin());
+            synchrotron_.erase(thread_idx, src, offset,
+                               makeRange(src_range.begin(), src_range.end()), true);
+        }
+    }
+
+
+    void erase()
+    {
+        std::sort(replaceable.begin(), replaceable.end(),
+                  [](auto const& a, auto const& b) { return a > b; });
+
+        for (auto& [offset, n_replaceable] : replaceable)
+        {
+            if (n_replaceable > 0)
+            {
+                if (threads_ == 1)
+                    dst.erase(dst.begin() + offset, dst.begin() + offset + n_replaceable);
+                else
+                    synchrotron_.erase(
+                        thread_idx, dst, offset,
+                        makeRange(dst.begin() + offset, dst.begin() + offset + n_replaceable));
+            }
+        }
+        replaceable.clear();
+    }
+
+    void add_replaceable(Range_t range, iterator newEnd)
+    {
+        auto offset = std::distance(dst.begin(), newEnd);
+        auto size   = std::distance(newEnd, range.end());
+        replaceable.push_back({offset, size});
+    }
+
+    template<typename Fn>
+    void add_replaceable(Range_t range, Fn fn)
+    {
+        add_replaceable(range, std::partition(range.begin(), range.end(), fn));
+    }
+
+    void replace_with(Container& src, Range_t range, iterator newEnd)
+    {
+        replace(src, makeRange(newEnd, range.end()));
+    }
+
+    template<typename Fn>
+    void replace_with(Container& src, Range_t range, Fn fn)
+    {
+        replace_with(src, range, std::partition(range.begin(), range.end(), fn));
+    }
+
+private:
+    Container& dst;
+    RangeSynchrotron_t& synchrotron_;
+    std::uint16_t const thread_idx = -1;
+    PartitionInfo replaceable{};
+    std::uint16_t threads_ = synchrotron_.n_threads;
+};
+} // namespace PHARE::core
+
+#endif // PHARE_CORE_UTILITITES_RANGE_REPLACER_HPP

--- a/src/core/utilities/range/ranges.hpp
+++ b/src/core/utilities/range/ranges.hpp
@@ -1,0 +1,105 @@
+#ifndef PHARE_CORE_UTILITITES_RANGES_HPP
+#define PHARE_CORE_UTILITITES_RANGES_HPP
+
+#include <vector>
+#include <iterator>
+#include <cstddef>
+#include <iterator>
+#include <algorithm>
+
+#include "core/utilities/types.hpp"
+#include "core/utilities/range/range.hpp"
+
+namespace PHARE::core
+{
+template<typename Container, typename Iterator = typename Container::iterator>
+auto ranges(Container& container, std::size_t batch_size, std::size_t offset = 0)
+{
+    std::size_t size     = container.size() - offset;
+    std::size_t modulo   = size % batch_size;
+    std::size_t n_ranges = size / batch_size;
+    std::vector<Range<Iterator>> ranges;
+    ;
+    ranges.reserve(n_ranges + (modulo > 0 ? 1 : 0));
+    auto begin = container.begin();
+    for (std::size_t i = 0; i < n_ranges; ++i)
+    {
+        begin = container.begin() + offset + i * batch_size;
+        ranges.emplace_back(makeRange(begin, begin + batch_size));
+    }
+    if (modulo > 0)
+    {
+        begin = container.begin() + offset + n_ranges * batch_size;
+        ranges.emplace_back(makeRange(begin, begin + modulo));
+    }
+    return ranges;
+}
+} // namespace PHARE::core
+
+namespace PHARE::core::detail
+{
+struct BalancedRangesDefaults
+{
+    auto static constexpr accessor = [](auto& el) -> auto& { return el; };
+    using Accessor                 = decltype(accessor);
+    auto static constexpr builder  = [](auto range, auto& el) { return range; };
+    using Builder                  = decltype(builder);
+};
+} // namespace PHARE::core::detail
+
+
+namespace PHARE::core
+{
+template<typename Container, typename Defaults = detail::BalancedRangesDefaults,
+         typename Accessor = typename Defaults::Accessor,
+         typename Builder  = typename Defaults::Builder>
+auto make_balanced_ranges(Container& container, std::size_t split = 10,
+                          Accessor accessor = Defaults::accessor,
+                          Builder builder   = Defaults::builder)
+{
+    using Array   = std::decay_t<std::result_of_t<Accessor&(typename Container::value_type&)>>;
+    using Range_t = Range<typename Array::iterator>;
+    using BuildRange_t
+        = std::decay_t<std::result_of_t<Builder&(Range_t const, typename Container::value_type&)>>;
+
+    auto arrays = core::generate([&](auto& el) { return &accessor(el); }, container);
+
+    std::vector<std::vector<BuildRange_t>> ranges_vec(split);
+    std::size_t arr_idx = 0, offset = 0;
+
+    auto load_ranges = [&](auto const t_idx, auto const size) {
+        auto rem = size;
+        while (rem > 0)
+        {
+            auto& arr  = *arrays[arr_idx];
+            auto range = makeRange(arr.begin() + offset, arr.end());
+            auto op    = rem >= range.size() ? range.size() : rem;
+
+            ranges_vec[t_idx].emplace_back(
+                builder(makeRange(range.begin(), range.begin() + op), container[arr_idx]));
+
+            offset += op;
+            if (rem >= range.size())
+            {
+                ++arr_idx;
+                offset = 0;
+            }
+            rem -= op;
+        }
+    };
+
+    auto const total = sum_from(container, [&](auto const& el) { return accessor(el).size(); });
+    std::size_t const each   = total / split;
+    std::size_t const modulo = total % split;
+
+    // give any remaining to index 0, assuming it's the main thread
+    load_ranges(0, each + modulo);
+    for (std::size_t i = 1; i < ranges_vec.size(); ++i)
+        load_ranges(i, each);
+
+    return ranges_vec;
+}
+
+} // namespace PHARE::core
+
+#endif // PHARE_CORE_UTILITITES_RANGES_HPP

--- a/src/core/utilities/types.hpp
+++ b/src/core/utilities/types.hpp
@@ -203,7 +203,7 @@ namespace core
 
 
     template<typename T, std::size_t... Is>
-    constexpr auto gft_helper(std::index_sequence<Is...> const&&)
+    constexpr auto gft_helper(std::index_sequence<Is...> const &&)
         -> decltype(std::make_tuple((Is, std::declval<T>())...));
 
     template<typename T, std::size_t N>
@@ -239,6 +239,52 @@ Return sum(Container const& container, Return r = 0)
 {
     return std::accumulate(container.begin(), container.end(), r);
 }
+
+
+template<typename Container, typename F>
+auto sum_from(Container const& container, F fn)
+{
+    using value_type  = typename Container::value_type;
+    using return_type = std::decay_t<std::result_of_t<F(value_type const&)>>;
+    return_type sum   = 0;
+    for (auto const& el : container)
+        sum += fn(el);
+    return sum;
+}
+
+
+template<typename F>
+auto generate(F&& f, std::size_t from, std::size_t to)
+{
+    using value_type = std::decay_t<std::result_of_t<F(std::size_t const&)>>;
+    std::vector<value_type> vec;
+    std::size_t count = to - from;
+    vec.reserve(count);
+    for (std::size_t i = from; i < to; ++i)
+        vec.emplace_back(f(i));
+    return vec;
+}
+
+template<typename F>
+auto generate(F&& f, std::size_t count)
+{
+    return generate(std::forward<F>(f), 0, count);
+}
+
+
+template<typename F, typename Container>
+auto generate(F&& f, Container& container)
+{
+    using T          = typename Container::value_type;
+    using value_type = std::decay_t<std::result_of_t<F(T&)>>;
+    std::vector<value_type> vec;
+    vec.reserve(container.size());
+    for (auto& v : container)
+        vec.emplace_back(f(v));
+    return vec;
+}
+
+
 } // namespace PHARE::core
 
 

--- a/tests/core/utilities/range/CMakeLists.txt
+++ b/tests/core/utilities/range/CMakeLists.txt
@@ -1,19 +1,8 @@
 cmake_minimum_required (VERSION 3.9)
 
-project(test-range)
+project(test_range)
 
-set(SOURCES test_main.cpp)
-
-add_executable(${PROJECT_NAME} ${SOURCES})
-
-target_include_directories(${PROJECT_NAME} PRIVATE
-  ${GTEST_INCLUDE_DIRS}
-  )
-
-target_link_libraries(${PROJECT_NAME} PRIVATE
-  phare_core
-  ${GTEST_LIBS})
-
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE ${GTEST_INCLUDE_DIRS} )
+target_link_libraries(${PROJECT_NAME} PRIVATE phare_core ${GTEST_LIBS})
 add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
-
-

--- a/tests/core/utilities/range/test_range.cpp
+++ b/tests/core/utilities/range/test_range.cpp
@@ -1,0 +1,16 @@
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "test_range.hpp"
+#include "test_ranges.hpp"
+#include "test_range_replacer.hpp"
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/core/utilities/range/test_range.hpp
+++ b/tests/core/utilities/range/test_range.hpp
@@ -1,3 +1,5 @@
+#ifndef PHARE_TEST_UTILITY_TEST_RANGE_HPP
+#define PHARE_TEST_UTILITY_TEST_RANGE_HPP
 
 #include <string>
 
@@ -37,11 +39,4 @@ TEST(ARange, returnBeginAndEnd)
 }
 
 
-
-
-int main(int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-
-    return RUN_ALL_TESTS();
-}
+#endif /*  PHARE_TEST_UTILITY_TEST_RANGE_HPP  */

--- a/tests/core/utilities/range/test_range_replacer.hpp
+++ b/tests/core/utilities/range/test_range_replacer.hpp
@@ -1,0 +1,350 @@
+#ifndef PHARE_TEST_UTILITY_TEST_RANGE_REPLACER_HPP
+#define PHARE_TEST_UTILITY_TEST_RANGE_REPLACER_HPP
+
+#include "core/utilities/range/range_replacer.hpp"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <thread>
+
+namespace PHARE::core
+{
+template<typename Container, typename DstPartitionFn, typename SrcPartitionFn>
+void replace(Container& dst, Container& src, std::size_t batch_size, DstPartitionFn dstFn,
+             SrcPartitionFn srcFn)
+{
+    RangeSynchrotron<Container> synchrotron;             // Only one
+    RangeReplacer<Container> refiller{dst, synchrotron}; // potentially one of many
+
+    for (auto& range : ranges(dst, batch_size))
+        refiller.add_replaceable(range, dstFn);
+    for (auto& range : ranges(src, batch_size))
+        refiller.replace_with(src, range, srcFn);
+}
+
+template<typename Container, typename DstPartitionFn>
+void replace(Container& src, Container& dst, std::size_t batch_size, DstPartitionFn fn)
+{
+    replace(src, dst, batch_size, fn, [&](auto const& v) { return !(fn(v)); });
+}
+
+TEST(RangeReplacer, test_replacer_v0)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    for (std::size_t i = 0; i < range_size; ++i)
+        src.emplace_back(i);
+
+    replace(
+        dst, src, batch_size, [](auto const& v) { return v % 2 == 0; },
+        [](auto const& v) { return v % 2 != 0; });
+
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+
+    EXPECT_EQ(dst.size(), range_size + range_size / 2);
+}
+
+TEST(RangeReplacer, test_replacer_v1)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    for (std::size_t i = 0; i < range_size; ++i)
+        src.emplace_back(i);
+
+    replace(dst, src, batch_size, [](auto const& v) { return v % 2 == 0; });
+
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+
+    EXPECT_EQ(dst.size(), range_size + range_size / 2);
+}
+
+TEST(RangeReplacer, test_replacer_v2)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100, extra = 22;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    for (std::size_t i = 0; i < range_size + extra; ++i)
+        src.emplace_back(i);
+
+    replace(dst, src, batch_size, [](auto const& v) { return v % 2 == 0; });
+
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+
+    EXPECT_EQ(dst.size(), range_size + range_size / 2 + extra / 2);
+}
+
+TEST(RangeReplacer, test_replacer_v3)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100, less = 22;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    for (std::size_t i = 0; i < range_size - less; ++i)
+        src.emplace_back(i);
+
+    replace(dst, src, batch_size, [](auto const& v) { return v % 2 == 0; });
+
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+
+    EXPECT_EQ(dst.size(), range_size + range_size / 2 - less / 2);
+}
+
+TEST(RangeReplacer, test_replacer_v4)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100, less = 22;
+
+    V dst(range_size - less);
+    for (std::size_t i = 0; i < range_size - less; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    for (std::size_t i = 0; i < range_size; ++i)
+        src.emplace_back(i);
+
+    replace(dst, src, batch_size, [](auto const& v) { return v % 2 == 0; });
+
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+
+    EXPECT_EQ(dst.size(), range_size - less + range_size / 2);
+}
+
+
+TEST(RangeReplacer, test_replacer_v5)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    EXPECT_EQ(src.size(), range_size);
+    for (std::size_t i = 0; i < range_size * 2; ++i)
+        dst.emplace_back(i);
+    EXPECT_EQ(dst.size(), range_size * 3);
+
+    auto dstFn = [](auto const& v) { return v % 2 == 0; };
+    auto srcFn = [&](auto const& v) { return !(dstFn(v)); };
+
+    {
+        RangeSynchrotron<V> synchrotron;             // Only one
+        RangeReplacer<V> refiller{dst, synchrotron}; // potentially one of many
+
+        for (auto& range : ranges(dst, batch_size))
+            refiller.add_replaceable(range, dstFn);
+        for (auto& range : ranges(src, batch_size))
+            refiller.replace_with(src, range, srcFn);
+
+        EXPECT_EQ(dst.size(), range_size * 3);
+        refiller.erase(); // can be called in parallel
+    }
+
+    EXPECT_EQ(dst.size(), range_size * 2);
+
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+
+    EXPECT_EQ(dst.size(), range_size + range_size);
+}
+
+
+
+TEST(RangeReplacer, test_replacer_v6)
+{
+    using V = std::vector<std::size_t>;
+
+    std::size_t batch_size = 50, range_size = 100;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    V src = dst;
+    EXPECT_EQ(src.size(), range_size);
+    for (std::size_t i = 0; i < range_size * 2; ++i)
+        dst.emplace_back(i);
+    EXPECT_EQ(dst.size(), range_size * 3);
+
+    auto dstFn = [](auto const& v) { return v % 2 == 0; };
+    auto srcFn = [&](auto const& v) { return !(dstFn(v)); };
+
+    {
+        RangeSynchrotron<V> synchrotron;             // Only one
+        RangeReplacer<V> refiller{dst, synchrotron}; // potentially one of many
+
+        for (auto& range : ranges(dst, batch_size))
+            refiller.add_replaceable(range, dstFn);
+        for (auto& range : ranges(src, batch_size))
+            refiller.replace(
+                src, makeRange(std::partition(range.begin(), range.end(), srcFn), range.end()),
+                /*copy_src*/ false, /*erase=*/true);
+
+        EXPECT_EQ(dst.size(), range_size * 3);
+        refiller.erase(); // can be called in parallel
+    }
+
+    EXPECT_EQ(src.size(), range_size / 2);
+    EXPECT_EQ(dst.size(), range_size * 2);
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+}
+
+
+
+
+TEST(RangeReplacer, test_replacer_pseudo_parallel)
+{
+    using V                         = std::vector<std::size_t>;
+    constexpr std::size_t n_threads = 3; // not really
+
+    std::size_t batch_size = 50, range_size = 100;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    auto src = ConstArray<V, n_threads>(dst);
+    EXPECT_EQ(src[0].size(), range_size);
+
+    for (std::size_t i = 0; i < range_size * 2; ++i)
+        dst.emplace_back(i);
+    EXPECT_EQ(dst.size(), range_size * 3);
+
+    auto dstFn = [](auto const& v) { return v % 2 == 0; };
+    auto srcFn = [&](auto const& v) { return !(dstFn(v)); };
+
+    {
+        RangeSynchrotron<V> synchrotron{n_threads}; // Only one
+
+        auto refillers = generate(
+            [&](auto i) { return std::make_unique<RangeReplacer<V>>(dst, synchrotron, i); },
+            n_threads);
+
+        for (auto& range : ranges(dst, batch_size))
+            refillers[0]->add_replaceable(range, dstFn);
+
+        for (std::uint16_t i = 0; i < n_threads; ++i)
+        {
+            for (auto& range : ranges(src[i], batch_size))
+                refillers[i]->replace(
+                    src[i],
+                    makeRange(std::partition(range.begin(), range.end(), srcFn), range.end()),
+                    /*copy_src*/ false, /*erase=*/true);
+
+            refillers[i]->erase(); // can be called in parallel
+        }
+    }
+
+    for (std::uint16_t i = 0; i < n_threads; ++i)
+        EXPECT_EQ(src[i].size(), range_size / 2);
+
+    EXPECT_EQ(dst.size(), range_size * 3);
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+}
+
+
+
+
+TEST(RangeReplacer, test_replacer_parallel)
+{
+    using V                         = std::vector<std::size_t>;
+    constexpr std::size_t n_threads = 3;
+
+    std::size_t batch_size = 50, range_size = 100;
+
+    V dst(range_size);
+    for (std::size_t i = 0; i < range_size; ++i)
+        dst[i] = i;
+
+    auto src = ConstArray<V, n_threads>(dst);
+    EXPECT_EQ(src[0].size(), range_size);
+
+    for (std::size_t i = 0; i < range_size * 2; ++i)
+        dst.emplace_back(i);
+    EXPECT_EQ(dst.size(), range_size * 3);
+
+    auto dstFn = [](auto const& v) { return v % 2 == 0; };
+    auto srcFn = [&](auto const& v) { return !(dstFn(v)); };
+
+    {
+        RangeSynchrotron<V> synchrotron{n_threads}; // Only one
+
+        auto refillers = generate(
+            [&](auto i) { return std::make_unique<RangeReplacer<V>>(dst, synchrotron, i); },
+            n_threads);
+
+        EXPECT_EQ(refillers.size(), n_threads);
+
+        for (auto& range : ranges(dst, batch_size))
+            refillers[0]->add_replaceable(range, dstFn);
+
+        auto threads = generate(
+            [&](auto i) {
+                return std::thread([&, i]() {
+                    for (auto& range : ranges(src[i], batch_size))
+                        refillers[i]->replace(
+                            src[i],
+                            makeRange(std::partition(range.begin(), range.end(), srcFn),
+                                      range.end()),
+                            /*copy_src*/ false, /*erase=*/true);
+
+                    refillers[i]->erase();
+                });
+            },
+            n_threads);
+
+        for (auto& thread : threads)
+            if (thread.joinable())
+                thread.join();
+    }
+
+    for (std::uint16_t i = 0; i < n_threads; ++i)
+        EXPECT_EQ(src[i].size(), range_size / 2);
+
+    EXPECT_EQ(dst.size(), range_size * 3);
+    for (auto& v : dst)
+        EXPECT_EQ(v % 2, 0);
+}
+
+
+
+} // namespace PHARE::core
+
+
+#endif /*  PHARE_TEST_UTILITY_TEST_RANGE_REPLACER_HPP  */

--- a/tests/core/utilities/range/test_ranges.hpp
+++ b/tests/core/utilities/range/test_ranges.hpp
@@ -1,0 +1,211 @@
+#ifndef PHARE_TEST_UTILITY_TEST_RANGES_HPP
+#define PHARE_TEST_UTILITY_TEST_RANGES_HPP
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "core/utilities/range/ranges.hpp"
+
+namespace PHARE::core
+{
+template<typename RangesList>
+auto _check_ranges(RangesList const& ranges_list, std::size_t val = 0)
+{
+    for (auto const& ranges : ranges_list)
+    {
+        EXPECT_GE(ranges.size(), 1);
+        for (auto const& range : ranges)
+        {
+            EXPECT_GE(range.size(), 1);
+            for (auto const& s : range)
+                EXPECT_EQ(s, val++);
+        }
+    }
+    return val;
+}
+
+
+TEST(Ranges, test_range_builder_simple)
+{
+    using V                   = std::vector<std::size_t>;
+    std::size_t constexpr MAX = 10 * 100;
+
+    std::vector<V> vs(10);
+    std::size_t val = 0;
+    for (auto& v : vs)
+        for (std::size_t i = 0; i < 100; ++i)
+            v.emplace_back(val++);
+
+    EXPECT_EQ(val, MAX);
+    EXPECT_EQ(_check_ranges(make_balanced_ranges(vs)), MAX);
+}
+
+TEST(Ranges, test_range_builder_v0)
+{
+    using V                   = std::vector<std::size_t>;
+    std::size_t constexpr MAX = 70;
+
+    std::vector<V> vs(5);
+    std::size_t val = 0;
+
+    for (std::size_t i = 0; i < 10; ++i)
+        vs[0].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 20; ++i)
+        vs[1].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 10; ++i)
+        vs[2].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 20; ++i)
+        vs[3].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 10; ++i)
+        vs[4].emplace_back(val++);
+
+    EXPECT_EQ(val, MAX);
+    EXPECT_EQ(_check_ranges(make_balanced_ranges(vs)), MAX);
+}
+
+
+TEST(Ranges, test_range_builder_v1)
+{
+    using V                   = std::vector<std::size_t>;
+    std::size_t constexpr MAX = 430;
+
+    std::vector<V> vs(5);
+    std::size_t val = 0;
+
+    for (std::size_t i = 0; i < 10; ++i)
+        vs[0].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 200; ++i)
+        vs[1].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 10; ++i)
+        vs[2].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 200; ++i)
+        vs[3].emplace_back(val++);
+
+    for (std::size_t i = 0; i < 10; ++i)
+        vs[4].emplace_back(val++);
+
+    EXPECT_EQ(val, MAX);
+    EXPECT_EQ(_check_ranges(make_balanced_ranges(vs)), MAX);
+}
+
+namespace detail
+{
+    struct S
+    {
+        S(std::size_t i_)
+            : i{i_}
+        {
+        }
+
+        std::size_t i = 0;
+    };
+
+    struct V
+    {
+        std::vector<S> s;
+    };
+
+} // namespace detail
+
+TEST(Ranges, test_range_builder_v2)
+{
+    std::vector<detail::V> vs(2);
+    std::size_t constexpr SPLIT_IN = 10;
+    std::size_t constexpr MAX      = 300;
+
+    {
+        std::size_t val = 0;
+        for (std::size_t i = 0; i < MAX / 2 - 5; ++i)
+            vs[0].s.emplace_back(val++);
+        for (std::size_t i = 0; i < MAX / 2 + 5; ++i)
+            vs[1].s.emplace_back(val++);
+
+        EXPECT_EQ(val, MAX);
+        EXPECT_EQ(vs[1].s.back().i + 1, val);
+    }
+
+    auto ranges_vec = make_balanced_ranges(
+        vs, SPLIT_IN, [](auto& el) -> auto& { return el.s; });
+
+    std::size_t val = 0;
+    for (auto const& ranges : ranges_vec)
+    {
+        std::size_t ranges_cover = 0;
+        EXPECT_GE(ranges.size(), 1);
+        for (auto const& range : ranges)
+        {
+            ranges_cover += range.size();
+            for (auto const& s : range)
+                EXPECT_EQ(s.i, val++);
+        }
+        EXPECT_EQ(ranges_cover, 30);
+    }
+
+    EXPECT_EQ(val, 300);
+}
+
+
+namespace detail
+{
+    struct R : public Range<std::vector<S>::iterator>
+    {
+        using Super = Range<std::vector<S>::iterator>;
+
+        R(Super&& super)
+            : Super{std::forward<Super>(super)}
+        {
+        }
+    };
+} // namespace detail
+
+TEST(Ranges, test_range_builder_v3)
+{
+    using Range_t                  = Range<std::vector<detail::S>::iterator>;
+    std::size_t constexpr SPLIT_IN = 10;
+    std::size_t constexpr MAX      = 300;
+
+    std::vector<detail::V> vs(2);
+
+    {
+        std::size_t val = 0;
+        for (std::size_t i = 0; i < MAX / 2 - 5; ++i)
+            vs[0].s.emplace_back(val++);
+        for (std::size_t i = 0; i < MAX / 2 + 5; ++i)
+            vs[1].s.emplace_back(val++);
+        EXPECT_EQ(val, MAX);
+        EXPECT_EQ(vs[1].s.back().i + 1, val);
+    }
+
+    auto ranges_vec = make_balanced_ranges(
+        vs, SPLIT_IN, [](auto& el) -> auto& { return el.s; },
+        [](auto&& range, auto& el) { return detail::R{std::forward<Range_t>(range)}; });
+
+    EXPECT_EQ(ranges_vec.size(), SPLIT_IN);
+
+    std::size_t val = 0;
+    for (auto const& ranges : ranges_vec)
+    {
+        std::size_t ranges_cover = 0;
+        EXPECT_GE(ranges.size(), 1);
+        for (auto const& range : ranges)
+        {
+            ranges_cover += range.size();
+            for (auto const& s : range)
+                EXPECT_EQ(s.i, val++);
+        }
+        EXPECT_EQ(ranges_cover, 30);
+    }
+
+    EXPECT_EQ(val, MAX);
+}
+
+} // namespace PHARE::core
+
+#endif /*  PHARE_TEST_UTILITY_TEST_RANGES_HPP  */


### PR DESCRIPTION
Allows splitting of containers into parts (ranges) so each part can be operated on independently.
Range replacer/refiller, currently not used, but added with tests for if/when it will be used. if not ever used. rm