### PR TITLE
fix the finest_part_data to work (at least in 1d)

### DIFF
--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -510,7 +510,8 @@ def finest_part_data(hierarchy, time=None):
                         else:
                             toRemove = np.concatenate((toRemove, within))
 
-                    parts = remove(parts, toRemove)
+                    if toRemove.size != 0:
+                        parts = remove(parts, toRemove)
                     if parts is not None:
                         particles[popname].add(parts)
     return particles

--- a/pyphare/pyphare/pharesee/particles.py
+++ b/pyphare/pyphare/pharesee/particles.py
@@ -39,8 +39,6 @@ class Particles:
 
 
     def xyz(self, i=0):
-        if self.ndim == 1:
-            return self.dl[:,0]*(self.iCells[:] + self.deltas[:])
         return self.dl[:,i]*(self.iCells[:,i] + self.deltas[:,i])
 
 
@@ -241,8 +239,8 @@ def remove(particles, idx):
     if len(idx) == particles.size():
         return None
 
-    icells = np.delete(particles.iCells, idx)
-    deltas = np.delete(particles.deltas, idx)
+    icells = np.delete(particles.iCells, idx, axis=0)
+    deltas = np.delete(particles.deltas, idx, axis=0)
     vx = np.delete(particles.v[:,0], idx)
     vy = np.delete(particles.v[:,1], idx)
     vz = np.delete(particles.v[:,2], idx)
@@ -250,12 +248,13 @@ def remove(particles, idx):
     v[:,0] = vx
     v[:,1] = vy
     v[:,2] = vz
-    weights = np.delete(particles.weights, idx)
+    weights = np.delete(particles.weights, idx, axis=0)
     dl = np.zeros((len(weights),particles.ndim))
     for i in range(particles.ndim):
         dl[:,i] = np.delete(particles.dl[:,i], idx)
 
-    charges = np.delete(particles.charges, idx)
+    charges = np.delete(particles.charges, idx, axis=0)
+
     return Particles(icells=icells,
                      deltas=deltas,
                      v = v,

--- a/pyphare/pyphare/pharesee/plotting.py
+++ b/pyphare/pyphare/pharesee/plotting.py
@@ -62,7 +62,7 @@ def dist_plot(particles, **kwargs):
     bins = kwargs.get("bins", (50,50))
     h, xh, yh  = np.histogram2d(x, y,
               bins=kwargs.get("bins", bins),
-              weights=particles.weights)
+              weights=particles.weights[:,0])
 
     if "gaussian_filter_sigma" in kwargs and "median_filter_size" not in kwargs: 
         from scipy.ndimage import gaussian_filter
@@ -103,7 +103,6 @@ def dist_plot(particles, **kwargs):
         ax.set_xlim(kwargs["xlim"])
     if "ylim" in kwargs:
         ax.set_ylim(kwargs["ylim"])
-    ax.legend()
 
     if "bulk" in kwargs:
         if kwargs["bulk"] is True:


### PR DESCRIPTION
This PR makes the `finest_part_data` working with the new format
of particles data (like `iCells` had a size `(num_of_part)` while now,
it is of size `(nom_of_part, ndim)`. It can be used with something like :

```
allParts = Run(run_path).GetParticles(time=time, pop_name=pop_name)
particles = finest_part_data(allParts)

plt.scatter(particles["proton"].x,
            particles["proton"].v[:,0],
            s=particles["proton"].weights*100)
```