### PR TITLE
sync n and v

### DIFF
--- a/src/amr/data/field/field_geometry.hpp
+++ b/src/amr/data/field/field_geometry.hpp
@@ -65,14 +65,7 @@ namespace amr
             SAMRAI::hier::IntVector growth(SAMRAI::tbox::Dimension{dimension});
             for (auto dir = 0u; dir < dimension; ++dir)
             {
-                std::cout << static_cast<int>(centerings[dir]) << " and "
-                          << static_cast<int>(PHARE::core::QtyCentering::primal) << "\n";
-                if (static_cast<int>(centerings[dir]) == static_cast<int>(0))
-                {
-                    growth[dir] = -1;
-                }
-                else
-                    growth[dir] = 0;
+                growth[dir] = (centerings[dir] == core::QtyCentering::primal) ? -1 : 0;
             }
             noSharedNodeBox.grow(growth);
             return noSharedNodeBox;

--- a/src/amr/level_initializer/hybrid_level_initializer.hpp
+++ b/src/amr/level_initializer/hybrid_level_initializer.hpp
@@ -105,10 +105,11 @@ namespace solver
                     core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
                 }
 
-                core::fixMomentGhosts(ions, layout);
                 ions.computeDensity();
                 ions.computeBulkVelocity();
             }
+            hybMessenger.fillIonMomentGhosts(hybridModel.state.ions, level, initDataTime,
+                                             initDataTime);
 
 
             if (isRootLevel(levelNumber))

--- a/src/amr/level_initializer/hybrid_level_initializer.hpp
+++ b/src/amr/level_initializer/hybrid_level_initializer.hpp
@@ -1,5 +1,3 @@
-
-
 #ifndef PHARE_HYBRID_LEVEL_INITIALIZER_HPP
 #define PHARE_HYBRID_LEVEL_INITIALIZER_HPP
 
@@ -108,8 +106,7 @@ namespace solver
                 ions.computeDensity();
                 ions.computeBulkVelocity();
             }
-            hybMessenger.fillIonMomentGhosts(hybridModel.state.ions, level, initDataTime,
-                                             initDataTime);
+            hybMessenger.fillIonMomentGhosts(hybridModel.state.ions, level, initDataTime);
 
 
             if (isRootLevel(levelNumber))

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -57,7 +57,8 @@ namespace amr
 
         std::vector<Property> getFieldNamesAndQuantities() const { return {{name, quantity}}; }
 
-        void setBuffer([[maybe_unused]] std::string const& bufferName, FieldT* field) { f = field; }
+        void setBuffer(std::string const& /*bufferName*/, FieldT* field) { f = field; }
+        void copyData(FieldT const& source) { f->copyData(source); }
     };
 
 
@@ -569,7 +570,7 @@ namespace amr
                 EM_old_.copyData(EM);
                 Jold_.copyData(J);
                 ViOld_.copyData(Vi);
-                NiOldUser_.f->copyData(Ni);
+                NiOldUser_.copyData(Ni);
             }
         }
 

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -386,8 +386,8 @@ namespace amr
          * for all populations, linear time interpolation is used to get the contribution of old/new
          * particles
          */
-        void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                 double const afterPushTime) override
+        void fillIonPopMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
+                                    double const afterPushTime) override
         {
             PHARE_LOG_SCOPE("HybridHybridMessengerStrategy::fillIonMomentGhosts");
 
@@ -436,7 +436,7 @@ namespace amr
          * population densities and fluxes. These partial densities and fluxes are thus
          * not available on ANY ghost node.*/
         virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                         double beforePushTime, double const afterPushTime) override
+                                         double const afterPushTime) override
         {
             densityGhosts_.fill(level.getLevelNumber(), afterPushTime);
             bulkVelGhosts_.fill(level.getLevelNumber(), afterPushTime);

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_HYBRID_HYBRID_MESSENGER_STRATEGY_HPP
 #define PHARE_HYBRID_HYBRID_MESSENGER_STRATEGY_HPP
 
@@ -34,6 +33,35 @@ namespace PHARE
 {
 namespace amr
 {
+
+    // this structure is a wrapper of a field*
+    // so to serve as a ResourcesUser for the ResourcesManager
+    template<typename FieldT>
+    struct FieldUser
+    {
+        struct Property
+        {
+            std::string name;
+            typename HybridQuantity::Scalar qty;
+        };
+        FieldUser(std::string fieldName, FieldT* ptr, typename HybridQuantity::Scalar qty)
+            : name{fieldName}
+            , f{ptr}
+            , quantity{qty}
+        {
+        }
+        std::string name;
+        FieldT* f;
+        typename HybridQuantity::Scalar quantity;
+        using field_type = FieldT;
+
+        std::vector<Property> getFieldNamesAndQuantities() const { return {{name, quantity}}; }
+
+        void setBuffer([[maybe_unused]] std::string const& bufferName, FieldT* field) { f = field; }
+    };
+
+
+
     /** \brief An HybridMessenger is the specialization of a HybridMessengerStrategy for hybrid to
      * hybrid data communications.
      */
@@ -68,6 +96,8 @@ namespace amr
         {
             resourcesManager_->registerResources(EM_old_);
             resourcesManager_->registerResources(Jold_);
+            resourcesManager_->registerResources(NiOldUser_);
+            resourcesManager_->registerResources(ViOld_);
         }
 
         virtual ~HybridHybridMessengerStrategy() = default;
@@ -86,6 +116,8 @@ namespace amr
         {
             resourcesManager_->allocate(EM_old_, patch, allocateTime);
             resourcesManager_->allocate(Jold_, patch, allocateTime);
+            resourcesManager_->allocate(NiOldUser_, patch, allocateTime);
+            resourcesManager_->allocate(ViOld_, patch, allocateTime);
         }
 
 
@@ -123,10 +155,13 @@ namespace amr
          *  - electric fields
          *  - patch ghost particles
          *
-         *  ion moments : do not need to be filled on ghost node by SAMRAI schedules
+         *  ion moments :
+         *  do not need to be filled on shared border nodes by SAMRAI schedules
          *  since they will be filled with levelGhostParticles[old,new] on level ghost nodes
          *  and computed by ghost particles on interior patch ghost nodes
-         *
+         *  however they need to be filled on pure ghost nodes.
+         *  Note : they are filled for all pure ghost nodes for now although
+         *  only the first one is needed (for the coarsening stencil).
          *
          * Init communicators that need to know this level :
          *
@@ -147,6 +182,9 @@ namespace amr
             magneticGhosts_.registerLevel(hierarchy, level);
             electricGhosts_.registerLevel(hierarchy, level);
             currentGhosts_.registerLevel(hierarchy, level);
+
+            densityGhosts_.registerLevel(hierarchy, level);
+            bulkVelGhosts_.registerLevel(hierarchy, level);
 
             patchGhostParticles_.registerLevel(hierarchy, level);
 
@@ -339,11 +377,13 @@ namespace amr
 
 
         /**
-         * @brief fillIonMomentGhosts will compute the ion moments for all species on ghost nodes.
+         * @brief fillIonMomentGhosts works on moment ghost nodes
          *
-         * For patch ghost nodes, patch ghost particles are used.
-         * For level ghost nodes, levelGhostParticlesOld and new are both projected with a time
-         * interpolation coef.
+         * patch border node moments are completed by the deposition of patch ghost particles
+         * for all populations
+         * level border nodes are completed by the deposition of level ghost [old,new] particles
+         * for all populations, linear time interpolation is used to get the contribution of old/new
+         * particles
          */
         void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
                                  double const afterPushTime) override
@@ -388,6 +428,18 @@ namespace amr
         }
 
 
+        /* pure (patch and level) ghost nodes are filled by applying a regular ghost schedule
+         * i.e. that does not overwrite the border patch node previously well calculated from
+         * particles
+         * Note : the ghost schedule only fills the total density and bulk velocity and NOT
+         * population densities and fluxes. These partial densities and fluxes are thus
+         * not available on ANY ghost node.*/
+        virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
+                                         double beforePushTime, double const afterPushTime) override
+        {
+            densityGhosts_.fill(level.getLevelNumber(), afterPushTime);
+            bulkVelGhosts_.fill(level.getLevelNumber(), afterPushTime);
+        }
 
         /**
          * @brief firstStep : in the HybridHybridMessengerStrategy, the firstStep method is used to
@@ -484,12 +536,13 @@ namespace amr
         /**
          * @brief prepareStep is the concrete implementation of the
          * HybridMessengerStrategy::prepareStep method For hybrid-Hybrid communications.
-         * This method copies the current model electromagnetic field and current, defined at
-         * t=n. Since prepareStep() is called just before advancing the level, this operation
-         * actually saves the t=n electromagnetic field and current into the messenger. When the
-         * time comes that the next finer level needs to time interpolate the electromagnetic
-         * field and current at its ghost nodes, this level will have its model EM field  and
-         * current at t=n+1 and thanks to this methods, the t=n field will be in the messenger.
+         * This method copies the current model electromagnetic field E,B, the current density J,
+         * and the density and bulk velocity, defined at t=n. Since prepareStep() is called just
+         * before advancing the level, this operation actually saves the t=n versions of E,B,J,Ni,Vi
+         * into the messenger. When the time comes that the next finer level needs to
+         * time interpolate the electromagnetic field and current at its ghost nodes, this level
+         * will be able to interpolate at required time because the t=n Vi,Ni,E,B,J
+         * fields of previous next coarser step will be in the messenger.
          */
         void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
                          double currentTime) override
@@ -500,14 +553,23 @@ namespace amr
             for (auto& patch : level)
             {
                 auto dataOnPatch = resourcesManager_->setOnPatch(
-                    *patch, hybridModel.state.electromag, hybridModel.state.J, EM_old_, Jold_);
+                    *patch, hybridModel.state.electromag, hybridModel.state.J,
+                    hybridModel.state.ions, EM_old_, Jold_, NiOldUser_, ViOld_);
+
                 resourcesManager_->setTime(EM_old_, *patch, currentTime);
                 resourcesManager_->setTime(Jold_, *patch, currentTime);
+                resourcesManager_->setTime(NiOldUser_, *patch, currentTime);
+                resourcesManager_->setTime(ViOld_, *patch, currentTime);
 
                 auto& EM = hybridModel.state.electromag;
                 auto& J  = hybridModel.state.J;
+                auto& Vi = hybridModel.state.ions.velocity();
+                auto& Ni = hybridModel.state.ions.density();
+
                 EM_old_.copyData(EM);
                 Jold_.copyData(J);
+                ViOld_.copyData(Vi);
+                NiOldUser_.f->copyData(Ni);
             }
         }
 
@@ -531,6 +593,16 @@ namespace amr
 
             // at some point in the future levelGhostParticles could be filled with injected
             // particles depending on the domain boundary condition.
+            //
+            // Do we need J ghosts filled here?
+            // This method is only called when root level is initialized
+            // but J ghosts are needed a priori for the laplacian when the first Ohm is calculated
+            // so I think we do, not having them here is just having the laplacian wrong on
+            // L0 borders for the initial E, which is not the end of the world...
+            //
+            // do we need moment ghosts filled here?
+            // a priori no because those are at this time only needed for coarsening, which
+            // will not happen before the first advance
         }
 
 
@@ -544,10 +616,18 @@ namespace amr
             // call coarsning schedules...
             magnetoSynchronizers_.sync(levelNumber);
             electroSynchronizers_.sync(levelNumber);
-            // densitySynchronizers_.sync(levelNumber);
-            // ionBulkVelSynchronizers_.sync(levelNumber);
+            densitySynchronizers_.sync(levelNumber);
+            ionBulkVelSynchronizers_.sync(levelNumber);
         }
 
+        // after coarsening, domain nodes have been updated and therefore patch ghost nodes
+        // will probably stop having the exact same value as their overlapped neighbor domain node
+        // we thus fill ghost nodes.
+        // note that we first fill shared border nodes with the sharedNode refiners so that
+        // these shared nodes agree on their value at MPI process boundaries.
+        // then regular refiner fill are called, which fill only pure ghost nodes.
+        // note also that moments are not filled on border nodes since already OK from particle
+        // deposition
         void postSynchronize(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
                              double const time) override
         {
@@ -558,6 +638,8 @@ namespace amr
 
             magneticGhosts_.fill(hybridModel.state.electromag.B, levelNumber, time);
             electricGhosts_.fill(hybridModel.state.electromag.E, levelNumber, time);
+            densityGhosts_.fill(levelNumber, time);
+            bulkVelGhosts_.fill(hybridModel.state.ions.velocity(), levelNumber, time);
         }
 
     private:
@@ -580,6 +662,17 @@ namespace amr
                           currentSharedNodes_, fieldNodeRefineOp_);
             fillRefiners_(info->ghostCurrent, info->modelCurrent, VecFieldDescriptor{Jold_},
                           currentGhosts_);
+
+            // no fillRefiners overload for a scalar so do it manually for the density
+            // density and bulk velocity are OK on border node because it is obtained from
+            // domain particles and either patch ghost particles or levelghost[old,new] particles
+            // so we only need to fill pure ghost nodes. Therefore there is no need for a
+            // SharedNodes refiner
+            densityGhosts_.add(info->modelIonDensity, fieldRefineOp_, info->modelIonDensity,
+                               resourcesManager_);
+
+            fillRefiners_(info->ghostBulkVelocity, info->modelIonBulkVelocity,
+                          VecFieldDescriptor{ViOld_}, bulkVelGhosts_);
         }
 
 
@@ -721,12 +814,15 @@ namespace amr
 
 
 
-
         //! keeps a copy of the model electromagnetic field at t=n
         ElectromagT EM_old_{stratName + "_EM_old"}; // TODO needs to be allocated somewhere and
                                                     // updated to t=n before advanceLevel()
 
         VecFieldT Jold_{stratName + "_Jold", core::HybridQuantity::Vector::J};
+        VecFieldT ViOld_{stratName + "_VBulkOld", core::HybridQuantity::Vector::V};
+        FieldT* NiOld_{nullptr};
+        FieldUser<FieldT> NiOldUser_{stratName + "_NiOld", NiOld_,
+                                     core::HybridQuantity::Scalar::rho};
 
 
         //! ResourceManager shared with other objects (like the HybridModel)
@@ -758,6 +854,9 @@ namespace amr
         RefinerPool<RefinerType::GhostField> currentSharedNodes_;
         RefinerPool<RefinerType::GhostField> currentGhosts_;
 
+        // moment ghosts
+        RefinerPool<RefinerType::GhostField> densityGhosts_;
+        RefinerPool<RefinerType::GhostField> bulkVelGhosts_;
 
         // algo and schedule used to initialize domain particles
         // from coarser level using particleRefineOp<domain>
@@ -773,15 +872,14 @@ namespace amr
         RefinerPool<RefinerType::InteriorGhostParticles> patchGhostParticles_;
 
         SynchronizerPool<dimension> densitySynchronizers_;
-
         SynchronizerPool<dimension> ionBulkVelSynchronizers_;
-
         SynchronizerPool<dimension> electroSynchronizers_;
-
         SynchronizerPool<dimension> magnetoSynchronizers_;
 
 
         // see field_variable_fill_pattern.hpp for explanation about this "node_only" flag
+        // Note that refinement operator, via the boolean argument, serve as a relay for the
+        // the RefineAlgorithm to get the correct VariableFillPattern
         std::shared_ptr<SAMRAI::hier::RefineOperator> fieldNodeRefineOp_{
             std::make_shared<FieldRefineOperator<GridLayoutT, FieldT>>(/*node_only*/ true)};
 

--- a/src/amr/messengers/hybrid_messenger.hpp
+++ b/src/amr/messengers/hybrid_messenger.hpp
@@ -1,5 +1,3 @@
-
-
 #ifndef PHARE_HYBRID_MESSENGER_HPP
 #define PHARE_HYBRID_MESSENGER_HPP
 
@@ -328,9 +326,9 @@ namespace amr
          * @param fillTime
          */
         void fillIonPopMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                    double const currentTime, double const fillTime)
+                                    double const fillTime)
         {
-            strat_->fillIonPopMomentGhosts(ions, level, currentTime, fillTime);
+            strat_->fillIonPopMomentGhosts(ions, level, fillTime);
         }
 
 

--- a/src/amr/messengers/hybrid_messenger.hpp
+++ b/src/amr/messengers/hybrid_messenger.hpp
@@ -321,19 +321,24 @@ namespace amr
 
 
         /**
-         * @brief fillIonMomentGhosts is called by a ISolver solving hybrid equations to fill the
+         * @brief fillIonPopMomentGhosts is called by a ISolver solving hybrid equations to fill the
          * ion moments
          * @param ions
          * @param levelNumber
          * @param fillTime
          */
+        void fillIonPopMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
+                                    double const currentTime, double const fillTime)
+        {
+            strat_->fillIonPopMomentGhosts(ions, level, currentTime, fillTime);
+        }
+
+
         void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
                                  double const fillTime)
         {
             strat_->fillIonMomentGhosts(ions, level, fillTime);
         }
-
-
 
         // synchronization/coarsening methods
 

--- a/src/amr/messengers/hybrid_messenger_info.hpp
+++ b/src/amr/messengers/hybrid_messenger_info.hpp
@@ -98,6 +98,8 @@ namespace amr
         std::vector<VecFieldDescriptor> ghostCurrent;
 
 
+        std::vector<VecFieldDescriptor> ghostBulkVelocity;
+
         virtual ~HybridMessengerInfo() = default;
     };
 

--- a/src/amr/messengers/hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_messenger_strategy.hpp
@@ -83,13 +83,13 @@ namespace amr
             = 0;
 
 
-        virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                         double const afterPushTime)
+        virtual void fillIonPopMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
+                                            double const afterPushTime)
             = 0;
 
 
         virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                         double beforePushTime, double const afterPushTime)
+                                         double const afterPushTime)
             = 0;
 
         virtual std::string fineModelName() const = 0;

--- a/src/amr/messengers/hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_messenger_strategy.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_HYBRID_MESSENGER_STRATEGY_HPP
 #define PHARE_HYBRID_MESSENGER_STRATEGY_HPP
 
@@ -89,6 +88,9 @@ namespace amr
             = 0;
 
 
+        virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
+                                         double beforePushTime, double const afterPushTime)
+            = 0;
 
         virtual std::string fineModelName() const = 0;
 

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
@@ -115,11 +115,16 @@ namespace amr
                                    double const /*fillTime*/) override
         {
         }
+        void fillIonPopMomentGhosts(IonsT& /*ions*/, SAMRAI::hier::PatchLevel& /*level*/,
+                                    double const /*currentTime*/,
+                                    double const /*fillTime*/) override
+        {
+        }
+
         void fillIonMomentGhosts(IonsT& /*ions*/, SAMRAI::hier::PatchLevel& /*level*/,
                                  double const /*fillTime*/) override
         {
         }
-
 
         void firstStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
                        const std::shared_ptr<SAMRAI::hier::PatchHierarchy>& /*hierarchy*/,

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_MHD_HYBRID_MESSENGER_STRATEGY_HPP
 #define PHARE_MHD_HYBRID_MESSENGER_STRATEGY_HPP
 
@@ -116,7 +115,6 @@ namespace amr
         {
         }
         void fillIonPopMomentGhosts(IonsT& /*ions*/, SAMRAI::hier::PatchLevel& /*level*/,
-                                    double const /*currentTime*/,
                                     double const /*fillTime*/) override
         {
         }

--- a/src/amr/messengers/quantity_communicator.hpp
+++ b/src/amr/messengers/quantity_communicator.hpp
@@ -141,7 +141,8 @@ namespace amr
                 std::shared_ptr<SAMRAI::hier::RefineOperator> refineOp,
                 std::shared_ptr<SAMRAI::hier::TimeInterpolateOperator> timeOp)
     {
-        auto variableFillPattern = FieldFillPattern::make_shared(refineOp);
+        constexpr auto dimension = ResourcesManager::dimension;
+        auto variableFillPattern = FieldFillPattern<dimension>::make_shared(refineOp);
 
         Communicator<Refiner> com;
 

--- a/src/amr/physical_models/hybrid_model.hpp
+++ b/src/amr/physical_models/hybrid_model.hpp
@@ -156,6 +156,7 @@ void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::fillMesse
     modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
     modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
     modelInfo.ghostCurrent.push_back(state.J);
+    modelInfo.ghostBulkVelocity.push_back(modelInfo.modelIonBulkVelocity);
 
 
     auto transform_ = [](auto& ions, auto& inserter) {

--- a/src/amr/solvers/solver_ppc.hpp
+++ b/src/amr/solvers/solver_ppc.hpp
@@ -577,7 +577,7 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, Ions& ions,
 
 
     fromCoarser.fillIonGhostParticles(ions, level, newTime);
-    fromCoarser.fillIonMomentGhosts(ions, level, newTime);
+    fromCoarser.fillIonPopMomentGhosts(ions, level, newTime);
 
     for (auto& patch : level)
     {

--- a/src/amr/solvers/solver_ppc.hpp
+++ b/src/amr/solvers/solver_ppc.hpp
@@ -589,7 +589,7 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, Ions& ions,
     }
     // now Ni and Vi are calculated we can fill pure ghost nodes
     // these were not completed by the deposition of patch and levelghost particles
-    fromCoarser.fillIonMomentGhosts(ions, level, currentTime, newTime);
+    fromCoarser.fillIonMomentGhosts(ions, level, newTime);
 }
 } // namespace PHARE::solver
 

--- a/src/amr/solvers/solver_ppc.hpp
+++ b/src/amr/solvers/solver_ppc.hpp
@@ -1,5 +1,3 @@
-
-
 #ifndef PHARE_SOLVER_PPC_HPP
 #define PHARE_SOLVER_PPC_HPP
 
@@ -589,6 +587,9 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, Ions& ions,
 
         // no need to update time, since it has been done before
     }
+    // now Ni and Vi are calculated we can fill pure ghost nodes
+    // these were not completed by the deposition of patch and levelghost particles
+    fromCoarser.fillIonMomentGhosts(ions, level, currentTime, newTime);
 }
 } // namespace PHARE::solver
 

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -864,7 +864,7 @@ namespace core
 
 
         /**
-         * @brief returns the centering of all hybrid quantities in all directions
+         * @brief returns the centering of a scalar hybrid quantity in each directions
          */
         constexpr static std::array<QtyCentering, dimension>
         centering(HybridQuantity::Scalar hybridQuantity)
@@ -875,7 +875,7 @@ namespace core
 
 
         /**
-         * @brief returns the centering of all hybrid quantities in all directions
+         * @brief returns the centering of a vector hybrid quantity in each directions
          */
         constexpr static std::array<std::array<QtyCentering, dimension>, 3>
         centering(HybridQuantity::Vector hybridQuantity)

--- a/src/core/data/ions/ions.hpp
+++ b/src/core/data/ions/ions.hpp
@@ -233,44 +233,6 @@ namespace core
         std::vector<IonPopulation> populations_; // TODO we have to name this so they are unique
                                                  // although only 1 Ions should exist.
     };
-
-
-
-    /**
-     * This routine sets NaNs on all but closest to domain ghost moment nodes
-     * All nodes set to NaN are unsued and NaNs helps finding bugs if they are
-     * used by mistake. The ghost node that is closest to domain is used
-     * in refinement ratio 2 coarsening and should thus not be NaN. It is set
-     * to a copy of the first domain node.
-     *
-     * Directions for start index are superfluous, as all directions are primal for these fields
-     */
-    template<typename Ions, typename GridLayout>
-    void fixMomentGhosts(Ions& ions, GridLayout const& layout)
-    {
-        using Mask = NdArrayMask;
-
-        for (auto& pop : ions)
-        {
-            for (auto& [id, type] : Components::componentMap)
-            {
-                auto& flux_comp = pop.flux().getComponent(type);
-
-                auto phyStartIdx
-                    = layout.physicalStartIndex(flux_comp.physicalQuantity(), Direction::X);
-
-                flux_comp[Mask{0, phyStartIdx - 2}] = NAN;
-                flux_comp[Mask{phyStartIdx}] >> flux_comp[Mask{phyStartIdx - 1}];
-            }
-
-            auto& density    = pop.density();
-            auto phyStartIdx = layout.physicalStartIndex(density.physicalQuantity(), Direction::X);
-
-            density[Mask{0, phyStartIdx - 2}] = NAN;
-            density[Mask{phyStartIdx}] >> density[Mask{phyStartIdx - 1}];
-        }
-    }
-
 } // namespace core
 } // namespace PHARE
 

--- a/src/core/numerics/ion_updater/ion_updater.hpp
+++ b/src/core/numerics/ion_updater/ion_updater.hpp
@@ -96,7 +96,6 @@ void IonUpdater<Ions, Electromag, GridLayout>::updatePopulations(Ions& ions, Ele
 template<typename Ions, typename Electromag, typename GridLayout>
 void IonUpdater<Ions, Electromag, GridLayout>::updateIons(Ions& ions, GridLayout const& layout)
 {
-    fixMomentGhosts(ions, layout);
     ions.computeDensity();
     ions.computeBulkVelocity();
 }

--- a/tests/core/numerics/ion_updater/test_updater.cpp
+++ b/tests/core/numerics/ion_updater/test_updater.cpp
@@ -976,58 +976,6 @@ TYPED_TEST(IonUpdaterTest, thatNoNaNsExistOnPhysicalNodesMoments)
 
 
 
-TYPED_TEST(IonUpdaterTest, thatUnusedMomentNodesAreNaN)
-{
-    typename IonUpdaterTest<TypeParam>::IonUpdater ionUpdater{
-        init_dict["simulation"]["algo"]["ion_updater"]};
-
-    ionUpdater.updatePopulations(this->ions, this->EM, this->layout, this->dt,
-                                 UpdaterMode::domain_only);
-
-    this->fillIonsMomentsGhosts();
-
-    ionUpdater.updateIons(this->ions, this->layout);
-
-
-    auto ix0 = this->layout.physicalStartIndex(QtyCentering::primal, Direction::X);
-    auto ix1 = this->layout.physicalEndIndex(QtyCentering::primal, Direction::X);
-    auto ix2 = this->layout.ghostEndIndex(QtyCentering::primal, Direction::X);
-
-    for (auto& pop : this->ions)
-    {
-        for (auto ix = 0u; ix < ix0 - 1; ++ix) // leftGhostNodes
-        {
-            auto& density = pop.density();
-            auto& flux    = pop.flux();
-
-            auto& fx = flux.getComponent(Component::X);
-            auto& fy = flux.getComponent(Component::Y);
-            auto& fz = flux.getComponent(Component::Z);
-
-            EXPECT_TRUE(std::isnan(density(ix)));
-            EXPECT_TRUE(std::isnan(fx(ix)));
-            EXPECT_TRUE(std::isnan(fy(ix)));
-            EXPECT_TRUE(std::isnan(fz(ix)));
-        }
-
-        for (auto ix = ix1 + 1 + 1; ix <= ix2; ++ix)
-        {
-            auto& density = pop.density();
-            auto& flux    = pop.flux();
-
-            auto& fx = flux.getComponent(Component::X);
-            auto& fy = flux.getComponent(Component::Y);
-            auto& fz = flux.getComponent(Component::Z);
-
-            EXPECT_TRUE(std::isnan(density(ix)));
-            EXPECT_TRUE(std::isnan(fx(ix)));
-            EXPECT_TRUE(std::isnan(fy(ix)));
-            EXPECT_TRUE(std::isnan(fz(ix)));
-        }
-    }
-}
-
-
 
 int main(int argc, char** argv)
 {

--- a/tests/simulator/advance/test_fields_advance_2d.py
+++ b/tests/simulator/advance/test_fields_advance_2d.py
@@ -33,7 +33,7 @@ class AdvanceTest(AdvanceTestBase):
         time_step_nbr=3
         time_step=0.001
         diag_outputs=f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
-        datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", diag_outputs=diag_outputs,
+        datahier = self.getHierarchy(interp_order, refinement_boxes, "fields", diag_outputs=diag_outputs,
                                   time_step=time_step, time_step_nbr=time_step_nbr, ndim=ndim, nbr_part_per_cell=ppc)
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 

--- a/tests/simulator/refinement/test_2d_2_core.py
+++ b/tests/simulator/refinement/test_2d_2_core.py
@@ -160,7 +160,7 @@ def post_advance_1(new_time):
         L0L1_datahier = get_hier(L0L1_diags)
         extra_collections = []
         errors = test.base_test_overlaped_fields_are_equal(L0L1_datahier, new_time)
-        errors = test.base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(L0_datahier, L0L1_datahier)
+#        errors = test.base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(L0_datahier, L0L1_datahier)
         if isinstance(errors, list):
             extra_collections += [{
                 "boxes": errors,

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -236,10 +236,10 @@ class AdvanceTestBase(SimulatorTest):
                     try:
                         assert slice1.dtype == np.float64
 
-                        # empirical max absolute observed 3.33e-15
+                        # empirical max absolute observed 4e-15
                         # seems correct considering ghosts are filled with schedules
                         # involving linear/spatial interpolations and so on where
-                        # rounding errors may occur.... setting atol to 2e-15
+                        # rounding errors may occur.... setting atol to 4e-15
                         np.testing.assert_allclose(slice1,slice2, atol=3.5e-15, rtol=0)
                         checks += 1
                     except AssertionError as e:

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -427,7 +427,7 @@ class AdvanceTestBase(SimulatorTest):
                                 coarsen(qty, coarse_pd, fine_pd, coarseBox, fine_pdDataset, afterCoarse)
                                 # 1e-16 seems to fail for some reason. Discrepency appears to be
                                 # on refined adjacent patches. Was way worse (1e-4 or so) when not
-                                # filling pure ghosts for Ni and Vi. 1e-15 seems food enough
+                                # filling pure ghosts for Ni and Vi. 1e-15 seems good enough
                                 np.testing.assert_allclose(coarse_pdDataset, afterCoarse, atol=1e-15, rtol=0)
 
 


### PR DESCRIPTION
see #693 

This PR enables the syncing of the total ion density and total ion bulk velocity in the coarsening ops.
Coarsening just E and B is not enough. If moments are not synced, E gets re-computed on next step with unsynced moments, any possible divergence in particle dynamics across levels will result in diverging moments and thus diverging E which enhances the particle dynamic divergence etc.
The PR also adds rho and V in the coarsening test.

Because of the 3-nodes coarsening stencil, the first primal ghost node is needed for n and V. Before this PR, n&V were NOT complete on any ghost node from particle deposition, because the particle ghost area is not wide enough.
The first ghost node was assigned a copy of the shared border primal node (for no good reason) and the other nodes were assigned NaN as they should be unused. This causes a coarsening issue since two adjacent procs would not share the same value, i.e. first primal ghost on proc1 would be a copy of border node (of proc 1 and 2), and not equal to the overlaped domain node of proc2.
This PR thus now fills ghosts for n and V with a regular ghost field schedule. Not this schedule does NOT touch the shared border node (through one mode of the FieldVariableFillPattern/FieldGeometry). The shared border node was and still is complete anyway, from the deposit of domain particles and the patch or level ghost (old and new) particles.

Fluid tests are changed so not to expect NaNs and not to expect the copy of the shared border node
