### PR TITLE
separate out C++ simulator init from C++ object construction 

### DIFF
--- a/pyphare/pyphare/simulator/simulator.py
+++ b/pyphare/pyphare/simulator/simulator.py
@@ -51,10 +51,8 @@ class Simulator:
     def __del__(self):
         self.reset()
 
-
-    def initialize(self):
-        if self.cpp_sim is not None:
-            raise ValueError("Simulator already initialized: requires reset to re-initialize")
+    def setup(self):
+        # mostly to detach C++ class construction/dict parsing from C++ Simulator::init
         try:
             from pyphare.cpp import cpp_lib
             import pyphare.pharein as ph
@@ -67,9 +65,21 @@ class Simulator:
             self.cpp_sim = make_cpp_simulator(
               self.simulation.ndim, self.simulation.interp_order, self.simulation.refined_particle_nbr, self.cpp_hier
             )
+            return self
+        except:
+            import sys
+            print('Exception caught in "Simulator.setup()": {}'.format(sys.exc_info()[0]))
+            raise ValueError("Error in Simulator.setup(), see previous error")
+
+
+    def initialize(self):
+        if self.cpp_sim is not None:
+            raise ValueError("Simulator already initialized: requires reset to re-initialize")
+        try:
+            if self.cpp_hier is None:
+                self.setup()
 
             self.cpp_sim.initialize()
-
             self._auto_dump() # first dump might be before first advance
             return self
         except:

--- a/tests/simulator/test_validation.py
+++ b/tests/simulator/test_validation.py
@@ -41,7 +41,7 @@ class SimulatorValidation(unittest.TestCase):
 
             try:
                 self.simulator = Simulator(populate_simulation(dim, interp, **input))
-                self.simulator.initialize()
+                self.simulator.setup()
                 self.assertTrue(valid)
                 self.simulator = None
             except ValueError as e:


### PR DESCRIPTION
to not need to init to validate simulation config

no more maxwellian init/random stuff to validate the config/construct C++ objects and parse the dict