### PR TITLE
fix the finest_part_data to work (at least in 1d)

### DIFF
--- a/pyphare/pyphare/core/box.py
+++ b/pyphare/pyphare/core/box.py
@@ -131,7 +131,7 @@ def shrink(box, size):
 
 def remove(box, to_remove):
     """
-    removes "remove" from the box
+    removes "to_remove" from the box
     this operation returns the list of the boxes
     that are not part of the intersection box*remove
     """
@@ -185,3 +185,18 @@ def remove(box, to_remove):
 
 def amr_to_local(box, ref_box):
     return Box(box.lower - ref_box.lower, box.upper - ref_box.lower)
+
+
+def icells_is_in_box(icells, box):
+
+    idx0 = (icells[:,0] > box.lower[0]) & (icells[:,0] < box.upper[0])
+    idx1 = np.ones_like(idx0)*True
+    idx2 = np.ones_like(idx0)*True
+
+    if box.ndim > 1:
+        idx1 = (icells[:,1] > box.lower[1]) & (icells[:,1] < box.upper[1])
+        if box.ndim > 2:
+            idx2 = (icells[:,2] > box.lower[2]) & (icells[:,2] < box.upper[2])
+
+    return idx0 & idx1 & idx2
+

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -7,6 +7,7 @@ from .particles import Particles
 
 from ..core import box as boxm
 from ..core.box import Box
+from ..core.box import icells_is_in_box
 from ..core.gridlayout import GridLayout
 import matplotlib.pyplot as plt
 from ..core.phare_utilities import refinement_ratio, deep_copy
@@ -490,15 +491,16 @@ def finest_part_data(hierarchy, time=None):
                     create = True
                     for finerBox in lvlPatchBoxes[ilvl+1]:
                         coarseFinerBox = boxm.coarsen(finerBox, refinement_ratio)
-                        within = np.where((icells >= coarseFinerBox.lower[0]) &\
-                                                 (icells <= coarseFinerBox.upper[0]))[0]
+                        within = icells_is_in_box(icells, coarseFinerBox)
+
                         if create:
                             toRemove = within
                             create=False
                         else:
-                            toRemove = np.concatenate((toRemove, within))
+                            toRemove = toRemove | within
 
                     parts = remove(parts, toRemove)
+
                     if parts is not None:
                         particles[popname].add(parts)
     return particles

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -60,15 +60,16 @@ def dist_plot(particles, **kwargs):
         y = particles.v[:,vaxis[axis[1]]]
 
     bins = kwargs.get("bins", (50,50))
+
     h, xh, yh  = np.histogram2d(x, y,
               bins=kwargs.get("bins", bins),
-              weights=particles.weights)
+              weights=particles.weights[:,0])
 
-    if "gaussian_filter_sigma" in kwargs and "median_filter_size" not in kwargs: 
+    if "gaussian_filter_sigma" in kwargs and "median_filter_size" not in kwargs:
         from scipy.ndimage import gaussian_filter
         sig = kwargs.get("gaussian_filter_sigma", (0,0))
         image = gaussian_filter(h.T, sigma=sig)
-    elif "median_filter_size" in kwargs and "gaussian_filter_sigma" not in kwargs: 
+    elif "median_filter_size" in kwargs and "gaussian_filter_sigma" not in kwargs:
         from scipy.ndimage import median_filter
         siz = kwargs.get("median_filter_size", (0,0))
         image = median_filter(h.T, size=siz)
@@ -103,7 +104,7 @@ def dist_plot(particles, **kwargs):
         ax.set_xlim(kwargs["xlim"])
     if "ylim" in kwargs:
         ax.set_ylim(kwargs["ylim"])
-    ax.legend()
+    # ax.legend()
 
     if "bulk" in kwargs:
         if kwargs["bulk"] is True:

--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -121,7 +121,7 @@ def make_interpolator(data, coords, interp, domain, dl, qty, nbrGhosts):
 
         if interp == 'nearest':
             interpolator = NearestNDInterpolator(coords, data)
-        elif interp == 'bilinear':
+        elif interp == 'linear':
             interpolator = LinearNDInterpolator(coords, data)
         else:
             raise ValueError("interp can only be 'nearest' or 'bilinear'")
@@ -129,8 +129,7 @@ def make_interpolator(data, coords, interp, domain, dl, qty, nbrGhosts):
         nCells = [1+int(d/dl) for d,dl in zip(domain, dl)]
         x = yeeCoordsFor([0]*dim, nbrGhosts, dl, nCells,  qty, "x")
         y = yeeCoordsFor([0]*dim, nbrGhosts, dl, nCells,  qty, "y")
-        #x = np.arange(0, domain[0]+dl[0], dl[0])
-        #y = np.arange(0, domain[1]+dl[1], dl[1])
+
         finest_coords = (x, y)
 
     else:


### PR DESCRIPTION

This PR makes the `finest_part_data` working with the new format
of particles data (like `iCells` had a size `(num_of_part)` while now,
it is of size `(nom_of_part, ndim)`. It can be used with something like :

```
allParts = Run(run_path).GetParticles(time=time, pop_name=pop_name)
particles = finest_part_data(allParts)

# ..... scatter plot in x-vx plane
plt.scatter(particles["proton"].x,
            particles["proton"].v[:,0],
            s=particles["proton"].weights*100)
```

While used in 1D, not all the functions have been tested, neither their 2D
form.
