### PR TITLE
fix levelghost particle interpolation time #658

### DIFF
--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -346,17 +346,16 @@ namespace amr
          * interpolation coef.
          */
         void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                 double const beforePushTime, double const afterPushTime) override
+                                 double const afterPushTime) override
         {
             PHARE_LOG_SCOPE("HybridHybridMessengerStrategy::fillIonMomentGhosts");
 
-            auto alpha = timeInterpCoef_(beforePushTime, afterPushTime, level.getLevelNumber());
+            auto alpha = timeInterpCoef_(afterPushTime, level.getLevelNumber());
             if (level.getLevelNumber() > 0 and (alpha < 0 or alpha > 1))
             {
                 std::cout << std::setprecision(12) << alpha << "\n";
                 throw std::runtime_error("ion moment ghost time interp coef invalid : alpha: "
                                          + std::to_string(alpha) + " beforePushTime "
-                                         + std::to_string(beforePushTime) + " afterPushTime "
                                          + std::to_string(afterPushTime) + " on level "
                                          + std::to_string(level.getLevelNumber()));
             }
@@ -714,10 +713,9 @@ namespace amr
 
 
 
-        double timeInterpCoef_(double const beforePushTime, double const afterPushTime,
-                               std::size_t levelNumber)
+        double timeInterpCoef_(double const afterPushTime, std::size_t levelNumber)
         {
-            return (afterPushTime - beforePushTime)
+            return (afterPushTime - beforePushCoarseTime_[levelNumber])
                    / (afterPushCoarseTime_[levelNumber] - beforePushCoarseTime_[levelNumber]);
         }
 

--- a/src/amr/messengers/hybrid_messenger.hpp
+++ b/src/amr/messengers/hybrid_messenger.hpp
@@ -328,9 +328,9 @@ namespace amr
          * @param fillTime
          */
         void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                 double const currentTime, double const fillTime)
+                                 double const fillTime)
         {
-            strat_->fillIonMomentGhosts(ions, level, currentTime, fillTime);
+            strat_->fillIonMomentGhosts(ions, level, fillTime);
         }
 
 

--- a/src/amr/messengers/hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_messenger_strategy.hpp
@@ -85,7 +85,7 @@ namespace amr
 
 
         virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
-                                         double beforePushTime, double const afterPushTime)
+                                         double const afterPushTime)
             = 0;
 
 

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
@@ -116,7 +116,7 @@ namespace amr
         {
         }
         void fillIonMomentGhosts(IonsT& /*ions*/, SAMRAI::hier::PatchLevel& /*level*/,
-                                 double const /*currentTime*/, double const /*fillTime*/) override
+                                 double const /*fillTime*/) override
         {
         }
 

--- a/src/amr/solvers/solver_ppc.hpp
+++ b/src/amr/solvers/solver_ppc.hpp
@@ -579,7 +579,7 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, Ions& ions,
 
 
     fromCoarser.fillIonGhostParticles(ions, level, newTime);
-    fromCoarser.fillIonMomentGhosts(ions, level, currentTime, newTime);
+    fromCoarser.fillIonMomentGhosts(ions, level, newTime);
 
     for (auto& patch : level)
     {


### PR DESCRIPTION
issue #658 
time interpolation coef does not need to know about current time, just newTime.
The coef is given as the ratio between the time elapsed in the current subcycle (since last sync) and the total dt of the next coarser.