### PR TITLE
magnetic flux across grids

### DIFF
--- a/notes
+++ b/notes
@@ -1,0 +1,11 @@
+ - if the electric field is known on all cell edges, including those of ghost cells
+   then the magnetic field can be computed everywhere. Thus faraday now need to be computed
+   on the ghost box and magnetic ghosts not filled.
+
+ - electric field ghosts are needed for:
+   * particle push
+   * faraday p2 and faraday corr.
+     these two need Eavg to be filled on ghosts.
+   * faraday p1 needs En
+     this can be obtained from filling model E after corrector Ohm.
+

--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -10,49 +10,86 @@ directions = ["x", "y", "z"]
 direction_to_dim = {direction: idx for idx, direction in enumerate(directions)}
 
 yee_centering = {
-    'x': {
-        'Bx':'primal', 'By':'dual', 'Bz':'dual',
-        'Ex':'dual', 'Ey':'primal', 'Ez':'primal',
-        'Jx':'dual', 'Jy':'primal', 'Jz':'primal',
-        'Vx':'primal','Vy':'primal','Vz':'primal',
-        'Fx':'primal', 'Fy':'primal', 'Fz':'primal',
-        'rho':'primal', 'P':'primal',
-        'Vthx':'primal', 'Vthy':'primal', 'Vthz':'primal',
-        'tags':'dual',
+    "x": {
+        "Bx": "primal",
+        "By": "dual",
+        "Bz": "dual",
+        "Ex": "dual",
+        "Ey": "primal",
+        "Ez": "primal",
+        "Jx": "dual",
+        "Jy": "primal",
+        "Jz": "primal",
+        "Vx": "primal",
+        "Vy": "primal",
+        "Vz": "primal",
+        "Fx": "primal",
+        "Fy": "primal",
+        "Fz": "primal",
+        "rho": "primal",
+        "P": "primal",
+        "Vthx": "primal",
+        "Vthy": "primal",
+        "Vthz": "primal",
+        "tags": "dual",
     },
-    'y' : {
-        'Bx':'dual', 'By':'primal', 'Bz':'dual',
-        'Ex':'primal', 'Ey':'dual', 'Ez':'primal',
-        'Jx':'primal', 'Jy':'dual', 'Jz':'primal',
-        'Vx':'primal','Vy':'primal', 'Vz':'primal',
-        'Fx':'primal', 'Fy':'primal', 'Fz':'primal',
-        'rho':'primal', 'P':'primal',
-        'Vthx':'primal', 'Vthy':'primal', 'Vthz':'primal',
-        'tags':'dual',
+    "y": {
+        "Bx": "dual",
+        "By": "primal",
+        "Bz": "dual",
+        "Ex": "primal",
+        "Ey": "dual",
+        "Ez": "primal",
+        "Jx": "primal",
+        "Jy": "dual",
+        "Jz": "primal",
+        "Vx": "primal",
+        "Vy": "primal",
+        "Vz": "primal",
+        "Fx": "primal",
+        "Fy": "primal",
+        "Fz": "primal",
+        "rho": "primal",
+        "P": "primal",
+        "Vthx": "primal",
+        "Vthy": "primal",
+        "Vthz": "primal",
+        "tags": "dual",
     },
-    'z' : {
-        'Bx':'dual', 'By':'dual', 'Bz':'primal',
-        'Ex':'primal', 'Ey':'primal', 'Ez':'dual',
-        'Jx':'primal', 'Jy':'primal', 'Jz':'dual',
-        'Vx':'primal','Vy':'primal', 'Vz':'primal',
-        'Fx':'primal', 'Fy':'primal', 'Fz':'primal',
-        'rho':'primal', 'P':'primal',
-        'Vthx':'primal', 'Vthy':'primal', 'Vthz':'primal',
-        'tags':'dual',
-    }
+    "z": {
+        "Bx": "dual",
+        "By": "dual",
+        "Bz": "primal",
+        "Ex": "primal",
+        "Ey": "primal",
+        "Ez": "dual",
+        "Jx": "primal",
+        "Jy": "primal",
+        "Jz": "dual",
+        "Vx": "primal",
+        "Vy": "primal",
+        "Vz": "primal",
+        "Fx": "primal",
+        "Fy": "primal",
+        "Fz": "primal",
+        "rho": "primal",
+        "P": "primal",
+        "Vthx": "primal",
+        "Vthy": "primal",
+        "Vthz": "primal",
+        "tags": "dual",
+    },
 }
 yee_centering_lower = {
-  direction : {
-    key.lower() : centering
-    for key, centering in key_dict.items()
-  }
-  for direction, key_dict in yee_centering.items()
+    direction: {key.lower(): centering for key, centering in key_dict.items()}
+    for direction, key_dict in yee_centering.items()
 }
 
-def yee_element_is_primal(key, direction = 'x'):
+
+def yee_element_is_primal(key, direction="x"):
     if key in yee_centering_lower[direction]:
-        return yee_centering_lower[direction][key] == 'primal'
-    return yee_centering[direction][key] == 'primal'
+        return yee_centering_lower[direction][key] == "primal"
+    return yee_centering[direction][key] == "primal"
 
 
 class YeeCentering(object):
@@ -62,7 +99,9 @@ class YeeCentering(object):
         self.centerZ = yee_centering["z"]
 
 
-def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =False, **kwargs):
+def yeeCoordsFor(
+    origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts=False, **kwargs
+):
 
     assert direction in direction_to_dim, f"direction ({direction} not supported)"
     if qty in yee_centering_lower[direction] and qty not in yee_centering[direction]:
@@ -71,7 +110,7 @@ def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =Fa
     if "centering" in kwargs:
         centering = kwargs["centering"]
     else:
-        centering= yee_centering[direction][qty]
+        centering = yee_centering[direction][qty]
 
     offset = 0
     dim = direction_to_dim[direction]
@@ -80,8 +119,8 @@ def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =Fa
     else:
         size = nbrCells[dim]
 
-    if centering == 'dual':
-        offset = 0.5*dl[dim]
+    if centering == "dual":
+        offset = 0.5 * dl[dim]
     else:
         size += 1
 
@@ -93,12 +132,14 @@ def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =Fa
 
 class GridLayout(object):
     """
-      field_ghosts_nbr is a parameter to support pyphare geometry tests having hard coded 5 ghosts
-      initialized default to -1 as an invalid value allowing the override mechanism. Using None
-      results in a pylint error elsewhere
+    field_ghosts_nbr is a parameter to support pyphare geometry tests having hard coded 5 ghosts
+    initialized default to -1 as an invalid value allowing the override mechanism. Using None
+    results in a pylint error elsewhere
     """
 
-    def __init__(self, box=Box(0,0), origin=0, dl=0.1, interp_order=1, field_ghosts_nbr=-1):
+    def __init__(
+        self, box=Box(0, 0), origin=0, dl=0.1, interp_order=1, field_ghosts_nbr=-1
+    ):
         self.box = box
 
         self.dl = listify(dl)
@@ -109,139 +150,148 @@ class GridLayout(object):
 
         self.interp_order = interp_order
         self.impl = "yee"
-        self.directions = ['X','Y','Z']
+        self.directions = ["X", "Y", "Z"]
 
-        self.hybridQuantities = ['Bx','By','Bz',
-                                 'Ex','Ey','Ez',
-                                 'Jx','Jy','Jz',
-                                 'rho','Vx','Vy',
-                                 'Vz','P', 'Fx', 'Fy', 'Fz']
-
+        self.hybridQuantities = [
+            "Bx",
+            "By",
+            "Bz",
+            "Ex",
+            "Ey",
+            "Ez",
+            "Jx",
+            "Jy",
+            "Jz",
+            "rho",
+            "Vx",
+            "Vy",
+            "Vz",
+            "P",
+            "Fx",
+            "Fy",
+            "Fz",
+        ]
 
         self.yeeCentering = YeeCentering()
 
-        self.centering = {'X' : self.yeeCentering.centerX,
-                          'Y' : self.yeeCentering.centerY,
-                          'Z' : self.yeeCentering.centerZ
-                         }
+        self.centering = {
+            "X": self.yeeCentering.centerX,
+            "Y": self.yeeCentering.centerY,
+            "Z": self.yeeCentering.centerZ,
+        }
 
-        self.field_ghosts_nbr = field_ghosts_nbr # allows override
-
+        self.field_ghosts_nbr = field_ghosts_nbr  # allows override
 
     @property
     def ndim(self):
         return self.box.ndim
 
-
     def qtyCentering(self, quantity, direction):
         return self.centering[direction][quantity]
 
-
     def particleGhostNbr(self, interp_order):
         return 1 if interp_order == 1 else 2
-
 
     def nbrGhosts(self, interpOrder, centering):
         if self.field_ghosts_nbr == -1:
             return int((interpOrder + 1) / 2) + self.particleGhostNbr(interpOrder)
         return self.field_ghosts_nbr
 
-
     def nbrGhostsPrimal(self, interpOrder):
-        return self.nbrGhosts(interpOrder, 'primal')
-
+        return self.nbrGhosts(interpOrder, "primal")
 
     def qtyIsDual(self, qty, direction):
         return self.isDual(self.qtyCentering(qty, direction))
 
     def isDual(self, centering):
-        if centering == 'dual':
+        if centering == "dual":
             return 1
         else:
             return 0
 
-
-
     def ghostStartIndex(self):
-        return 0;
+        return 0
 
     def ghostEndIndex(self, interpOrder, centering, nbrCells):
-        index = self.physicalEndIndex(interpOrder, centering, nbrCells) \
-              + self.nbrGhosts(interpOrder, centering)
+        index = self.physicalEndIndex(
+            interpOrder, centering, nbrCells
+        ) + self.nbrGhosts(interpOrder, centering)
         return index
-
 
     def physicalStartIndex(self, interpOrder, centering):
         index = self.ghostStartIndex() + self.nbrGhosts(interpOrder, centering)
         return index
 
-
-
     def physicalEndIndex(self, interpOrder, centering, nbrCells):
-        index = self.physicalStartIndex(interpOrder, centering) \
-                + nbrCells - self.isDual(centering)
+        index = (
+            self.physicalStartIndex(interpOrder, centering)
+            + nbrCells
+            - self.isDual(centering)
+        )
         return index
-
-
 
     def physicalStartIndices(self, qty):
         assert qty in self.hybridQuantities
         indices = np.zeros(self.box.ndim)
-        for i, direction in enumerate(directions[:self.box.ndim]):
+        for i, direction in enumerate(directions[: self.box.ndim]):
             centering = yee_centering[direction][qty]
             indices[i] = self.physicalStartIndex(self.interp_order, centering)
         return indices
 
-
     def physicalEndIndices(self, qty):
         assert qty in self.hybridQuantities
         indices = np.zeros(self.box.ndim)
-        for i, direction in enumerate(directions[:self.box.ndim]):
+        for i, direction in enumerate(directions[: self.box.ndim]):
             centering = yee_centering[direction][qty]
-            indices[i] = self.physicalEndIndex(self.interp_order, centering, self.box.shape[i])
+            indices[i] = self.physicalEndIndex(
+                self.interp_order, centering, self.box.shape[i]
+            )
         return indices
-
 
     def nbrGhostFor(self, qty):
         assert qty in self.hybridQuantities
         nGhosts = np.zeros(self.box.ndim, dtype=np.int32)
-        for i, direction in enumerate(directions[:self.box.ndim]):
+        for i, direction in enumerate(directions[: self.box.ndim]):
             centering = yee_centering[direction][qty]
             nGhosts[i] = self.nbrGhosts(self.interp_order, centering)
         return nGhosts
-
 
     # ---- Start / End   primal methods ------
     def physicalStartPrimal(self, interpOrder):
         index = self.ghostStartIndex() + self.nbrGhostsPrimal(interpOrder)
         return index
 
-
-
-    def physicalEndPrimal(self,interpOrder, nbrCells):
+    def physicalEndPrimal(self, interpOrder, nbrCells):
         index = self.physicalStartPrimal(interpOrder) + nbrCells
         return index
 
     # ---- Alloc methods -------------------------
 
     def allocSize(self, interpOrder, centering, nbrCells):
-        size = nbrCells + 1 + 2*self.nbrGhosts(interpOrder, centering) \
-               - self.isDual(centering)
+        size = (
+            nbrCells
+            + 1
+            + 2 * self.nbrGhosts(interpOrder, centering)
+            - self.isDual(centering)
+        )
         return size
-
-
 
     # 1st derivative
     def allocSizeDerived(self, interpOrder, centering, nbrCells):
-        newCentering = self.changeCentering( centering, 1 )
+        newCentering = self.changeCentering(centering, 1)
 
-        size = nbrCells + 1 + 2*self.nbrGhosts(interpOrder, newCentering) \
-             - self.isDual(newCentering)
+        size = (
+            nbrCells
+            + 1
+            + 2 * self.nbrGhosts(interpOrder, newCentering)
+            - self.isDual(newCentering)
+        )
         return size
 
-
     def AMRPointToLocal(self, point):
-        return point - self.box.lower + self.physicalStartIndex(self.interp_order, "dual")
+        return (
+            point - self.box.lower + self.physicalStartIndex(self.interp_order, "dual")
+        )
 
     def AMRBoxToLocal(self, box):
         local = box.copy()
@@ -260,7 +310,6 @@ class GridLayout(object):
         dualStart = self.physicalStartIndex(self.interp_order, "dual")
         return index - self.box.lower[dim] + dualStart
 
-
     # ---- Yee coordinate methods -------------------------
     # knode : a primal or dual node index
     #
@@ -271,17 +320,16 @@ class GridLayout(object):
     # This method returns a point
     #
     def yeeCoords(self, knode, iStart, centering, direction, ds, origin, derivOrder):
-        halfCell = 0.
+        halfCell = 0.0
 
-        newCentering = self.changeCentering( centering, derivOrder )
+        newCentering = self.changeCentering(centering, derivOrder)
 
-        if newCentering == 'dual':
+        if newCentering == "dual":
             halfCell = 0.5
 
-        x = ( (knode - iStart) + halfCell )*ds + origin
+        x = ((knode - iStart) + halfCell) * ds + origin
 
         return x
-
 
     def yeeCoordsFor(self, qty, direction, withGhosts=True, **kwargs):
         """
@@ -292,21 +340,27 @@ class GridLayout(object):
         :param direction: can only be a single one
         """
 
-        if qty in yee_centering_lower[direction] and qty not in yee_centering[direction]:
+        if (
+            qty in yee_centering_lower[direction]
+            and qty not in yee_centering[direction]
+        ):
             qty = qty[0].upper() + qty[1:]
 
         if "centering" in kwargs:
             centering = kwargs["centering"]
         else:
-            centering= yee_centering[direction][qty]
+            centering = yee_centering[direction][qty]
 
-        return yeeCoordsFor(self.origin, self.nbrGhosts(self.interp_order, centering),
-                            self.dl, self.box.shape, qty, direction, withGhosts=withGhosts, centering=centering)
-
-
-
-
-
+        return yeeCoordsFor(
+            self.origin,
+            self.nbrGhosts(self.interp_order, centering),
+            self.dl,
+            self.box.shape,
+            qty,
+            direction,
+            withGhosts=withGhosts,
+            centering=centering,
+        )
 
     # ---- Get coordinate methods -------------------------
     # knode : a primal or dual node index
@@ -318,42 +372,40 @@ class GridLayout(object):
     # This method returns a point
     #
     def fieldCoords(self, knode, iStart, qty, direction, ds, origin, derivOrder):
-        halfCell = 0.
+        halfCell = 0.0
 
-        newCentering = self.changeCentering( self.qtyCentering(qty, direction), derivOrder )
+        newCentering = self.changeCentering(
+            self.qtyCentering(qty, direction), derivOrder
+        )
 
-        if newCentering == 'dual':
+        if newCentering == "dual":
             halfCell = 0.5
 
-        x = ( (knode - iStart) + halfCell )*ds + origin
+        x = ((knode - iStart) + halfCell) * ds + origin
 
         return x
-
-
 
     # ---- Change centering method -------------------------
     #
     # Use case:
     #   changeCentering( qtyCentering(qty, direct), 1 )
     #
-    def changeCentering(self, centering, derivOrder = 0):
+    def changeCentering(self, centering, derivOrder=0):
 
         newCentering = centering
 
         # if derivOrder is odd the centering is changed
         if derivOrder % 2 != 0:
-            newCentering = self.swapCentering( centering )
+            newCentering = self.swapCentering(centering)
 
         return newCentering
 
-
-
     # -------------------------------------------------------
-    def swapCentering(self, centering ):
+    def swapCentering(self, centering):
 
-        newCentering = 'primal'
+        newCentering = "primal"
 
-        if centering == 'primal':
-            newCentering = 'dual'
+        if centering == "primal":
+            newCentering = "dual"
 
         return newCentering

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -242,6 +242,24 @@ class Patch:
     def __copy__(self):
         return self.copy()
 
+    def __call__(self, qty, **kwargs):
+        if "x" in kwargs and len(kwargs) == 1:
+            cut = kwargs["x"]
+            idim = 0
+        elif "y" in kwargs and len(kwargs) == 1:
+            cut = kwargs["y"]
+            idim = 1
+        else:
+            raise ValueError("need to specify either x or y cut coordinate")
+        pd = self.patch_datas[qty]
+        origin = pd.origin[idim]
+        idx = int((cut - origin) / pd.layout.dl[idim])
+        nbrGhosts = pd.ghosts_nbr[idim]
+        if idim == 0:
+            return pd.dataset[idx + nbrGhosts, nbrGhosts:-nbrGhosts]
+        elif idim == 1:
+            return pd.dataset[nbrGhosts:-nbrGhosts, idx + nbrGhosts]
+
 
 class PatchLevel:
     """is a collection of patches"""
@@ -575,10 +593,78 @@ class PatchHierarchy(object):
                         )
                         first = False
                     else:
-                        self.qty.time_hier[time] = new_lvls
+                        self.qty.time_hier[time] = new_lvls  # pylint: disable=E1101
 
     def __getitem__(self, qty):
         return self.__dict__[qty]
+
+    def __call__(self, qty=None, **kwargs):
+        def cuts(c, coord):
+            return c > coord.min() and c < coord.max()
+
+        class Extractor:
+            def __init__(self):
+                self.exclusions = []
+
+            def extract(self, coord, data):
+                mask = coord == coord
+                for exclusion in self.exclusions:
+                    idx = np.where(
+                        (coord > exclusion[0] - 1e-6) & (coord < exclusion[1] + 1e-6)
+                    )[0]
+                    mask[idx] = False
+
+                self.exclusions += [(coord.min(), coord.max())]
+                return coord[mask], data[mask]
+
+        def domain_coords(patch, qty):
+            pd = patch.patch_datas[qty]
+            nbrGhosts = pd.ghosts_nbr[0]
+            return pd.x[nbrGhosts:-nbrGhosts], pd.y[nbrGhosts:-nbrGhosts]
+
+        if len(kwargs) < 1 or len(kwargs) > 3:
+            raise ValueError("Error - must provide coordinates")
+        if qty == None:
+            if len(self.quantities()) == 1:
+                qty = self.quantities()[0]
+            else:
+                raise ValueError(
+                    "The PatchHierarchy has several quantities but none is specified"
+                )
+
+        if len(kwargs) == 1:  # 1D cut
+            if "x" in kwargs:
+                c = kwargs["x"]
+                slice_dim = 1
+                cst_dim = 0
+            else:
+                c = kwargs["y"]
+                slice_dim = 0
+                cst_dim = 1
+
+        extractor = Extractor()
+        datas = []
+        coords = []
+        ilvls = list(self.levels().keys())[::-1]
+
+        for ilvl in ilvls:
+            lvl = self.patch_levels[ilvl]
+            for patch in lvl.patches:
+                slice_coord = domain_coords(patch, qty)[slice_dim]
+                cst_coord = domain_coords(patch, qty)[cst_dim]
+
+                if cuts(c, cst_coord):
+                    data = patch(qty, **kwargs)
+                    coord_keep, data_keep = extractor.extract(slice_coord, data)
+                    datas += [data_keep]
+                    coords += [coord_keep]
+
+        cut = np.concatenate(datas)
+        coords = np.concatenate(coords)
+        ic = np.argsort(coords)
+        coords = coords[ic]
+        cut = cut[ic]
+        return coords, cut
 
     def _default_time(self):
         return self.times()[0]
@@ -620,12 +706,43 @@ class PatchHierarchy(object):
         return it_is
 
     def _quantities(self):
-        return list(self.level(0).patches[0].patch_datas.keys())
+        for ilvl, lvl in self.levels().items():
+            if len(lvl.patches) > 0:
+                return list(self.level(ilvl).patches[0].patch_datas.keys())
+        return []
 
     def quantities(self):
         if not self.is_homogeneous():
             raise RuntimeError("Error - hierarchy is not homogeneous")
         return self._quantities()
+
+    def global_min(self, qty, **kwargs):
+        time = kwargs.get("time", self._default_time())
+        first = True
+        for ilvl, lvl in self.levels(time).items():
+            for patch in lvl.patches:
+                pd = patch.patch_datas[qty]
+                if first:
+                    m = pd.dataset[:].min()
+                    first = False
+                else:
+                    m = min(m, pd.dataset[:].min())
+
+        return m
+
+    def global_max(self, qty, **kwargs):
+        time = kwargs.get("time", self._default_time())
+        first = True
+        for ilvl, lvl in self.levels(time).items():
+            for patch in lvl.patches:
+                pd = patch.patch_datas[qty]
+                if first:
+                    m = pd.dataset[:].max()
+                    first = False
+                else:
+                    m = max(m, pd.dataset[:].max())
+
+        return m
 
     def refined_domain_box(self, level_number):
         """
@@ -788,7 +905,10 @@ class PatchHierarchy(object):
 
         time = kwargs.get("time", self._default_time())
         usr_lvls = kwargs.get("levels", self.levelNbrs(time))
-        qty = kwargs.get("qty", None)
+        default_qty = None
+        if len(self.quantities()) == 1:
+            default_qty = self.quantities()[0]
+        qty = kwargs.get("qty", default_qty)
 
         if "ax" not in kwargs:
             fig, ax = plt.subplots()
@@ -796,6 +916,8 @@ class PatchHierarchy(object):
             ax = kwargs["ax"]
             fig = ax.figure
 
+        glob_min = self.global_min(qty)
+        glob_max = self.global_max(qty)
         # assumes max 5 levels...
         patchcolors = {ilvl: "k" for ilvl in usr_lvls}
         patchcolors = kwargs.get("patchcolors", patchcolors)
@@ -839,8 +961,8 @@ class PatchHierarchy(object):
                     y,
                     data.T,
                     cmap=kwargs.get("cmap", "Spectral_r"),
-                    vmin=kwargs.get("vmin", None),
-                    vmax=kwargs.get("vmax", None),
+                    vmin=kwargs.get("vmin", glob_min),
+                    vmax=kwargs.get("vmax", glob_max),
                 )
 
                 if kwargs.get("plot_patches", False) is True:
@@ -1220,6 +1342,9 @@ def hierarchy_fromh5(h5_filename, time, hier, silent=True):
             lvl_cell_width = root_cell_width / refinement_ratio**ilvl
             patches = {}
 
+            if ilvl not in patches:
+                patches[ilvl] = []
+
             for pkey in h5_patch_lvl_grp.keys():
 
                 h5_patch_grp = h5_patch_lvl_grp[pkey]
@@ -1228,9 +1353,6 @@ def hierarchy_fromh5(h5_filename, time, hier, silent=True):
                     patch_datas = {}
                     layout = make_layout(h5_patch_grp, lvl_cell_width, interp)
                     add_to_patchdata(patch_datas, h5_patch_grp, basename, layout)
-
-                    if ilvl not in patches:
-                        patches[ilvl] = []
 
                     patches[ilvl].append(
                         Patch(patch_datas, h5_patch_grp.name.split("/")[-1])

--- a/src/amr/CMakeLists.txt
+++ b/src/amr/CMakeLists.txt
@@ -10,7 +10,8 @@ set( SOURCES_INC
      data/field/coarsening/field_coarsen_operator.hpp
      data/field/coarsening/field_coarsen_index_weight.hpp
      data/field/coarsening/coarsen_weighter.hpp
-     data/field/coarsening/field_coarsener.hpp
+     data/field/coarsening/default_field_coarsener.hpp
+     data/field/coarsening/magnetic_field_coarsener.hpp
      data/field/field_data.hpp
      data/field/field_data_factory.hpp
      data/field/field_geometry.hpp
@@ -18,6 +19,8 @@ set( SOURCES_INC
      data/field/field_variable.hpp
      data/field/refine/field_linear_refine.hpp
      data/field/refine/field_refiner.hpp
+     data/field/refine/magnetic_field_refiner.hpp
+     data/field/refine/electric_field_refiner.hpp
      data/field/refine/linear_weighter.hpp
      data/field/refine/field_refine_operator.hpp
      data/field/time_interpolate/field_linear_time_interpolate.hpp
@@ -27,8 +30,9 @@ set( SOURCES_INC
      resources_manager/resources_manager.hpp
      resources_manager/resources_manager_utilities.hpp
      resources_manager/resources_guards.hpp
-     messengers/quantity_communicator.hpp
-     messengers/communicators.hpp
+     messengers/communicator.hpp
+     messengers/refiner_pool.hpp
+     messengers/synchronizer_pool.hpp
      messengers/messenger.hpp
      messengers/hybrid_messenger.hpp
      messengers/hybrid_messenger_strategy.hpp
@@ -61,6 +65,7 @@ set( SOURCES_INC
      data/field/field_variable_fill_pattern.hpp
    )
 set( SOURCES_CPP
+     data/field/patch_level_ghost_fill_pattern.cpp
      data/field/refine/linear_weighter.cpp
      resources_manager/amr_utils.cpp
      data/field/coarsening/field_coarsen.cpp

--- a/src/amr/data/field/coarsening/default_field_coarsener.hpp
+++ b/src/amr/data/field/coarsening/default_field_coarsener.hpp
@@ -1,5 +1,5 @@
-#ifndef PHARE_FIELD_COARSENER_HPP
-#define PHARE_FIELD_COARSENER_HPP
+#ifndef PHARE_DEFAULT_FIELD_COARSENER_HPP
+#define PHARE_DEFAULT_FIELD_COARSENER_HPP
 
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/utilities/constants.hpp"
@@ -25,16 +25,19 @@ namespace amr
     /** @brief This class gives an operator() that performs the coarsening of N fine nodes onto a
      * given coarse node
      *
-     * A FieldCoarsener object is created each time the refine() method of the FieldCoarsenOperator
-     * is called and its operator() is called for each coarse index.
+     * A DefaultFieldCoarsener object is created each time the refine() method of the
+     * FieldCoarsenOperator is called and its operator() is called for each coarse index.
+     * It is the default coarsening policy and used for any field that does not come with
+     * specific constraints (such as conserving some property in the coarsening process).
      */
     template<std::size_t dimension>
-    class FieldCoarsener
+    class DefaultFieldCoarsener
     {
     public:
-        FieldCoarsener(std::array<core::QtyCentering, dimension> const& centering,
-                       SAMRAI::hier::Box const& sourceBox, SAMRAI::hier::Box const& destinationBox,
-                       SAMRAI::hier::IntVector const& ratio)
+        DefaultFieldCoarsener(std::array<core::QtyCentering, dimension> const& centering,
+                              SAMRAI::hier::Box const& sourceBox,
+                              SAMRAI::hier::Box const& destinationBox,
+                              SAMRAI::hier::IntVector const& ratio)
             : indexesAndWeights_{centering, ratio}
             , sourceBox_{sourceBox}
             , destinationBox_{destinationBox}

--- a/src/amr/data/field/coarsening/field_coarsen_index_weight.hpp
+++ b/src/amr/data/field/coarsening/field_coarsen_index_weight.hpp
@@ -5,9 +5,9 @@
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/hybrid/hybrid_quantities.hpp"
 #include "core/data/field/field.hpp"
-#include "amr/resources_manager/amr_utils.hpp"
 #include "core/utilities/constants.hpp"
 
+#include "amr/resources_manager/amr_utils.hpp"
 
 
 #include <SAMRAI/hier/Box.h>

--- a/src/amr/data/field/coarsening/field_coarsen_operator.hpp
+++ b/src/amr/data/field/coarsening/field_coarsen_operator.hpp
@@ -4,7 +4,7 @@
 #include "amr/data/field/field_data.hpp"
 #include "amr/data/field/field_geometry.hpp"
 #include "field_coarsen_index_weight.hpp"
-#include "field_coarsener.hpp"
+#include "default_field_coarsener.hpp"
 #include "core/utilities/constants.hpp"
 #include "core/utilities/point/point.hpp"
 
@@ -21,7 +21,7 @@ namespace amr
     using core::dirY;
     using core::dirZ;
     //
-    template<typename GridLayoutT, typename FieldT,
+    template<typename GridLayoutT, typename FieldT, typename FieldCoarsenerPolicy,
              typename PhysicalQuantity = decltype(std::declval<FieldT>().physicalQuantity())>
     /**
      * @brief The FieldCoarsenOperator class
@@ -40,10 +40,10 @@ namespace amr
         {
         }
 
-        FieldCoarsenOperator(FieldCoarsenOperator const&) = delete;
-        FieldCoarsenOperator(FieldCoarsenOperator&&)      = delete;
+        FieldCoarsenOperator(FieldCoarsenOperator const&)            = delete;
+        FieldCoarsenOperator(FieldCoarsenOperator&&)                 = delete;
         FieldCoarsenOperator& operator=(FieldCoarsenOperator const&) = delete;
-        FieldCoarsenOperator&& operator=(FieldCoarsenOperator&&) = delete;
+        FieldCoarsenOperator&& operator=(FieldCoarsenOperator&&)     = delete;
 
 
         virtual ~FieldCoarsenOperator() = default;
@@ -127,8 +127,8 @@ namespace amr
 
 
             // We can now create the coarsening operator
-            FieldCoarsener<dimension> coarsener{destinationLayout.centering(qty), sourceBox,
-                                                destinationBox, ratio};
+            FieldCoarsenerPolicy coarsener{destinationLayout.centering(qty), sourceBox,
+                                           destinationBox, ratio};
 
             // now we can loop over the intersection box
 

--- a/src/amr/data/field/coarsening/magnetic_field_coarsener.hpp
+++ b/src/amr/data/field/coarsening/magnetic_field_coarsener.hpp
@@ -1,0 +1,133 @@
+#ifndef PHARE_MAGNETIC_FIELD_COARSENER
+#define PHARE_MAGNETIC_FIELD_COARSENER
+
+#include "core/data/grid/gridlayoutdefs.hpp"
+#include "core/hybrid/hybrid_quantities.hpp"
+#include "core/utilities/constants.hpp"
+
+
+#include <SAMRAI/hier/Box.h>
+#include <stdexcept>
+
+namespace PHARE::amr
+{
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+/** @brief This class gives an operator() that performs the coarsening of N fine nodes onto a
+ * given coarse node
+ *
+ * A MagneticFieldCoarsener object is created each time the refine() method of the
+ * FieldCoarsenOperator is called and its operator() is called for each coarse index.
+ * It is the default coarsening policy and used for any field that does not come with
+ * specific constraints (such as conserving some property in the coarsening process).
+ */
+template<std::size_t dimension>
+class MagneticFieldCoarsener
+{
+public:
+    MagneticFieldCoarsener(std::array<core::QtyCentering, dimension> const centering,
+                           SAMRAI::hier::Box const& sourceBox,
+                           SAMRAI::hier::Box const& destinationBox,
+                           SAMRAI::hier::IntVector const& ratio)
+        : centering_{centering}
+        , sourceBox_{sourceBox}
+        , destinationBox_{destinationBox}
+
+    {
+    }
+
+    template<typename FieldT>
+    void operator()(FieldT const& fineField, FieldT& coarseField,
+                    core::Point<int, dimension> coarseIndex)
+    {
+        // For the moment we only take the case of field with the same centering
+        TBOX_ASSERT(fineField.physicalQuantity() == coarseField.physicalQuantity());
+
+        core::Point<int, dimension> fineStartIndex;
+
+        fineStartIndex[dirX] = coarseIndex[dirX] * this->ratio_;
+
+        if constexpr (dimension > 1)
+        {
+            fineStartIndex[dirY] = coarseIndex[dirY] * this->ratio_;
+            if constexpr (dimension > 2)
+            {
+                fineStartIndex[dirZ] = coarseIndex[dirZ] * this->ratio_;
+            }
+        }
+
+        fineStartIndex = AMRToLocal(fineStartIndex, sourceBox_);
+        coarseIndex    = AMRToLocal(coarseIndex, destinationBox_);
+
+        // the following kinda assumes where B is, i.e. Yee layout centering
+        // as it only does faces pirmal-dual, dual-primal and dual-dual
+
+        if constexpr (dimension == 1)
+        {
+            // in 1D div(B) is automatically satisfied so using this coarsening
+            // opertor is probably not better than the default one, but we do that
+            // for a kind of consistency...
+            // coarse flux is equal to fine flux and we're 1D so there is flux partitioned
+            // only for By and Bz, Bx is equal to the fine value
+
+            if (centering_[dirX] == core::QtyCentering::primal) // bx
+            {
+                coarseField(coarseIndex[dirX]) = fineField(fineStartIndex[dirX]);
+            }
+            else if (centering_[dirX] == core::QtyCentering::dual) // by and bz
+            {
+                coarseField(coarseIndex[dirX])
+                    = 0.5 * (fineField(fineStartIndex[dirX] + 1) + fineField(fineStartIndex[dirX]));
+            }
+        }
+
+        if constexpr (dimension == 2)
+        {
+            if (centering_[dirX] == core::QtyCentering::primal
+                and centering_[dirY] == core::QtyCentering::dual)
+            {
+                coarseField(coarseIndex[dirX], coarseIndex[dirY])
+                    = 0.5
+                      * (fineField(fineStartIndex[dirX], fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX], fineStartIndex[dirY] + 1));
+            }
+            else if (centering_[dirX] == core::QtyCentering::dual
+                     and centering_[dirY] == core::QtyCentering::primal)
+            {
+                coarseField(coarseIndex[dirX], coarseIndex[dirY])
+                    = 0.5
+                      * (fineField(fineStartIndex[dirX], fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX] + 1, fineStartIndex[dirY]));
+            }
+            else if (centering_[dirX] == core::QtyCentering::dual
+                     and centering_[dirY] == core::QtyCentering::dual)
+            {
+                coarseField(coarseIndex[dirX], coarseIndex[dirY])
+                    = 0.25
+                      * (fineField(fineStartIndex[dirX], fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX] + 1, fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX], fineStartIndex[dirY] + 1)
+                         + fineField(fineStartIndex[dirX] + 1, fineStartIndex[dirY] + 1));
+            }
+            else
+            {
+                {
+                    throw std::runtime_error("no magnetic field should end up here");
+                }
+            }
+        }
+        else if constexpr (dimension == 3)
+        {
+            throw std::runtime_error("Not Implemented yet");
+        }
+    }
+
+private:
+    std::array<core::QtyCentering, dimension> const centering_;
+    SAMRAI::hier::Box const sourceBox_;
+    SAMRAI::hier::Box const destinationBox_;
+    static int constexpr ratio_ = 2;
+};
+} // namespace PHARE::amr
+#endif

--- a/src/amr/data/field/field_variable_fill_pattern.hpp
+++ b/src/amr/data/field/field_variable_fill_pattern.hpp
@@ -113,7 +113,7 @@ public:
     std::string const& getPatternName() const { return s_name_id; }
 
 private:
-    FieldFillPattern(FieldFillPattern const&) = delete;
+    FieldFillPattern(FieldFillPattern const&)            = delete;
     FieldFillPattern& operator=(FieldFillPattern const&) = delete;
 
     static const inline std::string s_name_id = "BOX_GEOMETRY_FILL_PATTERN";
@@ -156,6 +156,9 @@ private:
 
         SAMRAI::hier::BoxContainer overlap_boxes(fill_boxes);
         overlap_boxes.intersectBoxes(data_box);
+        //        overlap_boxes.removeIntersections(patch_box);
+        // overlap_boxes.removeIntersections(SAMRAI::hier::Box::grow(
+        //     patch_box, SAMRAI::hier::IntVector::getOne(patch_box.getDim())));
 
         return pdf.getBoxGeometry(patch_box)->setUpOverlap(overlap_boxes, transformation);
     }

--- a/src/amr/data/field/patch_level_ghost_fill_pattern.cpp
+++ b/src/amr/data/field/patch_level_ghost_fill_pattern.cpp
@@ -1,0 +1,158 @@
+#include "patch_level_ghost_fill_pattern.hpp"
+#include "SAMRAI/hier/BoxContainer.h"
+#include "SAMRAI/hier/RealBoxConstIterator.h"
+#include "SAMRAI/hier/Box.h"
+#include "SAMRAI/tbox/MathUtilities.h"
+
+
+namespace PHARE::amr
+{
+/*
+ *************************************************************************
+ *
+ * Default constructor
+ *
+ *************************************************************************
+ */
+
+PatchLevelGhostFillPattern::PatchLevelGhostFillPattern()
+    : d_max_fill_boxes(0)
+{
+}
+
+/*
+ *************************************************************************
+ *
+ * Destructor
+ *
+ *************************************************************************
+ */
+
+PatchLevelGhostFillPattern::~PatchLevelGhostFillPattern() {}
+
+/*
+ *************************************************************************
+ *
+ * computeFillBoxesAndNeighborhoodSets
+ *
+ *************************************************************************
+ */
+void PatchLevelGhostFillPattern::computeFillBoxesAndNeighborhoodSets(
+    std::shared_ptr<SAMRAI::hier::BoxLevel>& fill_box_level,
+    std::shared_ptr<SAMRAI::hier::Connector>& dst_to_fill,
+    const SAMRAI::hier::BoxLevel& dst_box_level, const SAMRAI::hier::IntVector& fill_ghost_width,
+    bool data_on_patch_border)
+{
+    TBOX_ASSERT_OBJDIM_EQUALITY2(dst_box_level, fill_ghost_width);
+
+    fill_box_level.reset(new SAMRAI::hier::BoxLevel(dst_box_level.getRefinementRatio(),
+                                                    dst_box_level.getGridGeometry(),
+                                                    dst_box_level.getMPI()));
+
+    dst_to_fill.reset(
+        new SAMRAI::hier::Connector(dst_box_level, *fill_box_level, fill_ghost_width));
+
+    const SAMRAI::hier::BoxContainer& dst_boxes = dst_box_level.getBoxes();
+
+    const int dst_level_num = dst_box_level.getGridGeometry()->getEquivalentLevelNumber(
+        dst_box_level.getRefinementRatio());
+
+    SAMRAI::hier::IntVector dst_to_dst_width(fill_ghost_width);
+    if (data_on_patch_border)
+    {
+        dst_to_dst_width += SAMRAI::hier::IntVector::getOne(fill_ghost_width.getDim());
+    }
+
+    const SAMRAI::hier::Connector& dst_to_dst = dst_box_level.findConnector(
+        dst_box_level, dst_to_dst_width, SAMRAI::hier::CONNECTOR_IMPLICIT_CREATION_RULE, true);
+
+    /*
+     * To get the level border, grow each patch box and remove
+     * the level from it.
+     */
+    SAMRAI::hier::LocalId last_id = dst_box_level.getLastLocalId();
+    for (SAMRAI::hier::RealBoxConstIterator ni(dst_boxes.realBegin()); ni != dst_boxes.realEnd();
+         ++ni)
+    {
+        const SAMRAI::hier::Box& dst_box = *ni;
+        SAMRAI::hier::BoxContainer fill_boxes(SAMRAI::hier::Box::grow(dst_box, fill_ghost_width));
+        SAMRAI::hier::Connector::ConstNeighborhoodIterator nabrs
+            = dst_to_dst.find(dst_box.getBoxId());
+        for (SAMRAI::hier::Connector::ConstNeighborIterator na = dst_to_dst.begin(nabrs);
+             na != dst_to_dst.end(nabrs); ++na)
+        {
+            // SAMRAI default PatchLevelBorderFillPattern from which this code
+            // is based seems to overwrite the border node
+            // therefore since we remove 'na' from the fill_boxes,
+            // we grow na by 1 in the hope that it
+            auto tmp = SAMRAI::hier::Box::grow(
+                *na, SAMRAI ::hier::IntVector::getOne(fill_ghost_width.getDim()));
+            if (dst_box.getBlockId() == na->getBlockId())
+            {
+                fill_boxes.removeIntersections(tmp);
+            }
+            else
+            {
+                throw std::runtime_error("WE SHOULD NEVER GET HERE");
+            }
+        }
+
+        if (!fill_boxes.empty())
+        {
+            d_max_fill_boxes
+                = SAMRAI::tbox::MathUtilities<int>::Max(d_max_fill_boxes, fill_boxes.size());
+            SAMRAI::hier::Connector::NeighborhoodIterator base_box_itr
+                = dst_to_fill->makeEmptyLocalNeighborhood(dst_box.getBoxId());
+            for (SAMRAI::hier::BoxContainer::iterator li = fill_boxes.begin();
+                 li != fill_boxes.end(); ++li)
+            {
+                SAMRAI::hier::Box fill_box(*li, ++last_id, dst_box.getOwnerRank());
+                TBOX_ASSERT(fill_box.getBlockId() == dst_box.getBlockId());
+                fill_box_level->addBoxWithoutUpdate(fill_box);
+                dst_to_fill->insertLocalNeighbor(fill_box, base_box_itr);
+            }
+        }
+    }
+    fill_box_level->finalize();
+}
+
+void PatchLevelGhostFillPattern::computeDestinationFillBoxesOnSourceProc(
+    FillSet& dst_fill_boxes_on_src_proc, const SAMRAI::hier::BoxLevel& dst_box_level,
+    const SAMRAI::hier::Connector& src_to_dst, const SAMRAI::hier::IntVector& fill_ghost_width)
+{
+    NULL_USE(dst_box_level);
+    NULL_USE(src_to_dst);
+    NULL_USE(fill_ghost_width);
+    NULL_USE(dst_fill_boxes_on_src_proc);
+    if (!needsToCommunicateDestinationFillBoxes())
+    {
+        TBOX_ERROR("PatchLevelGhostFillPattern cannot compute destination:\n"
+                   << "fill boxes on the source processor.\n");
+    }
+}
+
+bool PatchLevelGhostFillPattern::needsToCommunicateDestinationFillBoxes() const
+{
+    return true;
+}
+
+bool PatchLevelGhostFillPattern::doesSourceLevelCommunicateToDestination() const
+{
+    return false;
+}
+
+bool PatchLevelGhostFillPattern::fillingCoarseFineGhosts() const
+{
+    return true;
+}
+
+bool PatchLevelGhostFillPattern::fillingEnhancedConnectivityOnly() const
+{
+    return false;
+}
+
+int PatchLevelGhostFillPattern::getMaxFillBoxes() const
+{
+    return d_max_fill_boxes;
+}
+} // namespace PHARE::amr

--- a/src/amr/data/field/patch_level_ghost_fill_pattern.hpp
+++ b/src/amr/data/field/patch_level_ghost_fill_pattern.hpp
@@ -1,0 +1,122 @@
+#ifndef PHARE_PATCH_LEVEL_GHOST_FILL_PATTERN_HPP
+#define PHARE_PATCH_LEVEL_GHOST_FILL_PATTERN_HPP
+
+#include "SAMRAI/SAMRAI_config.h"
+
+#include "SAMRAI/xfer/PatchLevelFillPattern.h"
+
+namespace PHARE::amr
+{
+/*!
+ * @brief PatchLevelFillPattern implementation for filling at PatchLevel
+ * boundaries.
+ *
+ * For documentation on this interface see @ref PatchLevelFillPattern
+ *
+ * The fill boxes will consist of the ghost regions lying outside of
+ * the level interior--in other words the ghost regions at physical
+ * and coarse-fine boundaries.
+ */
+
+class PatchLevelGhostFillPattern : public SAMRAI::xfer::PatchLevelFillPattern
+{
+public:
+    /*!
+     * @brief Default constructor
+     */
+    PatchLevelGhostFillPattern();
+
+    /*!
+     * @brief Destructor
+     */
+    virtual ~PatchLevelGhostFillPattern();
+
+    /*!
+     * @brief Compute the boxes to be filled and related communication data.
+     *
+     * The computed fill_box_level will cover the ghost regions around the
+     * boxes of dst_box_level at coarse-fine and physical boundaries.
+     * The width of those ghost regions will be determined by fill_ghost_width.
+     *
+     * @param[out] fill_box_level       Output BoxLevel to be filled
+     * @param[out] dst_to_fill          Output Connector between
+     *                                  dst_box_level and fill_box_level
+     * @param[in] dst_box_level         destination level
+     * @param[in] fill_ghost_width      Ghost width being filled by refine
+     *                                  schedule
+     * @param[in] data_on_patch_border  true if there is data living on patch
+     *                                  borders
+     *
+     * @pre dst_box_level.getDim() == fill_ghost_width.getDim()
+     */
+    void
+    computeFillBoxesAndNeighborhoodSets(std::shared_ptr<SAMRAI::hier::BoxLevel>& fill_box_level,
+                                        std::shared_ptr<SAMRAI::hier::Connector>& dst_to_fill,
+                                        const SAMRAI::hier::BoxLevel& dst_box_level,
+                                        const SAMRAI::hier::IntVector& fill_ghost_width,
+                                        bool data_on_patch_border);
+
+    /*!
+     * @brief Return true to indicate source patch owners cannot compute
+     * fill boxes without using communication.
+     */
+    bool needsToCommunicateDestinationFillBoxes() const;
+
+    /*!
+     * @brief Virtual method to compute the destination fill boxes.
+     *
+     * Since needsToCommunicateDestinationFillBoxes() returns true, this
+     * method should never be called.  It is implemented here to satisfy
+     * the pure virtual interface from the base class.  An error will result
+     * if this is ever called.
+     *
+     * @pre needsToCommunicateDestinationFillBoxes()
+     */
+    void computeDestinationFillBoxesOnSourceProc(FillSet& dst_fill_boxes_on_src_proc,
+                                                 const SAMRAI::hier::BoxLevel& dst_box_level,
+                                                 const SAMRAI::hier::Connector& src_to_dst,
+                                                 const SAMRAI::hier::IntVector& fill_ghost_width);
+
+    /*!
+     * @brief Tell RefineSchedule not to communicate data directly from source
+     * to destination level.
+     *
+     * RefineSchedule should not attempt to fill as much of the
+     * destination level as possible from the source level at the same
+     * level of resolution for this fill pattern.
+     *
+     * @return false
+     */
+    bool doesSourceLevelCommunicateToDestination() const;
+
+    /*!
+     * @brief Return the maximum number of fill boxes.
+     *
+     * @return maximum number of fill boxes.
+     */
+    int getMaxFillBoxes() const;
+
+    /*!
+     * @brief Returns true because this fill pattern fills coarse-fine ghost
+     * data.
+     */
+    bool fillingCoarseFineGhosts() const;
+
+    /*!
+     * @brief Returns false because this fill pattern is not specialized for
+     * enhanced connectivity only.
+     */
+    bool fillingEnhancedConnectivityOnly() const;
+
+private:
+    PatchLevelGhostFillPattern(const PatchLevelGhostFillPattern&);            // not implemented
+    PatchLevelGhostFillPattern& operator=(const PatchLevelGhostFillPattern&); // not implemented
+
+    /*!
+     * @brief Maximum number of fill boxes across all destination patches.
+     */
+    int d_max_fill_boxes;
+};
+} // namespace PHARE::amr
+
+#endif

--- a/src/amr/data/field/refine/electric_field_refiner.hpp
+++ b/src/amr/data/field/refine/electric_field_refiner.hpp
@@ -1,0 +1,299 @@
+#ifndef PHARE_ELECTRIC_FIELD_REFINER_HPP
+#define PHARE_ELECTRIC_FIELD_REFINER_HPP
+
+#include <SAMRAI/hier/Box.h>
+
+#include "amr/resources_manager/amr_utils.hpp"
+#include "core/utilities/constants.hpp"
+#include "core/data/grid/gridlayoutdefs.hpp"
+#include "core/utilities/point/point.hpp"
+#include "core/utilities/constants.hpp"
+
+#include <cstddef>
+
+namespace PHARE::amr
+{
+
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+
+template<std::size_t dimension>
+class ElectricFieldRefiner
+{
+public:
+    ElectricFieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
+                         SAMRAI::hier::Box const& destinationGhostBox,
+                         SAMRAI::hier::Box const& sourceGhostBox,
+                         SAMRAI::hier::IntVector const& ratio)
+        : fineBox_{destinationGhostBox}
+        , coarseBox_{sourceGhostBox}
+        , centerings_{centering}
+    {
+    }
+
+
+    /** @brief Given a sourceField , a destinationField, and a fineIndex compute the
+     */
+    template<typename FieldT>
+    void operator()(FieldT const& coarseField, FieldT& fineField,
+                    core::Point<int, dimension> fineIndex)
+    {
+        TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
+
+        auto locFineIdx = AMRToLocal(fineIndex, fineBox_);
+        auto coarseIdx{fineIndex};
+        for (auto& idx : coarseIdx)
+            idx = idx / 2;
+        auto locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
+
+
+        if constexpr (dimension == 1)
+        {
+            // if dual, then Ex
+            // if even fine index, we're on top of coarse, we take 100% coarse overlaped fieldValue
+            // e.g. fineIndex==100, we take coarse[100/2]
+            // e.g. fineIndex==101  we take coarse[101/2] = coarse[50] as well
+            //
+            //          49           50             51
+            //    o     x     o      x       o      x      o        Ex on coarse
+            //    o  x  o  x  o   x  o   x   o   x  o   x  o        Ex on fine
+            //       98    99   100     101     102    103
+            //
+            //
+            // if primal, then Ey,Ez we just copy the coarse value
+            // since they are on top of the fine one.
+            //
+            // therefore in all cases in 1D we just copy the coarse value
+            //
+            fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
+        }
+        else if constexpr (dimension == 2)
+        {
+            // ilc: index local coarse
+            // ilf: index local fine
+            auto ilcx = locCoarseIdx[dirX];
+            auto ilcy = locCoarseIdx[dirY];
+            auto ilfx = locFineIdx[dirX];
+            auto ilfy = locFineIdx[dirY];
+
+
+            // Ey
+            if (centerings_[dirX] == core::QtyCentering::primal
+                and centerings_[dirY] == core::QtyCentering::dual)
+            {
+                if (onCoarseXFace_(fineIndex))
+                {
+                    // we're on a coarse edge at j=1/4 and 3/4
+                    // we thus copy the coarse at j=1/2
+                    // both fine Ey e.g. at j=100 and 101 will take j=50 on coarse
+                    // so no need to look at whether jfine is even or odd
+                    // just take the value at the local coarse index
+                    fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+                }
+                else
+                {
+                    // we're on a fine edge in between two coarse ones
+                    // we take the average
+                    fineField(ilfx, ilfy)
+                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy));
+                }
+            }
+            // this is Ex
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::primal)
+            {
+                if (onCoarseYFace_(fineIndex))
+                {
+                    // we're on a fine edge shared with coarse mesh
+                    // take the coarse face value
+                    fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+                }
+                else
+                {
+                    // we're on a fine edge in between two coarse edges
+                    // we take the average
+                    fineField(ilfx, ilfy)
+                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx, ilcy + 1));
+                }
+            }
+            // and this is now Ez
+            else if (centerings_[dirX] == core::QtyCentering::primal
+                     and centerings_[dirY] == core::QtyCentering::primal)
+            {
+                if (onCoarseXFace_(fineIndex) and onCoarseYFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+                }
+                else if (onCoarseXFace_(fineIndex))
+                    fineField(ilfx, ilfy)
+                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx, ilcy + 1));
+                else if (onCoarseYFace_(fineIndex))
+                    fineField(ilfx, ilfy)
+                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy));
+                else
+                    fineField(ilfx, ilfy)
+                        = 0.25
+                          * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy)
+                             + coarseField(ilcx, ilcy + 1) + coarseField(ilcx + 1, ilcy + 1));
+            }
+        }
+
+
+        else if constexpr (dimension == 3)
+        {
+            // ilc: index local coarse
+            // ilf: index local fine
+            auto ilcx = locCoarseIdx[dirX];
+            auto ilcy = locCoarseIdx[dirY];
+            auto ilcz = locCoarseIdx[dirZ];
+            auto ilfx = locFineIdx[dirX];
+            auto ilfy = locFineIdx[dirY];
+            auto ilfz = locFineIdx[dirZ];
+
+            // Ex
+            if (centerings_[dirX] == core::QtyCentering::dual
+                and centerings_[dirY] == core::QtyCentering::primal
+                and centerings_[dirZ] == core::QtyCentering::primal)
+            {
+                // here we share an X edge with coarse
+                // just copy the coarse value
+                if (onCoarseYFace_(fineIndex) and onCoarseZFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+                }
+                // we share the Y face but not the Z face
+                // we must be one of the 2 X fine edges on a Y face
+                // thus we take the average of the two surrounding edges at Z and Z+DZ
+                else if (onCoarseYFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy, ilcz + 1));
+                }
+                // we share a Z face but not the Y face
+                // we must be one of the 2 X fine edges on a Z face
+                // we thus take the average of the two X edges at y and y+dy
+                else if (onCoarseZFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz));
+                }
+                else
+                {
+                    // we don't share any face thus we're on one of the 2 middle X edges
+                    // we take the average of the 4 surrounding X averages
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.25 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz))
+                          + 0.25
+                                * (coarseField(ilcx, ilcy, ilcz + 1)
+                                   + coarseField(ilcx, ilcy + 1, ilcz + 1));
+                }
+            }
+            // now this is Ey
+            else if (centerings_[dirX] == core::QtyCentering::primal
+                     and centerings_[dirY] == core::QtyCentering::dual
+                     and centerings_[dirZ] == core::QtyCentering::primal)
+            {
+                // we're on coarse X and coarse Z face, i.e. share a Y coarse edge
+                if (onCoarseXFace_(fineIndex) and onCoarseZFace_(fineIndex))
+                {
+                    // we thus just copy the coarse value
+                    fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+                }
+                // now we only have same X face, but not (else) the Z face
+                // so we're a new fine Y edge in between two coarse Y edges
+                // on a X coarse face. Thus we average the two surrounding Y edges on that X
+                // face.
+                else if (onCoarseXFace_(fineIndex))
+                {
+                    // we're on a fine X face, but not on a Z face
+                    // this means we are on a Y edge that lies in between 2 coarse edges
+                    // at z and z+dz
+                    // take the average of these 2 coarse value
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy, ilcz + 1));
+                }
+                // we're on a Z coarse face, but not on a X coarse face
+                // we thus must be one of the 2 Y edges on a Z face
+                // and thus we take the average of the 2 Y edges at X and X+dX
+                else if (onCoarseZFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz));
+                }
+                // now we're not on any of the coarse faces
+                // so we must be one of the two Y edge in the middle of the cell
+                // we thus average over the 4 Y edges of the coarse cell
+                else
+                {
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.25
+                          * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz)
+                             + coarseField(ilcx, ilcy, ilcz + 1)
+                             + coarseField(ilcx + 1, ilcy, ilcz + 1));
+                }
+            }
+            // now let's do Ez
+            else if (centerings_[dirX] == core::QtyCentering::primal
+                     and centerings_[dirY] == core::QtyCentering::primal
+                     and centerings_[dirZ] == core::QtyCentering::dual)
+            {
+                // we're on a X and a Y coarse face, we thus share the Z coarse edge
+                // we thus copy the coarse value
+                if (onCoarseXFace_(fineIndex) and onCoarseYFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+                }
+                // here we're on a coarse X face, but not a Y face
+                // we must be 1 of the 2 Z edges on a X face
+                // thus we average the 2 surrounding Z coarse edges at Y and Y+dY
+                else if (onCoarseXFace_(fineIndex))
+                {
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz));
+                }
+                // here we're on a coarse Y face, but not a X face
+                // we must be 1 of the 2 Z edges on a Y face
+                // thus we average the 2 surrounding Z coarse edges at X and X+dX
+                else if (onCoarseYFace_(fineIndex))
+                {
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz));
+                }
+                // we're not on any coarse face thus must be one of the 2 Z edges
+                // in the middle of the coarse cell
+                // we therefore take the average of the 4 surrounding Z edges
+                else
+                {
+                    fineField(ilfx, ilfy, ilfz)
+                        = 0.25
+                          * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz)
+                             + coarseField(ilcx, ilcy + 1, ilcz + 1)
+                             + coarseField(ilcx + 1, ilcy + 1, ilcz));
+                }
+            }
+        }
+    }
+
+private:
+    bool onCoarseXFace_(core::Point<int, dimension> const& fineIndex)
+    {
+        return fineIndex[dirX] % 2 == 0;
+    }
+    bool onCoarseYFace_(core::Point<int, dimension> const& fineIndex)
+    {
+        return fineIndex[dirY] % 2 == 0;
+    }
+    bool onCoarseZFace_(core::Point<int, dimension> const& fineIndex)
+    {
+        return fineIndex[dirZ] % 2 == 0;
+    }
+
+    SAMRAI::hier::Box const fineBox_;
+    SAMRAI::hier::Box const coarseBox_;
+    std::array<core::QtyCentering, dimension> const centerings_;
+};
+} // namespace PHARE::amr
+
+
+#endif // !PHARE_ELECTRIC_FIELD_REFINER_HPP

--- a/src/amr/data/field/refine/field_refine_operator.hpp
+++ b/src/amr/data/field/refine/field_refine_operator.hpp
@@ -27,168 +27,161 @@ public:
 
     bool const node_only = false;
 };
-} // namespace PHARE::amr
 
 
-namespace PHARE
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+
+template<typename GridLayoutT, typename FieldT, typename FieldRefinerPolicy>
+class FieldRefineOperator : public SAMRAI::hier::RefineOperator, public AFieldRefineOperator
 {
-namespace amr
-{
-    using core::dirX;
-    using core::dirY;
-    using core::dirZ;
+public:
+    static constexpr std::size_t dimension = GridLayoutT::dimension;
+    using GridLayoutImpl                   = typename GridLayoutT::implT;
+    using PhysicalQuantity                 = typename FieldT::physical_quantity_type;
+    using FieldDataT                       = FieldData<GridLayoutT, FieldT>;
 
-    template<typename GridLayoutT, typename FieldT>
-    class FieldRefineOperator : public SAMRAI::hier::RefineOperator, public AFieldRefineOperator
+    FieldRefineOperator(bool node_only = false)
+        : SAMRAI::hier::RefineOperator{"FieldRefineOperator"}
+        , AFieldRefineOperator{node_only}
     {
-    public:
-        static constexpr std::size_t dimension = GridLayoutT::dimension;
-        using GridLayoutImpl                   = typename GridLayoutT::implT;
-        using PhysicalQuantity                 = typename FieldT::physical_quantity_type;
-        using FieldDataT                       = FieldData<GridLayoutT, FieldT>;
+    }
 
-        FieldRefineOperator(bool node_only = false)
-            : SAMRAI::hier::RefineOperator{"FieldRefineOperator"}
-            , AFieldRefineOperator{node_only}
+    virtual ~FieldRefineOperator() = default;
+
+    /** This implementation have the top priority for refine operation
+     *
+     */
+    int getOperatorPriority() const override { return 0; }
+
+    /**
+     * @brief This operator needs to have at least 1 ghost cell to work properly
+     *
+     */
+    SAMRAI::hier::IntVector getStencilWidth(SAMRAI::tbox::Dimension const& dim) const override
+    {
+        return SAMRAI::hier::IntVector::getOne(dim);
+    }
+
+
+
+
+    /**
+     * @brief Given a  set of box on a  fine patch, compute the interpolation from
+     * a coarser patch that is underneath the fine box.
+     * Since we get our boxes from a FieldOverlap, we know that they are in correct
+     * Field Indexes
+     *
+     */
+    void refine(SAMRAI::hier::Patch& destination, SAMRAI::hier::Patch const& source,
+                int const destinationId, int const sourceId,
+                SAMRAI::hier::BoxOverlap const& destinationOverlap,
+                SAMRAI::hier::IntVector const& ratio) const override
+    {
+        using FieldGeometry = typename FieldDataT::Geometry;
+
+        auto const& destinationFieldOverlap = dynamic_cast<FieldOverlap const&>(destinationOverlap);
+
+        auto const& overlapBoxes = destinationFieldOverlap.getDestinationBoxContainer();
+
+        auto& destinationField        = FieldDataT::getField(destination, destinationId);
+        auto const& destinationLayout = FieldDataT::getLayout(destination, destinationId);
+        auto const& sourceField       = FieldDataT::getField(source, sourceId);
+        auto const& sourceLayout      = FieldDataT::getLayout(source, sourceId);
+
+
+        // We assume that quantity are all the same.
+        // Note that an assertion will be raised
+        // in refineIt operator
+        auto const& qty = destinationField.physicalQuantity();
+
+        bool const withGhost{true};
+
+        auto destinationFieldBox
+            = FieldGeometry::toFieldBox(destination.getBox(), qty, destinationLayout, withGhost);
+
+
+        auto sourceFieldBox
+            = FieldGeometry::toFieldBox(source.getBox(), qty, sourceLayout, withGhost);
+
+
+
+
+        FieldRefinerPolicy refiner{destinationLayout.centering(qty), destinationFieldBox,
+                                   sourceFieldBox, ratio};
+
+
+
+        for (auto const& box : overlapBoxes)
         {
-        }
-
-        virtual ~FieldRefineOperator() = default;
-
-        /** This implementation have the top priority for refine operation
-         *
-         */
-        int getOperatorPriority() const override { return 0; }
-
-        /**
-         * @brief This operator needs to have at least 1 ghost cell to work properly
-         *
-         */
-        SAMRAI::hier::IntVector getStencilWidth(SAMRAI::tbox::Dimension const& dim) const override
-        {
-            return SAMRAI::hier::IntVector::getOne(dim);
-        }
+            // we compute the intersection with the destination,
+            // and then we apply the refine operation on each fine
+            // index.
+            auto intersectionBox = destinationFieldBox * box;
 
 
 
 
-        /**
-         * @brief Given a  set of box on a  fine patch, compute the interpolation from
-         * a coarser patch that is underneath the fine box.
-         * Since we get our boxes from a FieldOverlap, we know that they are in correct
-         * Field Indexes
-         *
-         */
-        void refine(SAMRAI::hier::Patch& destination, SAMRAI::hier::Patch const& source,
-                    int const destinationId, int const sourceId,
-                    SAMRAI::hier::BoxOverlap const& destinationOverlap,
-                    SAMRAI::hier::IntVector const& ratio) const override
-        {
-            using FieldGeometry = typename FieldDataT::Geometry;
-
-            auto const& destinationFieldOverlap
-                = dynamic_cast<FieldOverlap const&>(destinationOverlap);
-
-            auto const& overlapBoxes = destinationFieldOverlap.getDestinationBoxContainer();
-
-            auto& destinationField        = FieldDataT::getField(destination, destinationId);
-            auto const& destinationLayout = FieldDataT::getLayout(destination, destinationId);
-            auto const& sourceField       = FieldDataT::getField(source, sourceId);
-            auto const& sourceLayout      = FieldDataT::getLayout(source, sourceId);
-
-
-            // We assume that quantity are all the same.
-            // Note that an assertion will be raised
-            // in refineIt operator
-            auto const& qty = destinationField.physicalQuantity();
-
-            bool const withGhost{true};
-
-            auto destinationFieldBox = FieldGeometry::toFieldBox(destination.getBox(), qty,
-                                                                 destinationLayout, withGhost);
-
-
-            auto sourceFieldBox
-                = FieldGeometry::toFieldBox(source.getBox(), qty, sourceLayout, withGhost);
-
-
-
-
-            FieldRefiner<dimension> refiner{destinationLayout.centering(qty), destinationFieldBox,
-                                            sourceFieldBox, ratio};
-
-
-
-            for (auto const& box : overlapBoxes)
+            if constexpr (dimension == 1)
             {
-                // we compute the intersection with the destination,
-                // and then we apply the refine operation on each fine
-                // index.
-                auto intersectionBox = destinationFieldBox * box;
+                int iStartX = intersectionBox.lower(dirX);
+                int iEndX   = intersectionBox.upper(dirX);
 
-
-
-
-                if constexpr (dimension == 1)
+                for (int ix = iStartX; ix <= iEndX; ++ix)
                 {
-                    int iStartX = intersectionBox.lower(dirX);
-                    int iEndX   = intersectionBox.upper(dirX);
+                    refiner(sourceField, destinationField, {{ix}});
+                }
+            }
 
-                    for (int ix = iStartX; ix <= iEndX; ++ix)
+
+
+
+            else if constexpr (dimension == 2)
+            {
+                int iStartX = intersectionBox.lower(dirX);
+                int iStartY = intersectionBox.lower(dirY);
+
+                int iEndX = intersectionBox.upper(dirX);
+                int iEndY = intersectionBox.upper(dirY);
+
+                for (int ix = iStartX; ix <= iEndX; ++ix)
+                {
+                    for (int iy = iStartY; iy <= iEndY; ++iy)
                     {
-                        refiner(sourceField, destinationField, {{ix}});
+                        refiner(sourceField, destinationField, {{ix, iy}});
                     }
                 }
+            }
 
 
 
 
-                else if constexpr (dimension == 2)
+            else if constexpr (dimension == 3)
+            {
+                int iStartX = intersectionBox.lower(dirX);
+                int iStartY = intersectionBox.lower(dirY);
+                int iStartZ = intersectionBox.lower(dirZ);
+
+                int iEndX = intersectionBox.upper(dirX);
+                int iEndY = intersectionBox.upper(dirY);
+                int iEndZ = intersectionBox.upper(dirZ);
+
+                for (int ix = iStartX; ix <= iEndX; ++ix)
                 {
-                    int iStartX = intersectionBox.lower(dirX);
-                    int iStartY = intersectionBox.lower(dirY);
-
-                    int iEndX = intersectionBox.upper(dirX);
-                    int iEndY = intersectionBox.upper(dirY);
-
-                    for (int ix = iStartX; ix <= iEndX; ++ix)
+                    for (int iy = iStartY; iy <= iEndY; ++iy)
                     {
-                        for (int iy = iStartY; iy <= iEndY; ++iy)
+                        for (int iz = iStartZ; iz <= iEndZ; ++iz)
                         {
-                            refiner(sourceField, destinationField, {{ix, iy}});
-                        }
-                    }
-                }
-
-
-
-
-                else if constexpr (dimension == 3)
-                {
-                    int iStartX = intersectionBox.lower(dirX);
-                    int iStartY = intersectionBox.lower(dirY);
-                    int iStartZ = intersectionBox.lower(dirZ);
-
-                    int iEndX = intersectionBox.upper(dirX);
-                    int iEndY = intersectionBox.upper(dirY);
-                    int iEndZ = intersectionBox.upper(dirZ);
-
-                    for (int ix = iStartX; ix <= iEndX; ++ix)
-                    {
-                        for (int iy = iStartY; iy <= iEndY; ++iy)
-                        {
-                            for (int iz = iStartZ; iz <= iEndZ; ++iz)
-                            {
-                                refiner(sourceField, destinationField, {{ix, iy, iz}});
-                            }
+                            refiner(sourceField, destinationField, {{ix, iy, iz}});
                         }
                     }
                 }
             }
         }
-    };
-} // namespace amr
-} // namespace PHARE
+    }
+};
+} // namespace PHARE::amr
 
 
 

--- a/src/amr/data/field/refine/field_refiner.hpp
+++ b/src/amr/data/field/refine/field_refiner.hpp
@@ -26,12 +26,13 @@ namespace amr
      * coarse field.
      */
     template<std::size_t dimension>
-    class FieldRefiner
+    class DefaultFieldRefiner
     {
     public:
-        FieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
-                     SAMRAI::hier::Box const& destinationGhostBox,
-                     SAMRAI::hier::Box const& sourceGhostBox, SAMRAI::hier::IntVector const& ratio)
+        DefaultFieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
+                            SAMRAI::hier::Box const& destinationGhostBox,
+                            SAMRAI::hier::Box const& sourceGhostBox,
+                            SAMRAI::hier::IntVector const& ratio)
             : indexesAndWeights_{centering, ratio}
             , fineBox_{destinationGhostBox}
             , coarseBox_{sourceGhostBox}

--- a/src/amr/data/field/refine/magnetic_field_refiner.hpp
+++ b/src/amr/data/field/refine/magnetic_field_refiner.hpp
@@ -1,0 +1,228 @@
+#ifndef PHARE_MAGNETIC_FIELD_REFINER_HPP
+#define PHARE_MAGNETIC_FIELD_REFINER_HPP
+
+#include <SAMRAI/hier/Box.h>
+
+#include "amr/resources_manager/amr_utils.hpp"
+#include "core/utilities/constants.hpp"
+#include "core/data/grid/gridlayoutdefs.hpp"
+#include "core/utilities/point/point.hpp"
+#include "core/utilities/constants.hpp"
+
+#include <cstddef>
+
+namespace PHARE::amr
+{
+
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+
+template<std::size_t dimension>
+class MagneticFieldRefiner
+{
+public:
+    MagneticFieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
+                         SAMRAI::hier::Box const& destinationGhostBox,
+                         SAMRAI::hier::Box const& sourceGhostBox,
+                         SAMRAI::hier::IntVector const& ratio)
+        : fineBox_{destinationGhostBox}
+        , coarseBox_{sourceGhostBox}
+        , centerings_{centering}
+    {
+    }
+
+
+    /** @brief Given a sourceField , a destinationField, and a fineIndex compute the
+     */
+    template<typename FieldT>
+    void operator()(FieldT const& coarseField, FieldT& fineField,
+                    core::Point<int, dimension> fineIndex)
+    {
+        TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
+
+        auto locFineIdx = AMRToLocal(fineIndex, fineBox_);
+        auto coarseIdx{fineIndex};
+        for (auto& idx : coarseIdx)
+            idx = idx / 2;
+        auto locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
+
+
+        if constexpr (dimension == 1)
+        {
+            // if primal, i.e. Bx :
+            // if even fine index, we're on top of coarse, we take 100% coarse overlaped fieldValue
+            // e.g. fineIndex==100, we take coarse[100/2]
+            // if odd fine index, we take 50% of surrounding coarse nodes
+            // e.g. fineIndex == 101, we take 0.5(coarse(101/2)+coarse(101/2+1))
+            //
+            //   49          50              51            52
+            //    o           o              o             o      Bx on coarse
+            //    x     x     x      x       o      x      x      Bx on fine
+            //   98     99   100    101     102    103    104
+            //
+            //
+            if (centerings_[0] == core::QtyCentering::primal)
+            {
+                if (fineIndex[0] % 2 == 0)
+                {
+                    fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
+                }
+                else
+                {
+                    fineField(locFineIdx[dirX])
+                        = 0.5
+                          * (coarseField(locCoarseIdx[dirX]) + coarseField(locCoarseIdx[dirX] + 1));
+                }
+            }
+            // dual case, By, Bz
+            //          49           50             51
+            //    o     +     o      +       o      +       o      Byz on coarse : +
+            //    o  +  o  +  o   +  o   +   o   +  o   +   o      Byz on fine   : +
+            //      98    99     100    101     102    103
+            //
+            // 100 takes 50 = 100/2
+            // 101 takes 50 = 101/2
+            else
+            {
+                fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
+            }
+        }
+
+
+
+
+        else if constexpr (dimension == 2)
+        {
+            if (centerings_[dirX] == core::QtyCentering::primal
+                and centerings_[dirY] == core::QtyCentering::dual)
+            {
+                // Bx
+                if (fineIndex[dirX] % 2 == 0)
+                {
+                    // we're on a coarse X face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                }
+                else
+                {
+                    // we're on a fine X face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = 0.5
+                          * (coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY])
+                             + coarseField(locCoarseIdx[dirX] + 1, locCoarseIdx[dirY]));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::primal)
+            {
+                // By
+                if (fineIndex[dirY] % 2 == 0)
+                {
+                    // we're on a coarse Y face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                }
+                else
+                {
+                    // we're on a fine Y face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = 0.5
+                          * (coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY])
+                             + coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY] + 1));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::dual)
+            {
+                // Bz
+                // we're always on a coarse Z face since there is no dual in z
+                // all 4 fine Bz take the coarse Z value
+                fineField(locFineIdx[dirX], locFineIdx[dirY])
+                    = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+            }
+        }
+
+
+        else if constexpr (dimension == 3)
+        {
+            auto ix = locCoarseIdx[dirX];
+            auto iy = locCoarseIdx[dirY];
+            auto iz = locCoarseIdx[dirZ];
+
+            if (centerings_[dirX] == core::QtyCentering::primal
+                and centerings_[dirY] == core::QtyCentering::dual
+                and centerings_[dirZ] == core::QtyCentering::dual)
+            {
+                // Bx
+                if (fineIndex[dirX] % 2 == 0)
+                {
+                    // we're on a coarse X face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = coarseField(ix, iy, iz);
+                }
+                else
+                {
+                    // we're on a fine X face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ix, iy, iz) + coarseField(ix + 1, iy, iz));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::primal
+                     and centerings_[dirZ] == core::QtyCentering::dual)
+            {
+                // By
+                if (fineIndex[dirY] % 2 == 0)
+                {
+                    // we're on a coarse Y face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = coarseField(ix, iy, iz);
+                }
+                else
+                {
+                    // we're on a fine Y face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ix, iy, iz) + coarseField(ix, iy + 1, iz));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::dual
+                     and centerings_[dirZ] == core::QtyCentering::primal)
+            {
+                // Bz
+                if (fineIndex[dirZ] % 2 == 0)
+                {
+                    // we're on a coarse X face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = coarseField(ix, iy, iz);
+                }
+                else
+                {
+                    // we're on a fine Z face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ix, iy, iz) + coarseField(ix, iy, iz + 1));
+                }
+            }
+        }
+    }
+
+private:
+    SAMRAI::hier::Box const fineBox_;
+    SAMRAI::hier::Box const coarseBox_;
+    std::array<core::QtyCentering, dimension> const centerings_;
+};
+} // namespace PHARE::amr
+
+
+#endif // !PHARE_MAGNETIC_FIELD_REFINER_HPP

--- a/src/amr/level_initializer/hybrid_level_initializer.hpp
+++ b/src/amr/level_initializer/hybrid_level_initializer.hpp
@@ -70,6 +70,7 @@ namespace solver
             {
                 if (isRegridding)
                 {
+                    std::cout << "reriding level " << levelNumber << "\n";
                     PHARE_LOG_START("hybridLevelInitializer::initialize : regriding block");
                     messenger.regrid(hierarchy, levelNumber, oldLevel, model, initDataTime);
                     PHARE_LOG_STOP("hybridLevelInitializer::initialize : regriding block");
@@ -106,6 +107,7 @@ namespace solver
                 ions.computeDensity();
                 ions.computeBulkVelocity();
             }
+            hybMessenger.prepareStep(hybridModel, level, initDataTime);
             hybMessenger.fillIonMomentGhosts(hybridModel.state.ions, level, initDataTime);
 
 

--- a/src/amr/messengers/hybrid_messenger_info.hpp
+++ b/src/amr/messengers/hybrid_messenger_info.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_HYBRID_MESSENGER_INFO_HPP
 #define PHARE_HYBRID_MESSENGER_INFO_HPP
 
@@ -41,7 +40,7 @@ namespace amr
         VecFieldDescriptor() = default;
 
         template<typename VecFieldT>
-        VecFieldDescriptor(VecFieldT const& v)
+        explicit VecFieldDescriptor(VecFieldT const& v)
             : vecName{v.name()}
             , xName{v.getComponentName(core::Component::X)}
             , yName{v.getComponentName(core::Component::Y)}

--- a/src/amr/messengers/synchronizer_pool.hpp
+++ b/src/amr/messengers/synchronizer_pool.hpp
@@ -1,0 +1,72 @@
+#ifndef PHARE_SYNCHRONIZER_POOL_HPP
+#define PHARE_SYNCHRONIZER_POOL_HPP
+
+#include "communicator.hpp"
+
+
+
+namespace PHARE::amr
+{
+
+
+template<std::size_t dimension>
+class SynchronizerPool
+{
+public:
+    template<typename Descriptor, typename ResourcesManager>
+    void add(Descriptor const& descriptor,
+             std::shared_ptr<SAMRAI::hier::CoarsenOperator> const& coarsenOp, std::string key,
+             std::shared_ptr<ResourcesManager> const& rm)
+    {
+        synchronizers_.insert(
+            {key, makeSynchronizer<ResourcesManager, dimension>(descriptor, rm, coarsenOp)});
+    }
+
+
+
+
+    template<typename ResourcesManager>
+    void add(VecFieldDescriptor const& descriptor, std::shared_ptr<ResourcesManager> const& rm,
+             std::shared_ptr<SAMRAI::hier::CoarsenOperator> const& coarsenOp, std::string key)
+    {
+        auto const [it, success] = synchronizers_.insert(
+            {key, makeSynchronizer<ResourcesManager, dimension>(descriptor, rm, coarsenOp)});
+
+        if (!success)
+            throw std::runtime_error(key + " is already registered");
+    }
+
+
+
+    void registerLevel(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
+                       std::shared_ptr<SAMRAI::hier::PatchLevel> const& level)
+    {
+        auto levelNumber        = level->getLevelNumber();
+        auto const& coarseLevel = hierarchy->getPatchLevel(levelNumber - 1);
+
+        for (auto& [_, synchronizer] : synchronizers_)
+            for (auto& algo : synchronizer.algos)
+                synchronizer.add(algo, algo->createSchedule(coarseLevel, level), levelNumber);
+    }
+
+
+
+    void sync(int const levelNumber)
+    {
+        for (auto& [key, synchronizer] : synchronizers_)
+        {
+            if (synchronizer.algos.size() == 0)
+                throw std::runtime_error("Algorithms are not configured");
+
+            for (auto const& algo : synchronizer.algos)
+                synchronizer.findSchedule(algo, levelNumber)->coarsenData();
+        }
+    }
+
+private:
+    std::map<std::string, Communicator<Synchronizer, dimension>> synchronizers_;
+};
+
+
+} // namespace PHARE::amr
+#endif

--- a/src/amr/multiphysics_integrator.hpp
+++ b/src/amr/multiphysics_integrator.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_MULTIPHYSICS_INTEGRATOR_HPP
 #define PHARE_MULTIPHYSICS_INTEGRATOR_HPP
 
@@ -49,7 +48,10 @@ namespace solver
     };
 
 
-    inline bool isRootLevel(int levelNumber) { return levelNumber == 0; }
+    inline bool isRootLevel(int levelNumber)
+    {
+        return levelNumber == 0;
+    }
 
 
     /**

--- a/src/amr/physical_models/hybrid_model.hpp
+++ b/src/amr/physical_models/hybrid_model.hpp
@@ -1,6 +1,3 @@
-
-
-
 #ifndef PHARE_HYBRID_MODEL_HPP
 #define PHARE_HYBRID_MODEL_HPP
 
@@ -150,12 +147,12 @@ void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::fillMesse
     modelInfo.modelIonBulkVelocity = amr::VecFieldDescriptor{state.ions.velocity()};
     modelInfo.modelCurrent         = amr::VecFieldDescriptor{state.J};
 
-    modelInfo.initElectric.emplace_back(state.electromag.E);
-    modelInfo.initMagnetic.emplace_back(state.electromag.B);
+    modelInfo.initElectric.emplace_back(amr::VecFieldDescriptor{state.electromag.E});
+    modelInfo.initMagnetic.emplace_back(amr::VecFieldDescriptor{state.electromag.B});
 
     modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
     modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
-    modelInfo.ghostCurrent.push_back(state.J);
+    modelInfo.ghostCurrent.push_back(amr::VecFieldDescriptor{state.J});
     modelInfo.ghostBulkVelocity.push_back(modelInfo.modelIonBulkVelocity);
 
 

--- a/src/core/data/field/field.hpp
+++ b/src/core/data/field/field.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_CORE_DATA_FIELD_FIELD_BASE_HPP
 #define PHARE_CORE_DATA_FIELD_FIELD_BASE_HPP
 
@@ -34,10 +33,10 @@ namespace core
         using NdArrayImpl::dimension;
 
 
-        Field()                    = delete;
-        Field(Field const& source) = delete;
-        Field(Field&& source)      = default;
-        Field& operator=(Field&& source) = delete;
+        Field()                               = delete;
+        Field(Field const& source)            = delete;
+        Field(Field&& source)                 = default;
+        Field& operator=(Field&& source)      = delete;
         Field& operator=(Field const& source) = delete;
 
         template<typename... Dims>

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -37,7 +37,10 @@ namespace core
     constexpr bool has_physicalQuantity_v = has_physicalQuantity<T>::value;
 
 
-    constexpr int centering2int(QtyCentering c) { return static_cast<int>(c); }
+    constexpr int centering2int(QtyCentering c)
+    {
+        return static_cast<int>(c);
+    }
 
 
     template<std::size_t interpOrder>
@@ -1140,6 +1143,15 @@ namespace core
             evalOnBox_(field, fn, indices);
         }
 
+        template<typename Field, typename Fn>
+        void evalOnGhostBox(Field& field, Fn&& fn) const
+        {
+            auto indices = [&](auto const& centering, auto const direction) {
+                return this->ghostStartToEnd(centering, direction);
+            };
+
+            evalOnBox_(field, fn, indices);
+        }
 
 
     private:

--- a/src/core/logger.hpp
+++ b/src/core/logger.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_CORE_LOGGER_HPP
 #define PHARE_CORE_LOGGER_HPP
 

--- a/src/core/numerics/faraday/faraday.hpp
+++ b/src/core/numerics/faraday/faraday.hpp
@@ -39,9 +39,12 @@ public:
         auto& Bynew = Bnew(Component::Y);
         auto& Bznew = Bnew(Component::Z);
 
-        layout_->evalOnBox(Bxnew, [&](auto&... args) mutable { BxEq_(Bx, E, Bxnew, args...); });
-        layout_->evalOnBox(Bynew, [&](auto&... args) mutable { ByEq_(By, E, Bynew, args...); });
-        layout_->evalOnBox(Bznew, [&](auto&... args) mutable { BzEq_(Bz, E, Bznew, args...); });
+        layout_->evalOnGhostBox(Bxnew,
+                                [&](auto&... args) mutable { BxEq_(Bx, E, Bxnew, args...); });
+        layout_->evalOnGhostBox(Bynew,
+                                [&](auto&... args) mutable { ByEq_(By, E, Bynew, args...); });
+        layout_->evalOnGhostBox(Bznew,
+                                [&](auto&... args) mutable { BzEq_(Bz, E, Bznew, args...); });
     }
 
 

--- a/tests/amr/data/field/coarsening/test_coarsen_field.py
+++ b/tests/amr/data/field/coarsening/test_coarsen_field.py
@@ -4,14 +4,17 @@
 
 import os
 import sys
-import numpy as np
+from multiprocessing import Value
+from socket import AI_PASSIVE
 
-from pyphare.core.box import Box
+import numpy as np
 import pyphare.core.box as boxm
 from pyphare.core import gridlayout
+from pyphare.core.box import Box
 from pyphare.core.gridlayout import directions
 from pyphare.core.phare_utilities import refinement_ratio
 from pyphare.pharesee.hierarchy import FieldData
+
 
 def exec_fn(xyz, fn):
     ndim = len(xyz)
@@ -104,14 +107,15 @@ def main(path="./"):
 
 
 
+
+
+
+
+
 def coarsen(qty, coarseField, fineField, coarseBox, fineData, coarseData):
     coarseLayout = coarseField.layout
     fineLayout = fineField.layout
     ndim = coarseLayout.box.ndim
-
-    nGhosts = coarseLayout.nbrGhostFor(qty)
-    coarseStartIndex = coarseLayout.physicalStartIndices(qty)
-    fineOffset = fineLayout.box.lower - boxm.refine(coarseLayout.box, 2).lower
 
     is_primal = []
     for direction in directions[:ndim]:
@@ -131,10 +135,14 @@ def coarsen(qty, coarseField, fineField, coarseBox, fineData, coarseData):
             fineIndex = fineLocal(index, 0)
             coarseLocalIndex = coarseLocal(index, 0)
             if is_primal[0]:
-                coarseData[coarseLocalIndex] = (
-                    fineData[fineIndex - 1] * .25 + fineData[fineIndex] * .5 + fineData[fineIndex + 1] * .25
+                if qty == "Bx":
+                    coarseData[coarseLocalIndex] = fineData[fineIndex]
+                else:
+                    coarseData[coarseLocalIndex] = (
+                               fineData[fineIndex - 1] * .25 + fineData[fineIndex] * .5 + fineData[fineIndex + 1] * .25
                 )
             else:
+                # ind 1D it is the same formula for By and Bz as for other quantities
                 coarseData[coarseLocalIndex] = (
                     fineData[fineIndex] * .5 + fineData[fineIndex + 1] * .5
                 )
@@ -157,37 +165,53 @@ def coarsen(qty, coarseField, fineField, coarseBox, fineData, coarseData):
                     middle += fineData[fineIndexX][fineIndexY + 1]    * .25
                     right += fineData[fineIndexX + 1][fineIndexY - 1] * .25
                     right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .25
+                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .25
                     coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
                         left * .25 + middle * .5 + right * .25
                     )
 
                 if is_primal[0] and not is_primal[1]:
-                    left += fineData[fineIndexX - 1][fineIndexY]      * .5
-                    left += fineData[fineIndexX - 1][fineIndexY + 1]  * .5
-                    middle += fineData[fineIndexX][fineIndexY]        * .5
-                    middle += fineData[fineIndexX][fineIndexY + 1]    * .5
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .5
-                    coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
-                        left * .25 + middle * .5 + right * .25
-                    )
+                    if qty == "Bx":
+                        coarseData[coarseLocalIndexX,coarseLocalIndexY] \
+                                = 0.5*(fineData[fineIndexX,fineIndexY] + fineData[fineIndexX,fineIndexY+1])
+                    else:
+                        left += fineData[fineIndexX - 1][fineIndexY]      * .5
+                        left += fineData[fineIndexX - 1][fineIndexY + 1]  * .5
+                        middle += fineData[fineIndexX][fineIndexY]        * .5
+                        middle += fineData[fineIndexX][fineIndexY + 1]    * .5
+                        right += fineData[fineIndexX + 1][fineIndexY]     * .5
+                        right += fineData[fineIndexX + 1][fineIndexY + 1] * .5
+                        coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
+                            left * .25 + middle * .5 + right * .25
+                        )
 
                 if not is_primal[0] and is_primal[1]:
-                    left += fineData[fineIndexX][fineIndexY - 1]      * .25
-                    left += fineData[fineIndexX][fineIndexY]          * .5
-                    left += fineData[fineIndexX][fineIndexY + 1]      * .25
-                    right += fineData[fineIndexX + 1][fineIndexY - 1] * .25
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .25
-                    coarseData[coarseLocalIndexX][coarseLocalIndexY] = (left * .5 + right * .5)
+                    if qty == "By":
+                        coarseData[coarseLocalIndexX,coarseLocalIndexY] \
+                                = 0.5*(fineData[fineIndexX,fineIndexY] + fineData[fineIndexX+1,fineIndexY])
+
+                    else:
+                        left += fineData[fineIndexX][fineIndexY - 1]      * .25
+                        left += fineData[fineIndexX][fineIndexY]          * .5
+                        left += fineData[fineIndexX][fineIndexY + 1]      * .25
+                        right += fineData[fineIndexX + 1][fineIndexY - 1] * .25
+                        right += fineData[fineIndexX + 1][fineIndexY]     * .5
+                        right += fineData[fineIndexX + 1][fineIndexY + 1] * .25
+                        coarseData[coarseLocalIndexX][coarseLocalIndexY] = (left * .5 + right * .5)
 
                 if not any(is_primal):
-                    left += fineData[fineIndexX][fineIndexY]          * .5
-                    left += fineData[fineIndexX][fineIndexY + 1]      * .5
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .5
-                    coarseData[coarseLocalIndexX][coarseLocalIndexY] = (left * .5 + right * .5)
+                    if qty == "Bz":
+                        coarseData[coarseLocalIndexX,coarseLocalIndexY] = \
+                                0.25*(fineData[fineIndexX,fineIndexY] + \
+                                      fineData[fineIndexX,fineIndexY+1] + \
+                                      fineData[fineIndexX+1,fineIndexY+1] + \
+                                      fineData[fineIndexX+1,fineIndexY] )
+                    else:
+                        left += fineData[fineIndexX][fineIndexY]          * .5
+                        left += fineData[fineIndexX][fineIndexY + 1]      * .5
+                        right += fineData[fineIndexX + 1][fineIndexY]     * .5
+                        right += fineData[fineIndexX + 1][fineIndexY + 1] * .5
+                        coarseData[coarseLocalIndexX][coarseLocalIndexY] = (left * .5 + right * .5)
 
 
 

--- a/tests/amr/data/field/coarsening/test_linear_coarsen.hpp
+++ b/tests/amr/data/field/coarsening/test_linear_coarsen.hpp
@@ -1,6 +1,8 @@
 #ifndef PHARE_TEST_LINEAR_COARSEN_HPP
 #define PHARE_TEST_LINEAR_COARSEN_HPP
 
+#include "amr/data/field/coarsening/default_field_coarsener.hpp"
+#include "amr/data/field/coarsening/magnetic_field_coarsener.hpp"
 #include "amr/data/field/coarsening/field_coarsen_operator.hpp"
 #include "amr/data/field/coarsening/field_coarsen_index_weight.hpp"
 #include "core/data/grid/gridlayout.hpp"
@@ -10,9 +12,7 @@
 
 #include <cassert>
 
-using testing::DoubleEq;
 using testing::DoubleNear;
-using testing::Eq;
 
 using namespace PHARE::core;
 using namespace PHARE::amr;
@@ -143,7 +143,40 @@ struct FieldCoarsenTestData
     }
 };
 
-template<std::size_t dimension>
+template<std::size_t dimension, typename Coarsener>
+void coarsen(std::size_t idx, SAMRAI::hier::Box& fineBox, SAMRAI::hier::Box& coarseBox,
+             std::array<PHARE::core::QtyCentering, dimension>& centering,
+             SAMRAI::hier::IntVector& ratio, EMData<dimension>& em)
+{
+    Coarsener coarseIt{centering, fineBox, coarseBox, ratio};
+
+    auto primals(ConstArray<int, dimension>());
+    for (std::size_t i = 0; i < dimension; i++)
+        primals[i] = centering[i] == QtyCentering::primal;
+
+    if constexpr (dimension == 1)
+    {
+        for (int coarseX = 10; coarseX < 15 + primals[0]; ++coarseX)
+            coarseIt(*em.fineValues[idx], *em.coarseValues[idx], Point<int, dimension>{coarseX});
+    }
+    else if constexpr (dimension == 2)
+    {
+        for (int coarseX = 10; coarseX < 15 + primals[0]; ++coarseX)
+            for (int coarseY = 10; coarseY < 15 + primals[1]; ++coarseY)
+                coarseIt(*em.fineValues[idx], *em.coarseValues[idx],
+                         Point<int, dimension>{coarseX, coarseY});
+    }
+    else if constexpr (dimension == 3)
+    {
+        for (int coarseX = 10; coarseX < 15 + primals[0]; ++coarseX)
+            for (int coarseY = 10; coarseY < 15 + primals[1]; ++coarseY)
+                for (int coarseZ = 10; coarseZ < 15 + primals[2]; ++coarseZ)
+                    coarseIt(*em.fineValues[idx], *em.coarseValues[idx],
+                             Point<int, dimension>{coarseX, coarseY, coarseZ});
+    }
+};
+
+template<std::size_t dimension, typename Coarsener>
 void load(FieldCoarsenTestData<dimension>& param, Files& file_data)
 {
     auto load = [](auto& value, auto const& nCells, auto& file) {
@@ -220,39 +253,9 @@ void load(FieldCoarsenTestData<dimension>& param, Files& file_data)
 
     SAMRAI::hier::IntVector ratio{dim, 2};
 
-    auto coarsen = [&em, &ratio](auto idx, auto& fineBox, auto& coarseBox, auto& centering) {
-        FieldCoarsener<dimension> coarseIt{centering, fineBox, coarseBox, ratio};
-
-        auto primals(ConstArray<int, dimension>());
-        for (std::size_t i = 0; i < dimension; i++)
-            primals[i] = centering[i] == QtyCentering::primal;
-
-        if constexpr (dimension == 1)
-        {
-            for (int coarseX = 10; coarseX < 15 + primals[0]; ++coarseX)
-                coarseIt(*em.fineValues[idx], *em.coarseValues[idx],
-                         Point<int, dimension>{coarseX});
-        }
-        else if constexpr (dimension == 2)
-        {
-            for (int coarseX = 10; coarseX < 15 + primals[0]; ++coarseX)
-                for (int coarseY = 10; coarseY < 15 + primals[1]; ++coarseY)
-                    coarseIt(*em.fineValues[idx], *em.coarseValues[idx],
-                             Point<int, dimension>{coarseX, coarseY});
-        }
-        else if constexpr (dimension == 3)
-        {
-            for (int coarseX = 10; coarseX < 15 + primals[0]; ++coarseX)
-                for (int coarseY = 10; coarseY < 15 + primals[1]; ++coarseY)
-                    for (int coarseZ = 10; coarseZ < 15 + primals[2]; ++coarseZ)
-                        coarseIt(*em.fineValues[idx], *em.coarseValues[idx],
-                                 Point<int, dimension>{coarseX, coarseY, coarseZ});
-        }
-    };
-
-    coarsen(0, fineBoxX, coarseBoxX, centeringX);
-    coarsen(1, fineBoxY, coarseBoxY, centeringY);
-    coarsen(2, fineBoxZ, coarseBoxZ, centeringZ);
+    coarsen<dimension, Coarsener>(0, fineBoxX, coarseBoxX, centeringX, ratio, em);
+    coarsen<dimension, Coarsener>(1, fineBoxY, coarseBoxY, centeringY, ratio, em);
+    coarsen<dimension, Coarsener>(2, fineBoxZ, coarseBoxZ, centeringZ, ratio, em);
 }
 
 
@@ -263,16 +266,32 @@ std::vector<FieldCoarsenTestData<dimension>> createParam()
 
     std::string const dimStr = std::to_string(dimension);
 
+
     std::array<std::pair<std::string, Files>, 2> files{
         {{"E", Files::init("E", dimStr)}, {"B", Files::init("B", dimStr)}}};
 
     for (auto& [em_key, file_data] : files)
+    {
         while (file_data.ok())
-            load(coarsenData
-                     .emplace_back(FieldCoarsenTestData<dimension>{EMData<dimension>::get(em_key)})
-                     .init(),
-                 file_data);
-
+        {
+            if (em_key == "E")
+                load<dimension, DefaultFieldCoarsener<dimension>>(
+                    coarsenData
+                        .emplace_back(
+                            FieldCoarsenTestData<dimension>{EMData<dimension>::get(em_key)})
+                        .init(),
+                    file_data);
+            else if (em_key == "B")
+            {
+                load<dimension, MagneticFieldCoarsener<dimension>>(
+                    coarsenData
+                        .emplace_back(
+                            FieldCoarsenTestData<dimension>{EMData<dimension>::get(em_key)})
+                        .init(),
+                    file_data);
+            }
+        }
+    }
     return coarsenData;
 }
 
@@ -281,12 +300,12 @@ template<typename FieldCoarsenTestDataParam>
 struct FieldCoarsenOperatorTest : public ::testing::Test
 {
     static constexpr auto dimension  = FieldCoarsenTestDataParam::dimension;
-    static constexpr double absError = 1.e-8;
+    static constexpr double absError = 1.e-15;
 };
 
 using FieldCoarsenOperators
     = testing::Types<FieldCoarsenTestData<1>,
-                     FieldCoarsenTestData<2> /* , FieldCoarsenTestData<3>*/>;
+                     FieldCoarsenTestData<2> /* , FieldCoarsenTestData<3>*/>; // TODO 3D
 TYPED_TEST_SUITE(FieldCoarsenOperatorTest, FieldCoarsenOperators);
 
 
@@ -323,7 +342,7 @@ TYPED_TEST(FieldCoarsenOperatorTest, doTheExpectedCoarseningForEB)
                         EXPECT_THAT(coarseValue(ix, iy),
                                     DoubleNear(expectedCoarseValue(ix, iy), absError));
             }
-            else if constexpr (dim == 3)
+            else if constexpr (dim == 3) // TODO 3D
             {
                 throw std::runtime_error("Unsupported dimension"); // uncomment/test below
                 // auto iStartZ = layout->ghostStartIndex(qty, Direction::Z);

--- a/tests/amr/data/field/refine/test_field_refine.cpp
+++ b/tests/amr/data/field/refine/test_field_refine.cpp
@@ -77,7 +77,7 @@ TYPED_TEST(aFieldRefineOperator, canBeCreated)
     using GridYee = GridLayout<GridLayoutImplYee<dim, interp>>;
     using FieldT  = Field<NdArrayVector<dim>, HybridQuantity::Scalar>;
 
-    FieldRefineOperator<GridYee, FieldT> linearRefine{};
+    FieldRefineOperator<GridYee, FieldT, DefaultFieldRefiner<dim>> linearRefine{};
 }
 
 
@@ -103,7 +103,8 @@ TYPED_TEST(aFieldRefine, canBeCreated)
     SAMRAI::hier::Box sourceGhostBox{dimension};
     SAMRAI::hier::IntVector ratio{dimension, 2};
 
-    FieldRefiner<dim> fieldLinearRefine{centering, destinationGhostBox, sourceGhostBox, ratio};
+    DefaultFieldRefiner<dim> fieldLinearRefine{centering, destinationGhostBox, sourceGhostBox,
+                                               ratio};
 }
 
 

--- a/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.hpp
+++ b/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.hpp
@@ -4,6 +4,7 @@
 
 #include "amr/data/field/field_variable.hpp"
 #include "amr/data/field/refine/field_refine_operator.hpp"
+#include "amr/data/field/refine/field_refiner.hpp"
 #include "core/data/grid/gridlayout.hpp"
 #include "test_tag_strategy.hpp"
 
@@ -104,7 +105,8 @@ public:
               dimension_, "ChopAndPackLoadBalancer",
               inputDatabase_->getDatabase("ChopAndPackLoadBalancer"))}
 
-        , refineOperator_{std::make_shared<FieldRefineOperator<GridLayoutT, FieldT>>()}
+        , refineOperator_{std::make_shared<
+              FieldRefineOperator<GridLayoutT, FieldT, DefaultFieldRefiner<dimension>>>()}
 
 
         , tagStrategy_{std::make_shared<TagStrategy<GridLayoutT, FieldT>>(variablesIds_,

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -536,9 +536,19 @@ class AdvanceTestBase(SimulatorTest):
                                 # 1e-16 seems to fail for some reason. Discrepency appears to be
                                 # on refined adjacent patches. Was way worse (1e-4 or so) when not
                                 # filling pure ghosts for Ni and Vi. 1e-15 seems good enough
-                                np.testing.assert_allclose(
-                                    coarse_pdDataset, afterCoarse, atol=1e-15, rtol=0
-                                )
+                                try:
+                                    np.testing.assert_allclose(
+                                        coarse_pdDataset,
+                                        afterCoarse,
+                                        atol=1e-15,
+                                        rtol=0,
+                                    )
+                                except AssertionError as e:
+                                    print("failing for {}".format(qty))
+                                    print(np.abs(coarse_pdDataset - afterCoarse).max())
+                                    print(coarse_pdDataset)
+                                    print(afterCoarse)
+                                    raise e
 
     def base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(
         self, L0_datahier, L0L1_datahier, quantities=None


### PR DESCRIPTION
## Add a new way to Coarsen a field, specialized for the magnetic field: 

- adds magnetic field coarsener
   - caveat : this is not 3D  
- previous coarsener becomes the `DefaultFieldCoarsener` and is used for the density and bulk velocity
- `FieldCoarserOperator`now takes a `FieldCoarsenerPolicy` as a template parameter


## Adding specific ways to refine the magnetic and electric fields: 

- `FieldRefineOperator` now takes a `FieldRefinerPolicy` as a template parameter, which is used in `refine()` to fill the fine filed given the coarse field and a coarse index.
- add objects `ElectricFieldRefiner` and `MagneticFieldRefiner`
- previous `FieldRefiner` now becomes `DefaultFieldRefiner` and is used by density and bulk velocity

## Conserving magnetic flux at level interfaces

- magnetic field components are defined on cell faces and its value on a face only depends on the electric components on the edges of that face. Hence knowing the electric field everywhere on the ghost box we can calculate B everywhere on the ghost box. 
    - Hence, B is now calculated over the whole **ghost** box using faraday.
    - This adds `evalOnGhostBox` in `GridLayout` which is called in `Faraday` instead of `evalOnBox`
    - Magnetic field ghosts are not filled anymore. the messenger method fillMagneticGhost is removed.
    - magnetic patch ghosts **only** are filled in `postSynchronize`. This is needed because reset of field data by coarsened values may break overlap consistency with neighbor patches. 
        - This uses the new `RefinerType::PatchGhostField` in `refiner_pool.hpp`
        - This adds a new type of schedule created for intra level only, associated with constexpr `RefinerType::PatchGhostField`
        - The hybridModel is the only one registering a magnetic field in `ghostMagnetic` (as opposed to also the SolverPPC which was also registering Bpred)
     - the electric field on level ghost nodes, obtained from refinement, cannot be anymore obtained with space/time inteprolation as before. This is because we need the magnetic field obtained at the end of the 4 fine substeps on fine level border faces, to be **exactly** the one obtained on the shared coarse faces during the underlying coarse step. This means that the electric field Faraday evaluates on level ghost nodes, must be the same as the one that was last used on next coarser overlaped nodes to obtain the coarse magnetic field. This means  : 
         - solverPPC now sets `Eavg` in the modelInfo `ghostElectric`  instead of `Epred`, since Eavg is the one the next coarser level uses last to update its magnetic field
         - the hybridhybrid messenger strat now adds various convenience method such as `fillStaticRefiner_` and the refiner pool `addStaticRefiner` and all necessary overloads for scalar and vector quantities.  

## bug fix
- density ghost nodes was previously filled with only spatial interpolation. This was a mistake since as a result the density on level ghost nodes was obtained from refining the next coarser values, defined in the future. This is now fixed by using the new refiner pool method `addTimeRefiner` in the `registerGhostComms_()` method. 
- the refiner pool `addTimeRefiner` overload for vector fields is now also used to register ghost communications for the bulk velocity (through calling `fillTimeRefiners_` 

## Regriding trick

During regriding, a level may shrink or grow. In the first case, some parts of the new level border end up on faces that were formerly fine domain faces. These fine faces had their magnetic field self consistently obtained from Faraday. Each face has its own value, i.e. fine level border faces enclosed in the same coarse face do not have equal values. This is inconsistent with flux conservation since next fine step we assume fine faces evolve based on the same electric induction to arrive at the same flux as the coarse level. Border fine faces thus need to be reset by refinement, which will get them equal both to the underlying coarse face's value. The drawback is that when changing the fine face value obtained self-consistently on the border, we screw-up divB in these fine border cells. Since the refined value is obtained from next coarser, which previously through coarsening recieved the averaged of both fine faces, the re-assignement does not change the total flux through the border faces, but only screw up divB of enclosed fine cells.


In the latter case, i.e. when the level grows, new level faces (on border or not) must take their value from refinement from next coarser. But fixing these faces' values will screw up divB in the fine level at the former level boundary since at this former boundary, one side has self consistent fine flux, and the other is set by refinement from coarser. 












## Misc. : 

- prepareStep() is now called in the hybrid level initializer because.... **SAY WHY**
- quantity_communicator.hpp becomes communicator.hpp
- communicator.hpp is split in two files :  refiner_pool.hpp and synchronizer_pool.hpp 
- a new overload of Communicator::makeRefiner() is created to communicated a scalar quantity with space and time refinement.

