### PR TITLE
simpler unique diag directories for //

### DIFF
--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -169,6 +169,19 @@ class FieldData(PatchData):
         self.dataset = data
 
 
+    def meshgrid(self, select=None):
+        def grid():
+            if self.ndim == 1:
+                return [self.x]
+            if self.ndim == 2:
+                return np.meshgrid(self.x, self.y, indexing="ij")
+            return np.meshgrid(self.x, self.y, self.z, indexing="ij")
+        mesh = grid()
+        if select is not None:
+            return tuple(g[select] for g in mesh)
+        return mesh
+
+
 class ParticleData(PatchData):
     """
     Concrete type of PatchData representing particles in a region

--- a/tests/simulator/__init__.py
+++ b/tests/simulator/__init__.py
@@ -240,6 +240,12 @@ class SimulatorTest(unittest.TestCase):
         self._outcome = result
         super().run(result)
 
+    def unique_diag_dir_for_test_case(self, base_path, ndim, interp, post_path=""):
+        from pyphare.cpp import cpp_lib
+
+        cpp = cpp_lib()
+        return f"{base_path}/{self._testMethodName}/{cpp.mpi_size()}/{ndim}/{interp}/{post_path}"
+
     def clean_up_diags_dirs(self):
         from pyphare.cpp import cpp_lib
 

--- a/tests/simulator/advance/test_fields_advance_1d.py
+++ b/tests/simulator/advance/test_fields_advance_1d.py
@@ -33,15 +33,14 @@ class AdvanceTest(AdvanceTestBase):
         print(f"{self._testMethodName}_{ndim}d")
         time_step_nbr = 3
         time_step = 0.001
-        diag_outputs = f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
+
         datahier = self.getHierarchy(
+            ndim,
             interp_order,
             refinement_boxes,
             "eb",
-            diag_outputs=diag_outputs,
             time_step=time_step,
             time_step_nbr=time_step_nbr,
-            ndim=ndim,
         )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 
@@ -58,20 +57,18 @@ class AdvanceTest(AdvanceTestBase):
         time_step = 0.001
         from pyphare.pharein.simulation import check_patch_size
 
-        diag_outputs = f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts/{ndim}/{interp_order}/{self.ddt_test_id()}"
         largest_patch_size, smallest_patch_size = check_patch_size(
             ndim, interp_order=interp_order, cells=[60] * ndim
         )
         datahier = self.getHierarchy(
+            ndim,
             interp_order,
             refinement_boxes,
             "eb",
-            diag_outputs=diag_outputs,
             smallest_patch_size=smallest_patch_size,
             largest_patch_size=smallest_patch_size,
             time_step=time_step,
             time_step_nbr=time_step_nbr,
-            ndim=ndim,
         )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 

--- a/tests/simulator/advance/test_fields_advance_2d.py
+++ b/tests/simulator/advance/test_fields_advance_2d.py
@@ -34,15 +34,14 @@ class AdvanceTest(AdvanceTestBase):
         print(f"{self._testMethodName}_{ndim}d")
         time_step_nbr = 3
         time_step = 0.001
-        diag_outputs = f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
+
         datahier = self.getHierarchy(
+            ndim,
             interp_order,
             refinement_boxes,
             "fields",
-            diag_outputs=diag_outputs,
             time_step=time_step,
             time_step_nbr=time_step_nbr,
-            ndim=ndim,
             nbr_part_per_cell=ppc,
         )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
@@ -60,20 +59,18 @@ class AdvanceTest(AdvanceTestBase):
         time_step = 0.001
         from pyphare.pharein.simulation import check_patch_size
 
-        diag_outputs = f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts/{ndim}/{interp_order}/{self.ddt_test_id()}"
         largest_patch_size, smallest_patch_size = check_patch_size(
             ndim, interp_order=interp_order, cells=[60] * ndim
         )
         datahier = self.getHierarchy(
+            ndim,
             interp_order,
             refinement_boxes,
             "eb",
-            diag_outputs=diag_outputs,
             smallest_patch_size=smallest_patch_size,
             largest_patch_size=smallest_patch_size,
             time_step=time_step,
             time_step_nbr=time_step_nbr,
-            ndim=ndim,
             nbr_part_per_cell=ppc,
         )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)

--- a/tests/simulator/initialize/test_fields_init_1d.py
+++ b/tests/simulator/initialize/test_fields_init_1d.py
@@ -17,7 +17,7 @@ interp_orders = [1, 2, 3]
 
 
 @ddt
-class InitializationTest(InitializationTest):
+class Initialization1DTest(InitializationTest):
     @data(*interp_orders)
     def test_B_is_as_provided_by_user(self, interp_order):
         print(f"{self._testMethodName}_{ndim}d")

--- a/tests/simulator/initialize/test_fields_init_2d.py
+++ b/tests/simulator/initialize/test_fields_init_2d.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+import numpy as np
 import matplotlib
 from ddt import data, ddt
 
@@ -18,7 +19,7 @@ ppc = 100
 
 
 @ddt
-class InitializationTest(InitializationTest):
+class Initialization2DTest(InitializationTest):
     @data(*interp_orders)
     def test_B_is_as_provided_by_user(self, interp_order):
         print(f"\n{self._testMethodName}_{ndim}d")
@@ -36,8 +37,10 @@ class InitializationTest(InitializationTest):
 
     @data(*interp_orders)
     def test_density_decreases_as_1overSqrtN(self, interp_order):
-        print(f"\n{self._testMethodName}_{ndim}d")
-        self._test_density_decreases_as_1overSqrtN(ndim, interp_order)
+        print(f"{self._testMethodName}_{ndim}d")
+        self._test_density_decreases_as_1overSqrtN(
+            ndim, interp_order, np.asarray([50, 500, 1000, 2222]), cells=220
+        )
 
 
 if __name__ == "__main__":

--- a/tests/simulator/initialize/test_particles_init_1d.py
+++ b/tests/simulator/initialize/test_particles_init_1d.py
@@ -26,7 +26,7 @@ def per_interp(dic):
 
 
 @ddt
-class InitializationTest(InitializationTest):
+class Initialization1DTest(InitializationTest):
     @data(*interp_orders)
     def test_nbr_particles_per_cell_is_as_provided(self, interp_order):
         print(f"{self._testMethodName}_{ndim}d")
@@ -45,12 +45,11 @@ class InitializationTest(InitializationTest):
 
         self._test_levelghostparticles_have_correct_split_from_coarser_particle(
             self.getHierarchy(
+                ndim,
                 interp_order,
                 refinement_boxes,
                 "particles",
-                ndim=ndim,
                 cells=30,
-                diag_outputs=f"phare_outputs/test_levelghost/{ndim}/{interp_order}/{self.ddt_test_id()}",
             )
         )
 
@@ -86,15 +85,14 @@ class InitializationTest(InitializationTest):
 
     @data("berger", "tile")
     def test_amr_clustering(self, clustering):
+        dim = 1
         interp_order = 1
-        test_id = self.ddt_test_id()
-        local_out = f"test_amr_clustering/mpi/{cpp.mpi_size()}/{test_id}"
         self.getHierarchy(
+            dim,
             interp_order,
             {"L0": {"B0": [(10,), (20,)]}},
             "particles",
             clustering=clustering,
-            diag_outputs=local_out,
         )
 
 

--- a/tests/simulator/initialize/test_particles_init_2d.py
+++ b/tests/simulator/initialize/test_particles_init_2d.py
@@ -23,7 +23,7 @@ def per_interp(dic):
 
 
 @ddt
-class InitializationTest(InitializationTest):
+class Initialization1DTest(InitializationTest):
     @data(*interp_orders)
     def test_nbr_particles_per_cell_is_as_provided(self, interp_order):
         print(f"{self._testMethodName}_{ndim}d")
@@ -42,13 +42,12 @@ class InitializationTest(InitializationTest):
         now = self.datetime_now()
         self._test_levelghostparticles_have_correct_split_from_coarser_particle(
             self.getHierarchy(
+                ndim,
                 interp_order,
                 refinement_boxes,
                 "particles",
-                ndim=ndim,
                 cells=30,
                 nbr_part_per_cell=ppc,
-                diag_outputs=f"phare_outputs/test_levelghost/{ndim}/{interp_order}/{self.ddt_test_id()}",
             )
         )
         print(

--- a/tests/simulator/refinement/test_2d_10_core.py
+++ b/tests/simulator/refinement/test_2d_10_core.py
@@ -182,7 +182,11 @@ def post_advance(new_time):
         L0L1_datahier = check_hier(get_hier(L0L1_diags))
         extra_collections = []
         errors = test.base_test_overlaped_fields_are_equal(L0L1_datahier, new_time)
-        # errors = test.base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(L0_datahier, L0L1_datahier)
+        errors = (
+            test.base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(
+                L0_datahier, L0L1_datahier
+            )
+        )
         print(f"errors {type(errors)}")
         if isinstance(errors, list):
             extra_collections += [

--- a/tests/simulator/test_restarts.py
+++ b/tests/simulator/test_restarts.py
@@ -20,7 +20,7 @@ from tests.diagnostic import dump_all_diags
 
 def permute(dic, expected_num_levels):
     # from pyphare.pharein.simulation import supported_dimensions # eventually
-    dims = [1]  # supported_dimensions()
+    dims = [1] # supported_dimensions()
     return [
         [dim, interp, dic, expected_num_levels] for dim in dims for interp in [1, 2, 3]
     ]
@@ -193,17 +193,17 @@ class RestartsTest(SimulatorTest):
         *permute(dup(dict()), expected_num_levels=2),  # refinement boxes set later
     )
     @unpack
-    def test_restarts(self, dim, interp, simInput, expected_num_levels):
-        print(f"test_restarts dim/interp:{dim}/{interp}")
+    def test_restarts(self, ndim, interp, simInput, expected_num_levels):
+        print(f"test_restarts dim/interp:{ndim}/{interp}")
 
         simput = copy.deepcopy(simInput)
 
         for key in ["cells", "dl", "boundary_types"]:
-            simput[key] = [simput[key]] * dim
+            simput[key] = [simput[key]] * ndim
 
         if "refinement" not in simput:
             # three levels has issues with refinementboxes and possibly regridding
-            b0 = [[10] * dim, [19] * dim]
+            b0 = [[10] * ndim, [19] * ndim]
             simput["refinement_boxes"] = {"L0": {"B0": b0}}
         else:  # https://github.com/LLNL/SAMRAI/issues/199
             # tagging can handle more than one timestep as it does not
@@ -224,9 +224,7 @@ class RestartsTest(SimulatorTest):
         timestamps = [time_step * restart_idx, time_step * time_step_nbr]
 
         # first simulation
-        local_out = (
-            f"{out}/test/{dim}/{interp}/mpi_n/{cpp.mpi_size()}/id{self.ddt_test_id()}"
-        )
+        local_out = self.unique_diag_dir_for_test_case(f"{out}/test", ndim, interp)
         simput["restart_options"]["dir"] = local_out
         simput["restart_options"]["timestamps"] = [timestep * 4]
         simput["diag_options"]["options"]["dir"] = local_out
@@ -269,18 +267,18 @@ class RestartsTest(SimulatorTest):
         *permute(dup(dict()), expected_num_levels=2),  # refinement boxes set later
     )
     @unpack
-    def test_restarts_elapsed_time(self, dim, interp, simInput, expected_num_levels):
-        print(f"test_restarts_elapsed_time dim/interp:{dim}/{interp}")
+    def test_restarts_elapsed_time(self, ndim, interp, simInput, expected_num_levels):
+        print(f"test_restarts_elapsed_time dim/interp:{ndim}/{interp}")
 
         simput = copy.deepcopy(simInput)
 
         for key in ["cells", "dl", "boundary_types"]:
-            simput[key] = [simput[key]] * dim
+            simput[key] = [simput[key]] * ndim
 
         if "refinement" not in simput:
             lo_cell = 10
             hi_cell = 19
-            b0 = [[lo_cell] * dim, [hi_cell] * dim]
+            b0 = [[lo_cell] * ndim, [hi_cell] * ndim]
             simput["refinement_boxes"] = {"L0": {"B0": b0}}
         else:  # https://github.com/LLNL/SAMRAI/issues/199
             # tagging can handle more than one timestep as it does not
@@ -301,7 +299,9 @@ class RestartsTest(SimulatorTest):
         timestamps = [time_step * restart_idx, time_step * time_step_nbr]
 
         # first simulation
-        local_out = f"{out}/elapsed_test/{dim}/{interp}/mpi_n/{cpp.mpi_size()}/id{self.ddt_test_id()}"
+        local_out = self.unique_diag_dir_for_test_case(
+            f"{out}/elapsed_test", ndim, interp
+        )
         simput["restart_options"]["dir"] = local_out
         import datetime
 
@@ -347,14 +347,14 @@ class RestartsTest(SimulatorTest):
             diag_dir0, diag_dir1, model.populations, timestamps, expected_num_levels
         )
 
-    def test_mode_conserve(self, dim=1, interp=1, simput=dup(simArgs)):
-        print(f"test_mode_conserve dim/interp:{dim}/{interp}")
+    def test_mode_conserve(self, ndim=1, interp=1, simput=dup(simArgs)):
+        print(f"test_mode_conserve dim/interp:{ndim}/{interp}")
 
         for key in ["cells", "dl", "boundary_types"]:
-            simput[key] = [simput[key]] * dim
+            simput[key] = [simput[key]] * ndim
 
         # first simulation
-        local_out = f"{out}/conserve/{dim}/{interp}/mpi_n/{cpp.mpi_size()}/id{self.ddt_test_id()}"
+        local_out = self.unique_diag_dir_for_test_case(f"{out}/conserve", ndim, interp)
         self.register_diag_dir_for_cleanup(local_out)
 
         simput["restart_options"]["dir"] = local_out


### PR DESCRIPTION
contains https://github.com/PHAREHUB/PHARE/pull/764

simpler unique diag directories for //
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Feature: Added `meshgrid` method to the `PatchData` class, enhancing data visualization capabilities by generating a mesh grid based on data dimensions.
- Refactor: Simplified and improved readability of test methods by reordering arguments and removing unused variables in `getHierarchy` function calls across multiple test files.
- Test: Enhanced test coverage by modifying existing test methods to accept additional parameters and arguments, ensuring more robust testing scenarios.
- Chore: Introduced a new method `unique_diag_dir_for_test_case` for generating unique directory paths for diagnostic outputs in tests, improving test data organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->