### PR TITLE
magnetic flux across levels

### DIFF
--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -10,49 +10,86 @@ directions = ["x", "y", "z"]
 direction_to_dim = {direction: idx for idx, direction in enumerate(directions)}
 
 yee_centering = {
-    'x': {
-        'Bx':'primal', 'By':'dual', 'Bz':'dual',
-        'Ex':'dual', 'Ey':'primal', 'Ez':'primal',
-        'Jx':'dual', 'Jy':'primal', 'Jz':'primal',
-        'Vx':'primal','Vy':'primal','Vz':'primal',
-        'Fx':'primal', 'Fy':'primal', 'Fz':'primal',
-        'rho':'primal', 'P':'primal',
-        'Vthx':'primal', 'Vthy':'primal', 'Vthz':'primal',
-        'tags':'dual',
+    "x": {
+        "Bx": "primal",
+        "By": "dual",
+        "Bz": "dual",
+        "Ex": "dual",
+        "Ey": "primal",
+        "Ez": "primal",
+        "Jx": "dual",
+        "Jy": "primal",
+        "Jz": "primal",
+        "Vx": "primal",
+        "Vy": "primal",
+        "Vz": "primal",
+        "Fx": "primal",
+        "Fy": "primal",
+        "Fz": "primal",
+        "rho": "primal",
+        "P": "primal",
+        "Vthx": "primal",
+        "Vthy": "primal",
+        "Vthz": "primal",
+        "tags": "dual",
     },
-    'y' : {
-        'Bx':'dual', 'By':'primal', 'Bz':'dual',
-        'Ex':'primal', 'Ey':'dual', 'Ez':'primal',
-        'Jx':'primal', 'Jy':'dual', 'Jz':'primal',
-        'Vx':'primal','Vy':'primal', 'Vz':'primal',
-        'Fx':'primal', 'Fy':'primal', 'Fz':'primal',
-        'rho':'primal', 'P':'primal',
-        'Vthx':'primal', 'Vthy':'primal', 'Vthz':'primal',
-        'tags':'dual',
+    "y": {
+        "Bx": "dual",
+        "By": "primal",
+        "Bz": "dual",
+        "Ex": "primal",
+        "Ey": "dual",
+        "Ez": "primal",
+        "Jx": "primal",
+        "Jy": "dual",
+        "Jz": "primal",
+        "Vx": "primal",
+        "Vy": "primal",
+        "Vz": "primal",
+        "Fx": "primal",
+        "Fy": "primal",
+        "Fz": "primal",
+        "rho": "primal",
+        "P": "primal",
+        "Vthx": "primal",
+        "Vthy": "primal",
+        "Vthz": "primal",
+        "tags": "dual",
     },
-    'z' : {
-        'Bx':'dual', 'By':'dual', 'Bz':'primal',
-        'Ex':'primal', 'Ey':'primal', 'Ez':'dual',
-        'Jx':'primal', 'Jy':'primal', 'Jz':'dual',
-        'Vx':'primal','Vy':'primal', 'Vz':'primal',
-        'Fx':'primal', 'Fy':'primal', 'Fz':'primal',
-        'rho':'primal', 'P':'primal',
-        'Vthx':'primal', 'Vthy':'primal', 'Vthz':'primal',
-        'tags':'dual',
-    }
+    "z": {
+        "Bx": "dual",
+        "By": "dual",
+        "Bz": "primal",
+        "Ex": "primal",
+        "Ey": "primal",
+        "Ez": "dual",
+        "Jx": "primal",
+        "Jy": "primal",
+        "Jz": "dual",
+        "Vx": "primal",
+        "Vy": "primal",
+        "Vz": "primal",
+        "Fx": "primal",
+        "Fy": "primal",
+        "Fz": "primal",
+        "rho": "primal",
+        "P": "primal",
+        "Vthx": "primal",
+        "Vthy": "primal",
+        "Vthz": "primal",
+        "tags": "dual",
+    },
 }
 yee_centering_lower = {
-  direction : {
-    key.lower() : centering
-    for key, centering in key_dict.items()
-  }
-  for direction, key_dict in yee_centering.items()
+    direction: {key.lower(): centering for key, centering in key_dict.items()}
+    for direction, key_dict in yee_centering.items()
 }
 
-def yee_element_is_primal(key, direction = 'x'):
+
+def yee_element_is_primal(key, direction="x"):
     if key in yee_centering_lower[direction]:
-        return yee_centering_lower[direction][key] == 'primal'
-    return yee_centering[direction][key] == 'primal'
+        return yee_centering_lower[direction][key] == "primal"
+    return yee_centering[direction][key] == "primal"
 
 
 class YeeCentering(object):
@@ -62,7 +99,9 @@ class YeeCentering(object):
         self.centerZ = yee_centering["z"]
 
 
-def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =False, **kwargs):
+def yeeCoordsFor(
+    origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts=False, **kwargs
+):
 
     assert direction in direction_to_dim, f"direction ({direction} not supported)"
     if qty in yee_centering_lower[direction] and qty not in yee_centering[direction]:
@@ -71,7 +110,7 @@ def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =Fa
     if "centering" in kwargs:
         centering = kwargs["centering"]
     else:
-        centering= yee_centering[direction][qty]
+        centering = yee_centering[direction][qty]
 
     offset = 0
     dim = direction_to_dim[direction]
@@ -80,8 +119,8 @@ def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =Fa
     else:
         size = nbrCells[dim]
 
-    if centering == 'dual':
-        offset = 0.5*dl[dim]
+    if centering == "dual":
+        offset = 0.5 * dl[dim]
     else:
         size += 1
 
@@ -93,12 +132,14 @@ def yeeCoordsFor(origin, nbrGhosts, dl, nbrCells, qty, direction, withGhosts =Fa
 
 class GridLayout(object):
     """
-      field_ghosts_nbr is a parameter to support pyphare geometry tests having hard coded 5 ghosts
-      initialized default to -1 as an invalid value allowing the override mechanism. Using None
-      results in a pylint error elsewhere
+    field_ghosts_nbr is a parameter to support pyphare geometry tests having hard coded 5 ghosts
+    initialized default to -1 as an invalid value allowing the override mechanism. Using None
+    results in a pylint error elsewhere
     """
 
-    def __init__(self, box=Box(0,0), origin=0, dl=0.1, interp_order=1, field_ghosts_nbr=-1):
+    def __init__(
+        self, box=Box(0, 0), origin=0, dl=0.1, interp_order=1, field_ghosts_nbr=-1
+    ):
         self.box = box
 
         self.dl = listify(dl)
@@ -109,139 +150,148 @@ class GridLayout(object):
 
         self.interp_order = interp_order
         self.impl = "yee"
-        self.directions = ['X','Y','Z']
+        self.directions = ["X", "Y", "Z"]
 
-        self.hybridQuantities = ['Bx','By','Bz',
-                                 'Ex','Ey','Ez',
-                                 'Jx','Jy','Jz',
-                                 'rho','Vx','Vy',
-                                 'Vz','P', 'Fx', 'Fy', 'Fz']
-
+        self.hybridQuantities = [
+            "Bx",
+            "By",
+            "Bz",
+            "Ex",
+            "Ey",
+            "Ez",
+            "Jx",
+            "Jy",
+            "Jz",
+            "rho",
+            "Vx",
+            "Vy",
+            "Vz",
+            "P",
+            "Fx",
+            "Fy",
+            "Fz",
+        ]
 
         self.yeeCentering = YeeCentering()
 
-        self.centering = {'X' : self.yeeCentering.centerX,
-                          'Y' : self.yeeCentering.centerY,
-                          'Z' : self.yeeCentering.centerZ
-                         }
+        self.centering = {
+            "X": self.yeeCentering.centerX,
+            "Y": self.yeeCentering.centerY,
+            "Z": self.yeeCentering.centerZ,
+        }
 
-        self.field_ghosts_nbr = field_ghosts_nbr # allows override
-
+        self.field_ghosts_nbr = field_ghosts_nbr  # allows override
 
     @property
     def ndim(self):
         return self.box.ndim
 
-
     def qtyCentering(self, quantity, direction):
         return self.centering[direction][quantity]
 
-
     def particleGhostNbr(self, interp_order):
         return 1 if interp_order == 1 else 2
-
 
     def nbrGhosts(self, interpOrder, centering):
         if self.field_ghosts_nbr == -1:
             return int((interpOrder + 1) / 2) + self.particleGhostNbr(interpOrder)
         return self.field_ghosts_nbr
 
-
     def nbrGhostsPrimal(self, interpOrder):
-        return self.nbrGhosts(interpOrder, 'primal')
-
+        return self.nbrGhosts(interpOrder, "primal")
 
     def qtyIsDual(self, qty, direction):
         return self.isDual(self.qtyCentering(qty, direction))
 
     def isDual(self, centering):
-        if centering == 'dual':
+        if centering == "dual":
             return 1
         else:
             return 0
 
-
-
     def ghostStartIndex(self):
-        return 0;
+        return 0
 
     def ghostEndIndex(self, interpOrder, centering, nbrCells):
-        index = self.physicalEndIndex(interpOrder, centering, nbrCells) \
-              + self.nbrGhosts(interpOrder, centering)
+        index = self.physicalEndIndex(
+            interpOrder, centering, nbrCells
+        ) + self.nbrGhosts(interpOrder, centering)
         return index
-
 
     def physicalStartIndex(self, interpOrder, centering):
         index = self.ghostStartIndex() + self.nbrGhosts(interpOrder, centering)
         return index
 
-
-
     def physicalEndIndex(self, interpOrder, centering, nbrCells):
-        index = self.physicalStartIndex(interpOrder, centering) \
-                + nbrCells - self.isDual(centering)
+        index = (
+            self.physicalStartIndex(interpOrder, centering)
+            + nbrCells
+            - self.isDual(centering)
+        )
         return index
-
-
 
     def physicalStartIndices(self, qty):
         assert qty in self.hybridQuantities
         indices = np.zeros(self.box.ndim)
-        for i, direction in enumerate(directions[:self.box.ndim]):
+        for i, direction in enumerate(directions[: self.box.ndim]):
             centering = yee_centering[direction][qty]
             indices[i] = self.physicalStartIndex(self.interp_order, centering)
         return indices
 
-
     def physicalEndIndices(self, qty):
         assert qty in self.hybridQuantities
         indices = np.zeros(self.box.ndim)
-        for i, direction in enumerate(directions[:self.box.ndim]):
+        for i, direction in enumerate(directions[: self.box.ndim]):
             centering = yee_centering[direction][qty]
-            indices[i] = self.physicalEndIndex(self.interp_order, centering, self.box.shape[i])
+            indices[i] = self.physicalEndIndex(
+                self.interp_order, centering, self.box.shape[i]
+            )
         return indices
-
 
     def nbrGhostFor(self, qty):
         assert qty in self.hybridQuantities
         nGhosts = np.zeros(self.box.ndim, dtype=np.int32)
-        for i, direction in enumerate(directions[:self.box.ndim]):
+        for i, direction in enumerate(directions[: self.box.ndim]):
             centering = yee_centering[direction][qty]
             nGhosts[i] = self.nbrGhosts(self.interp_order, centering)
         return nGhosts
-
 
     # ---- Start / End   primal methods ------
     def physicalStartPrimal(self, interpOrder):
         index = self.ghostStartIndex() + self.nbrGhostsPrimal(interpOrder)
         return index
 
-
-
-    def physicalEndPrimal(self,interpOrder, nbrCells):
+    def physicalEndPrimal(self, interpOrder, nbrCells):
         index = self.physicalStartPrimal(interpOrder) + nbrCells
         return index
 
     # ---- Alloc methods -------------------------
 
     def allocSize(self, interpOrder, centering, nbrCells):
-        size = nbrCells + 1 + 2*self.nbrGhosts(interpOrder, centering) \
-               - self.isDual(centering)
+        size = (
+            nbrCells
+            + 1
+            + 2 * self.nbrGhosts(interpOrder, centering)
+            - self.isDual(centering)
+        )
         return size
-
-
 
     # 1st derivative
     def allocSizeDerived(self, interpOrder, centering, nbrCells):
-        newCentering = self.changeCentering( centering, 1 )
+        newCentering = self.changeCentering(centering, 1)
 
-        size = nbrCells + 1 + 2*self.nbrGhosts(interpOrder, newCentering) \
-             - self.isDual(newCentering)
+        size = (
+            nbrCells
+            + 1
+            + 2 * self.nbrGhosts(interpOrder, newCentering)
+            - self.isDual(newCentering)
+        )
         return size
 
-
     def AMRPointToLocal(self, point):
-        return point - self.box.lower + self.physicalStartIndex(self.interp_order, "dual")
+        return (
+            point - self.box.lower + self.physicalStartIndex(self.interp_order, "dual")
+        )
 
     def AMRBoxToLocal(self, box):
         local = box.copy()
@@ -260,7 +310,6 @@ class GridLayout(object):
         dualStart = self.physicalStartIndex(self.interp_order, "dual")
         return index - self.box.lower[dim] + dualStart
 
-
     # ---- Yee coordinate methods -------------------------
     # knode : a primal or dual node index
     #
@@ -271,17 +320,16 @@ class GridLayout(object):
     # This method returns a point
     #
     def yeeCoords(self, knode, iStart, centering, direction, ds, origin, derivOrder):
-        halfCell = 0.
+        halfCell = 0.0
 
-        newCentering = self.changeCentering( centering, derivOrder )
+        newCentering = self.changeCentering(centering, derivOrder)
 
-        if newCentering == 'dual':
+        if newCentering == "dual":
             halfCell = 0.5
 
-        x = ( (knode - iStart) + halfCell )*ds + origin
+        x = ((knode - iStart) + halfCell) * ds + origin
 
         return x
-
 
     def yeeCoordsFor(self, qty, direction, withGhosts=True, **kwargs):
         """
@@ -292,21 +340,27 @@ class GridLayout(object):
         :param direction: can only be a single one
         """
 
-        if qty in yee_centering_lower[direction] and qty not in yee_centering[direction]:
+        if (
+            qty in yee_centering_lower[direction]
+            and qty not in yee_centering[direction]
+        ):
             qty = qty[0].upper() + qty[1:]
 
         if "centering" in kwargs:
             centering = kwargs["centering"]
         else:
-            centering= yee_centering[direction][qty]
+            centering = yee_centering[direction][qty]
 
-        return yeeCoordsFor(self.origin, self.nbrGhosts(self.interp_order, centering),
-                            self.dl, self.box.shape, qty, direction, withGhosts=withGhosts, centering=centering)
-
-
-
-
-
+        return yeeCoordsFor(
+            self.origin,
+            self.nbrGhosts(self.interp_order, centering),
+            self.dl,
+            self.box.shape,
+            qty,
+            direction,
+            withGhosts=withGhosts,
+            centering=centering,
+        )
 
     # ---- Get coordinate methods -------------------------
     # knode : a primal or dual node index
@@ -318,42 +372,40 @@ class GridLayout(object):
     # This method returns a point
     #
     def fieldCoords(self, knode, iStart, qty, direction, ds, origin, derivOrder):
-        halfCell = 0.
+        halfCell = 0.0
 
-        newCentering = self.changeCentering( self.qtyCentering(qty, direction), derivOrder )
+        newCentering = self.changeCentering(
+            self.qtyCentering(qty, direction), derivOrder
+        )
 
-        if newCentering == 'dual':
+        if newCentering == "dual":
             halfCell = 0.5
 
-        x = ( (knode - iStart) + halfCell )*ds + origin
+        x = ((knode - iStart) + halfCell) * ds + origin
 
         return x
-
-
 
     # ---- Change centering method -------------------------
     #
     # Use case:
     #   changeCentering( qtyCentering(qty, direct), 1 )
     #
-    def changeCentering(self, centering, derivOrder = 0):
+    def changeCentering(self, centering, derivOrder=0):
 
         newCentering = centering
 
         # if derivOrder is odd the centering is changed
         if derivOrder % 2 != 0:
-            newCentering = self.swapCentering( centering )
+            newCentering = self.swapCentering(centering)
 
         return newCentering
 
-
-
     # -------------------------------------------------------
-    def swapCentering(self, centering ):
+    def swapCentering(self, centering):
 
-        newCentering = 'primal'
+        newCentering = "primal"
 
-        if centering == 'primal':
-            newCentering = 'dual'
+        if centering == "primal":
+            newCentering = "dual"
 
         return newCentering

--- a/src/amr/CMakeLists.txt
+++ b/src/amr/CMakeLists.txt
@@ -10,7 +10,8 @@ set( SOURCES_INC
      data/field/coarsening/field_coarsen_operator.hpp
      data/field/coarsening/field_coarsen_index_weight.hpp
      data/field/coarsening/coarsen_weighter.hpp
-     data/field/coarsening/field_coarsener.hpp
+     data/field/coarsening/default_field_coarsener.hpp
+     data/field/coarsening/magnetic_field_coarsener.hpp
      data/field/field_data.hpp
      data/field/field_data_factory.hpp
      data/field/field_geometry.hpp
@@ -18,6 +19,8 @@ set( SOURCES_INC
      data/field/field_variable.hpp
      data/field/refine/field_linear_refine.hpp
      data/field/refine/field_refiner.hpp
+     data/field/refine/magnetic_field_refiner.hpp
+     data/field/refine/electric_field_refiner.hpp
      data/field/refine/linear_weighter.hpp
      data/field/refine/field_refine_operator.hpp
      data/field/time_interpolate/field_linear_time_interpolate.hpp
@@ -27,8 +30,9 @@ set( SOURCES_INC
      resources_manager/resources_manager.hpp
      resources_manager/resources_manager_utilities.hpp
      resources_manager/resources_guards.hpp
-     messengers/quantity_communicator.hpp
-     messengers/communicators.hpp
+     messengers/communicator.hpp
+     messengers/refiner_pool.hpp
+     messengers/synchronizer_pool.hpp
      messengers/messenger.hpp
      messengers/hybrid_messenger.hpp
      messengers/hybrid_messenger_strategy.hpp

--- a/src/amr/data/field/coarsening/default_field_coarsener.hpp
+++ b/src/amr/data/field/coarsening/default_field_coarsener.hpp
@@ -1,5 +1,5 @@
-#ifndef PHARE_FIELD_COARSENER_HPP
-#define PHARE_FIELD_COARSENER_HPP
+#ifndef PHARE_DEFAULT_FIELD_COARSENER_HPP
+#define PHARE_DEFAULT_FIELD_COARSENER_HPP
 
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/utilities/constants.hpp"
@@ -25,16 +25,19 @@ namespace amr
     /** @brief This class gives an operator() that performs the coarsening of N fine nodes onto a
      * given coarse node
      *
-     * A FieldCoarsener object is created each time the refine() method of the FieldCoarsenOperator
-     * is called and its operator() is called for each coarse index.
+     * A DefaultFieldCoarsener object is created each time the refine() method of the
+     * FieldCoarsenOperator is called and its operator() is called for each coarse index.
+     * It is the default coarsening policy and used for any field that does not come with
+     * specific constraints (such as conserving some property in the coarsening process).
      */
     template<std::size_t dimension>
-    class FieldCoarsener
+    class DefaultFieldCoarsener
     {
     public:
-        FieldCoarsener(std::array<core::QtyCentering, dimension> const& centering,
-                       SAMRAI::hier::Box const& sourceBox, SAMRAI::hier::Box const& destinationBox,
-                       SAMRAI::hier::IntVector const& ratio)
+        DefaultFieldCoarsener(std::array<core::QtyCentering, dimension> const& centering,
+                              SAMRAI::hier::Box const& sourceBox,
+                              SAMRAI::hier::Box const& destinationBox,
+                              SAMRAI::hier::IntVector const& ratio)
             : indexesAndWeights_{centering, ratio}
             , sourceBox_{sourceBox}
             , destinationBox_{destinationBox}

--- a/src/amr/data/field/coarsening/field_coarsen_index_weight.hpp
+++ b/src/amr/data/field/coarsening/field_coarsen_index_weight.hpp
@@ -5,9 +5,9 @@
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/hybrid/hybrid_quantities.hpp"
 #include "core/data/field/field.hpp"
-#include "amr/resources_manager/amr_utils.hpp"
 #include "core/utilities/constants.hpp"
 
+#include "amr/resources_manager/amr_utils.hpp"
 
 
 #include <SAMRAI/hier/Box.h>

--- a/src/amr/data/field/coarsening/field_coarsen_operator.hpp
+++ b/src/amr/data/field/coarsening/field_coarsen_operator.hpp
@@ -4,7 +4,7 @@
 #include "amr/data/field/field_data.hpp"
 #include "amr/data/field/field_geometry.hpp"
 #include "field_coarsen_index_weight.hpp"
-#include "field_coarsener.hpp"
+#include "default_field_coarsener.hpp"
 #include "core/utilities/constants.hpp"
 #include "core/utilities/point/point.hpp"
 
@@ -21,7 +21,7 @@ namespace amr
     using core::dirY;
     using core::dirZ;
     //
-    template<typename GridLayoutT, typename FieldT,
+    template<typename GridLayoutT, typename FieldT, typename FieldCoarsenerPolicy,
              typename PhysicalQuantity = decltype(std::declval<FieldT>().physicalQuantity())>
     /**
      * @brief The FieldCoarsenOperator class
@@ -40,10 +40,10 @@ namespace amr
         {
         }
 
-        FieldCoarsenOperator(FieldCoarsenOperator const&) = delete;
-        FieldCoarsenOperator(FieldCoarsenOperator&&)      = delete;
+        FieldCoarsenOperator(FieldCoarsenOperator const&)            = delete;
+        FieldCoarsenOperator(FieldCoarsenOperator&&)                 = delete;
         FieldCoarsenOperator& operator=(FieldCoarsenOperator const&) = delete;
-        FieldCoarsenOperator&& operator=(FieldCoarsenOperator&&) = delete;
+        FieldCoarsenOperator&& operator=(FieldCoarsenOperator&&)     = delete;
 
 
         virtual ~FieldCoarsenOperator() = default;
@@ -127,8 +127,8 @@ namespace amr
 
 
             // We can now create the coarsening operator
-            FieldCoarsener<dimension> coarsener{destinationLayout.centering(qty), sourceBox,
-                                                destinationBox, ratio};
+            FieldCoarsenerPolicy coarsener{destinationLayout.centering(qty), sourceBox,
+                                           destinationBox, ratio};
 
             // now we can loop over the intersection box
 

--- a/src/amr/data/field/coarsening/magnetic_field_coarsener.hpp
+++ b/src/amr/data/field/coarsening/magnetic_field_coarsener.hpp
@@ -1,0 +1,137 @@
+#ifndef PHARE_MAGNETIC_FIELD_COARSENER
+#define PHARE_MAGNETIC_FIELD_COARSENER
+
+#include "core/data/grid/gridlayoutdefs.hpp"
+#include "core/hybrid/hybrid_quantities.hpp"
+#include "core/utilities/constants.hpp"
+
+
+#include <SAMRAI/hier/Box.h>
+#include <stdexcept>
+
+namespace PHARE::amr
+{
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+/** @brief This class gives an operator() that performs the coarsening of N fine nodes onto a
+ * given coarse node
+ *
+ * A MagneticFieldCoarsener object is created each time the refine() method of the
+ * FieldCoarsenOperator is called and its operator() is called for each coarse index.
+ * It is the default coarsening policy and used for any field that does not come with
+ * specific constraints (such as conserving some property in the coarsening process).
+ *
+ *
+ * This coarsening operation is defined so to conserve the magnetic flux.
+ * This is done by assigning to a magnetic field component on a coarse face, the average
+ * of the enclosed fine faces
+ *
+ */
+template<std::size_t dimension>
+class MagneticFieldCoarsener
+{
+public:
+    MagneticFieldCoarsener(std::array<core::QtyCentering, dimension> const centering,
+                           SAMRAI::hier::Box const& sourceBox,
+                           SAMRAI::hier::Box const& destinationBox,
+                           SAMRAI::hier::IntVector const& ratio)
+        : centering_{centering}
+        , sourceBox_{sourceBox}
+        , destinationBox_{destinationBox}
+
+    {
+    }
+
+    template<typename FieldT>
+    void operator()(FieldT const& fineField, FieldT& coarseField,
+                    core::Point<int, dimension> coarseIndex)
+    {
+        // For the moment we only take the case of field with the same centering
+        TBOX_ASSERT(fineField.physicalQuantity() == coarseField.physicalQuantity());
+
+        core::Point<int, dimension> fineStartIndex;
+
+        fineStartIndex[dirX] = coarseIndex[dirX] * this->ratio_;
+
+        if constexpr (dimension > 1)
+        {
+            fineStartIndex[dirY] = coarseIndex[dirY] * this->ratio_;
+            if constexpr (dimension > 2)
+            {
+                fineStartIndex[dirZ] = coarseIndex[dirZ] * this->ratio_;
+            }
+        }
+
+        fineStartIndex = AMRToLocal(fineStartIndex, sourceBox_);
+        coarseIndex    = AMRToLocal(coarseIndex, destinationBox_);
+
+        // the following kinda assumes where B is, i.e. Yee layout centering
+        // as it only does faces pirmal-dual, dual-primal and dual-dual
+
+        if constexpr (dimension == 1)
+        {
+            // in 1D div(B) is automatically satisfied so using this coarsening
+            // opertor is probably not better than the default one, but we do that
+            // for a kind of consistency...
+            // coarse flux is equal to fine flux and we're 1D so there is flux partitioned
+            // only for By and Bz, Bx is equal to the fine value
+
+            if (centering_[dirX] == core::QtyCentering::primal) // bx
+            {
+                coarseField(coarseIndex[dirX]) = fineField(fineStartIndex[dirX]);
+            }
+            else if (centering_[dirX] == core::QtyCentering::dual) // by and bz
+            {
+                coarseField(coarseIndex[dirX])
+                    = 0.5 * (fineField(fineStartIndex[dirX] + 1) + fineField(fineStartIndex[dirX]));
+            }
+        }
+
+        if constexpr (dimension == 2)
+        {
+            if (centering_[dirX] == core::QtyCentering::primal
+                and centering_[dirY] == core::QtyCentering::dual)
+            {
+                coarseField(coarseIndex[dirX], coarseIndex[dirY])
+                    = 0.5
+                      * (fineField(fineStartIndex[dirX], fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX], fineStartIndex[dirY] + 1));
+            }
+            else if (centering_[dirX] == core::QtyCentering::dual
+                     and centering_[dirY] == core::QtyCentering::primal)
+            {
+                coarseField(coarseIndex[dirX], coarseIndex[dirY])
+                    = 0.5
+                      * (fineField(fineStartIndex[dirX], fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX] + 1, fineStartIndex[dirY]));
+            }
+            else if (centering_[dirX] == core::QtyCentering::dual
+                     and centering_[dirY] == core::QtyCentering::dual)
+            {
+                coarseField(coarseIndex[dirX], coarseIndex[dirY])
+                    = 0.25
+                      * (fineField(fineStartIndex[dirX], fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX] + 1, fineStartIndex[dirY])
+                         + fineField(fineStartIndex[dirX], fineStartIndex[dirY] + 1)
+                         + fineField(fineStartIndex[dirX] + 1, fineStartIndex[dirY] + 1));
+            }
+            else
+            {
+                throw std::runtime_error("no magnetic field should end up here");
+            }
+        }
+        else if constexpr (dimension == 3)
+        {
+            throw std::runtime_error("Not Implemented yet");
+        }
+    }
+
+private:
+    std::array<core::QtyCentering, dimension> const centering_;
+    SAMRAI::hier::Box const sourceBox_;
+    SAMRAI::hier::Box const destinationBox_;
+    static int constexpr ratio_ = 2;
+};
+} // namespace PHARE::amr
+#endif

--- a/src/amr/data/field/field_variable_fill_pattern.hpp
+++ b/src/amr/data/field/field_variable_fill_pattern.hpp
@@ -113,7 +113,7 @@ public:
     std::string const& getPatternName() const { return s_name_id; }
 
 private:
-    FieldFillPattern(FieldFillPattern const&) = delete;
+    FieldFillPattern(FieldFillPattern const&)            = delete;
     FieldFillPattern& operator=(FieldFillPattern const&) = delete;
 
     static const inline std::string s_name_id = "BOX_GEOMETRY_FILL_PATTERN";
@@ -156,7 +156,6 @@ private:
 
         SAMRAI::hier::BoxContainer overlap_boxes(fill_boxes);
         overlap_boxes.intersectBoxes(data_box);
-
         return pdf.getBoxGeometry(patch_box)->setUpOverlap(overlap_boxes, transformation);
     }
 

--- a/src/amr/data/field/refine/electric_field_refiner.hpp
+++ b/src/amr/data/field/refine/electric_field_refiner.hpp
@@ -1,0 +1,321 @@
+#ifndef PHARE_ELECTRIC_FIELD_REFINER_HPP
+#define PHARE_ELECTRIC_FIELD_REFINER_HPP
+
+#include <SAMRAI/hier/Box.h>
+
+#include "amr/resources_manager/amr_utils.hpp"
+#include "core/utilities/constants.hpp"
+#include "core/data/grid/gridlayoutdefs.hpp"
+#include "core/utilities/point/point.hpp"
+
+#include <cstddef>
+
+namespace PHARE::amr
+{
+
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+
+template<std::size_t dimension>
+class ElectricFieldRefiner
+{
+public:
+    ElectricFieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
+                         SAMRAI::hier::Box const& destinationGhostBox,
+                         SAMRAI::hier::Box const& sourceGhostBox,
+                         SAMRAI::hier::IntVector const& ratio)
+        : fineBox_{destinationGhostBox}
+        , coarseBox_{sourceGhostBox}
+        , centerings_{centering}
+    {
+    }
+
+
+    // electric field refinement strategy follows
+    // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    template<typename FieldT>
+    void operator()(FieldT const& coarseField, FieldT& fineField,
+                    core::Point<int, dimension> fineIndex)
+    {
+        TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
+
+        auto const locFineIdx          = AMRToLocal(fineIndex, fineBox_);
+        auto constexpr refinementRatio = 2;
+        auto coarseIdx{fineIndex};
+        for (auto& idx : coarseIdx)
+            idx = idx / refinementRatio;
+        auto const locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
+
+        if constexpr (dimension == 1)
+            refine1D_(coarseField, fineField, locFineIdx, locCoarseIdx);
+        else if constexpr (dimension == 2)
+            refine2D_(coarseField, fineField, fineIndex, locFineIdx, locCoarseIdx);
+        else if constexpr (dimension == 3)
+            refine3D_(coarseField, fineField, fineIndex, locFineIdx, locCoarseIdx);
+    }
+
+private:
+    // knowing we have a refinement ratio of 2, every fine face that has an even index
+    // is on top of a coarse face, and every fine face that has an odd index is in between
+    // two coarse faces.
+    bool onCoarseXFace_(core::Point<int, dimension> const& fineIndex)
+    {
+        return fineIndex[dirX] % 2 == 0;
+    }
+    bool onCoarseYFace_(core::Point<int, dimension> const& fineIndex)
+    {
+        return fineIndex[dirY] % 2 == 0;
+    }
+    bool onCoarseZFace_(core::Point<int, dimension> const& fineIndex)
+    {
+        return fineIndex[dirZ] % 2 == 0;
+    }
+
+
+    template<typename FieldT>
+    void refine1D_(FieldT const& coarseField, FieldT& fineField,
+                   core::Point<int, dimension> const& locFineIdx,
+                   core::Point<int, dimension> const& locCoarseIdx)
+    {
+        // if dual, then Ex
+        // if even fine index, we're on top of coarse, we take 100% coarse overlapped fieldValue
+        // e.g. fineIndex==100, we take coarse[100/2]
+        // e.g. fineIndex==101  we take coarse[101/2] = coarse[50] as well
+        //
+        //          49           50             51
+        //    o     x     o      x       o      x      o        Ex on coarse
+        //    o  x  o  x  o   x  o   x   o   x  o   x  o        Ex on fine
+        //       98    99   100     101     102    103
+        //
+        //
+        // if primal, then Ey,Ez we just copy the coarse value
+        // since they are on top of the fine one.
+        //
+        // therefore in all cases in 1D we just copy the coarse value
+        //
+        fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
+    }
+
+    template<typename FieldT>
+    void refine2D_(FieldT const& coarseField, FieldT& fineField,
+                   core::Point<int, dimension> const& fineIndex,
+                   core::Point<int, dimension> const& locFineIdx,
+                   core::Point<int, dimension> const& locCoarseIdx)
+    {
+        // ilc: index local coarse
+        // ilf: index local fine
+        auto const ilcx = locCoarseIdx[dirX];
+        auto const ilcy = locCoarseIdx[dirY];
+        auto const ilfx = locFineIdx[dirX];
+        auto const ilfy = locFineIdx[dirY];
+
+
+        // this is Ex
+        if (centerings_[dirX] == core::QtyCentering::dual
+            and centerings_[dirY] == core::QtyCentering::primal)
+        {
+            if (onCoarseYFace_(fineIndex))
+            {
+                // we're on a fine edge shared with coarse mesh
+                // take the coarse face value
+                fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+            }
+            else
+            {
+                // we're on a fine edge in between two coarse edges
+                // we take the average
+                fineField(ilfx, ilfy)
+                    = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx, ilcy + 1));
+            }
+        }
+        // Ey
+        else if (centerings_[dirX] == core::QtyCentering::primal
+                 and centerings_[dirY] == core::QtyCentering::dual)
+        {
+            if (onCoarseXFace_(fineIndex))
+            {
+                // we're on a coarse edge at j=1/4 and 3/4
+                // we thus copy the coarse at j=1/2
+                // both fine Ey e.g. at j=100 and 101 will take j=50 on coarse
+                // so no need to look at whether jfine is even or odd
+                // just take the value at the local coarse index
+                fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+            }
+            else
+            {
+                // we're on a fine edge in between two coarse ones
+                // we take the average
+                fineField(ilfx, ilfy)
+                    = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy));
+            }
+        }
+        // and this is now Ez
+        else if (centerings_[dirX] == core::QtyCentering::primal
+                 and centerings_[dirY] == core::QtyCentering::primal)
+        {
+            if (onCoarseXFace_(fineIndex) and onCoarseYFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+            }
+            else if (onCoarseXFace_(fineIndex))
+                fineField(ilfx, ilfy)
+                    = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx, ilcy + 1));
+            else if (onCoarseYFace_(fineIndex))
+                fineField(ilfx, ilfy)
+                    = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy));
+            else
+                fineField(ilfx, ilfy)
+                    = 0.25
+                      * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy)
+                         + coarseField(ilcx, ilcy + 1) + coarseField(ilcx + 1, ilcy + 1));
+        }
+    }
+
+
+    template<typename FieldT>
+    void refine3D_(FieldT const& coarseField, FieldT& fineField,
+                   core::Point<int, dimension> const& fineIndex,
+                   core::Point<int, dimension> const& locFineIdx,
+                   core::Point<int, dimension> const& locCoarseIdx)
+    {
+        // ilc: index local coarse
+        // ilf: index local fine
+        auto const ilcx = locCoarseIdx[dirX];
+        auto const ilcy = locCoarseIdx[dirY];
+        auto const ilcz = locCoarseIdx[dirZ];
+        auto const ilfx = locFineIdx[dirX];
+        auto const ilfy = locFineIdx[dirY];
+        auto const ilfz = locFineIdx[dirZ];
+
+        // Ex
+        if (centerings_[dirX] == core::QtyCentering::dual
+            and centerings_[dirY] == core::QtyCentering::primal
+            and centerings_[dirZ] == core::QtyCentering::primal)
+        {
+            // here we share an X edge with coarse
+            // just copy the coarse value
+            if (onCoarseYFace_(fineIndex) and onCoarseZFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+            }
+            // we share the Y face but not the Z face
+            // we must be one of the 2 X fine edges on a Y face
+            // thus we take the average of the two surrounding edges at Z and Z+DZ
+            else if (onCoarseYFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy, ilcz + 1));
+            }
+            // we share a Z face but not the Y face
+            // we must be one of the 2 X fine edges on a Z face
+            // we thus take the average of the two X edges at y and y+dy
+            else if (onCoarseZFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz));
+            }
+            else
+            {
+                // we don't share any face thus we're on one of the 2 middle X edges
+                // we take the average of the 4 surrounding X averages
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.25 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz))
+                      + 0.25
+                            * (coarseField(ilcx, ilcy, ilcz + 1)
+                               + coarseField(ilcx, ilcy + 1, ilcz + 1));
+            }
+        }
+        // now this is Ey
+        else if (centerings_[dirX] == core::QtyCentering::primal
+                 and centerings_[dirY] == core::QtyCentering::dual
+                 and centerings_[dirZ] == core::QtyCentering::primal)
+        {
+            // we're on coarse X and coarse Z face, i.e. share a Y coarse edge
+            if (onCoarseXFace_(fineIndex) and onCoarseZFace_(fineIndex))
+            {
+                // we thus just copy the coarse value
+                fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+            }
+            // now we only have same X face, but not (else) the Z face
+            // so we're a new fine Y edge in between two coarse Y edges
+            // on a X coarse face. Thus we average the two surrounding Y edges on that X
+            // face.
+            else if (onCoarseXFace_(fineIndex))
+            {
+                // we're on a fine X face, but not on a Z face
+                // this means we are on a Y edge that lies in between 2 coarse edges
+                // at z and z+dz
+                // take the average of these 2 coarse value
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy, ilcz + 1));
+            }
+            // we're on a Z coarse face, but not on a X coarse face
+            // we thus must be one of the 2 Y edges on a Z face
+            // and thus we take the average of the 2 Y edges at X and X+dX
+            else if (onCoarseZFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz));
+            }
+            // now we're not on any of the coarse faces
+            // so we must be one of the two Y edge in the middle of the cell
+            // we thus average over the 4 Y edges of the coarse cell
+            else
+            {
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.25
+                      * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz)
+                         + coarseField(ilcx, ilcy, ilcz + 1)
+                         + coarseField(ilcx + 1, ilcy, ilcz + 1));
+            }
+        }
+        // now let's do Ez
+        else if (centerings_[dirX] == core::QtyCentering::primal
+                 and centerings_[dirY] == core::QtyCentering::primal
+                 and centerings_[dirZ] == core::QtyCentering::dual)
+        {
+            // we're on a X and a Y coarse face, we thus share the Z coarse edge
+            // we thus copy the coarse value
+            if (onCoarseXFace_(fineIndex) and onCoarseYFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+            }
+            // here we're on a coarse X face, but not a Y face
+            // we must be 1 of the 2 Z edges on a X face
+            // thus we average the 2 surrounding Z coarse edges at Y and Y+dY
+            else if (onCoarseXFace_(fineIndex))
+            {
+                fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                    = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz));
+            }
+            // here we're on a coarse Y face, but not a X face
+            // we must be 1 of the 2 Z edges on a Y face
+            // thus we average the 2 surrounding Z coarse edges at X and X+dX
+            else if (onCoarseYFace_(fineIndex))
+            {
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz));
+            }
+            // we're not on any coarse face thus must be one of the 2 Z edges
+            // in the middle of the coarse cell
+            // we therefore take the average of the 4 surrounding Z edges
+            else
+            {
+                fineField(ilfx, ilfy, ilfz)
+                    = 0.25
+                      * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz)
+                         + coarseField(ilcx, ilcy + 1, ilcz + 1)
+                         + coarseField(ilcx + 1, ilcy + 1, ilcz));
+            }
+        }
+    }
+
+    SAMRAI::hier::Box const fineBox_;
+    SAMRAI::hier::Box const coarseBox_;
+    std::array<core::QtyCentering, dimension> const centerings_;
+};
+} // namespace PHARE::amr
+
+
+#endif // PHARE_ELECTRIC_FIELD_REFINER_HPP

--- a/src/amr/data/field/refine/field_refiner.hpp
+++ b/src/amr/data/field/refine/field_refiner.hpp
@@ -26,12 +26,13 @@ namespace amr
      * coarse field.
      */
     template<std::size_t dimension>
-    class FieldRefiner
+    class DefaultFieldRefiner
     {
     public:
-        FieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
-                     SAMRAI::hier::Box const& destinationGhostBox,
-                     SAMRAI::hier::Box const& sourceGhostBox, SAMRAI::hier::IntVector const& ratio)
+        DefaultFieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
+                            SAMRAI::hier::Box const& destinationGhostBox,
+                            SAMRAI::hier::Box const& sourceGhostBox,
+                            SAMRAI::hier::IntVector const& ratio)
             : indexesAndWeights_{centering, ratio}
             , fineBox_{destinationGhostBox}
             , coarseBox_{sourceGhostBox}

--- a/src/amr/data/field/refine/magnetic_field_refiner.hpp
+++ b/src/amr/data/field/refine/magnetic_field_refiner.hpp
@@ -1,0 +1,230 @@
+#ifndef PHARE_MAGNETIC_FIELD_REFINER_HPP
+#define PHARE_MAGNETIC_FIELD_REFINER_HPP
+
+#include <SAMRAI/hier/Box.h>
+
+#include "amr/resources_manager/amr_utils.hpp"
+#include "core/utilities/constants.hpp"
+#include "core/data/grid/gridlayoutdefs.hpp"
+#include "core/utilities/point/point.hpp"
+
+#include <cstddef>
+
+namespace PHARE::amr
+{
+
+using core::dirX;
+using core::dirY;
+using core::dirZ;
+
+template<std::size_t dimension>
+class MagneticFieldRefiner
+{
+public:
+    MagneticFieldRefiner(std::array<core::QtyCentering, dimension> const& centering,
+                         SAMRAI::hier::Box const& destinationGhostBox,
+                         SAMRAI::hier::Box const& sourceGhostBox,
+                         SAMRAI::hier::IntVector const& ratio)
+        : fineBox_{destinationGhostBox}
+        , coarseBox_{sourceGhostBox}
+        , centerings_{centering}
+    {
+    }
+
+
+    // magnetic field refinement is made so to conserve the divergence of B
+    // it simply copies the value of the magnetic field existing on a coarse face
+    // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
+    // these fine faces equals that on the overlaped coarse face.
+    // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    template<typename FieldT>
+    void operator()(FieldT const& coarseField, FieldT& fineField,
+                    core::Point<int, dimension> fineIndex)
+    {
+        TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
+
+        auto locFineIdx = AMRToLocal(fineIndex, fineBox_);
+        auto coarseIdx{fineIndex};
+        for (auto& idx : coarseIdx)
+            idx = idx / 2;
+        auto locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
+
+
+        if constexpr (dimension == 1)
+        {
+            // if primal, i.e. Bx :
+            // if even fine index, we're on top of coarse, we take 100% coarse overlaped fieldValue
+            // e.g. fineIndex==100, we take coarse[100/2]
+            // if odd fine index, we take 50% of surrounding coarse nodes
+            // e.g. fineIndex == 101, we take 0.5(coarse(101/2)+coarse(101/2+1))
+            //
+            //   49          50              51            52
+            //    o           o              o             o      Bx on coarse
+            //    x     x     x      x       o      x      x      Bx on fine
+            //   98     99   100    101     102    103    104
+            //
+            //
+            if (centerings_[0] == core::QtyCentering::primal)
+            {
+                if (fineIndex[0] % 2 == 0)
+                {
+                    fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
+                }
+                else
+                {
+                    fineField(locFineIdx[dirX])
+                        = 0.5
+                          * (coarseField(locCoarseIdx[dirX]) + coarseField(locCoarseIdx[dirX] + 1));
+                }
+            }
+            // dual case, By, Bz
+            //          49           50             51
+            //    o     +     o      +       o      +       o      Byz on coarse : +
+            //    o  +  o  +  o   +  o   +   o   +  o   +   o      Byz on fine   : +
+            //      98    99     100    101     102    103
+            //
+            // 100 takes 50 = 100/2
+            // 101 takes 50 = 101/2
+            else
+            {
+                fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
+            }
+        }
+
+
+
+
+        else if constexpr (dimension == 2)
+        {
+            if (centerings_[dirX] == core::QtyCentering::primal
+                and centerings_[dirY] == core::QtyCentering::dual)
+            {
+                // Bx
+                if (fineIndex[dirX] % 2 == 0)
+                {
+                    // we're on a coarse X face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                }
+                else
+                {
+                    // we're on a fine X face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = 0.5
+                          * (coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY])
+                             + coarseField(locCoarseIdx[dirX] + 1, locCoarseIdx[dirY]));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::primal)
+            {
+                // By
+                if (fineIndex[dirY] % 2 == 0)
+                {
+                    // we're on a coarse Y face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                }
+                else
+                {
+                    // we're on a fine Y face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY])
+                        = 0.5
+                          * (coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY])
+                             + coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY] + 1));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::dual)
+            {
+                // Bz
+                // we're always on a coarse Z face since there is no dual in z
+                // all 4 fine Bz take the coarse Z value
+                fineField(locFineIdx[dirX], locFineIdx[dirY])
+                    = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+            }
+        }
+
+
+        else if constexpr (dimension == 3)
+        {
+            auto ix = locCoarseIdx[dirX];
+            auto iy = locCoarseIdx[dirY];
+            auto iz = locCoarseIdx[dirZ];
+
+            if (centerings_[dirX] == core::QtyCentering::primal
+                and centerings_[dirY] == core::QtyCentering::dual
+                and centerings_[dirZ] == core::QtyCentering::dual)
+            {
+                // Bx
+                if (fineIndex[dirX] % 2 == 0)
+                {
+                    // we're on a coarse X face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = coarseField(ix, iy, iz);
+                }
+                else
+                {
+                    // we're on a fine X face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ix, iy, iz) + coarseField(ix + 1, iy, iz));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::primal
+                     and centerings_[dirZ] == core::QtyCentering::dual)
+            {
+                // By
+                if (fineIndex[dirY] % 2 == 0)
+                {
+                    // we're on a coarse Y face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = coarseField(ix, iy, iz);
+                }
+                else
+                {
+                    // we're on a fine Y face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ix, iy, iz) + coarseField(ix, iy + 1, iz));
+                }
+            }
+            else if (centerings_[dirX] == core::QtyCentering::dual
+                     and centerings_[dirY] == core::QtyCentering::dual
+                     and centerings_[dirZ] == core::QtyCentering::primal)
+            {
+                // Bz
+                if (fineIndex[dirZ] % 2 == 0)
+                {
+                    // we're on a coarse X face
+                    // take the coarse face value
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = coarseField(ix, iy, iz);
+                }
+                else
+                {
+                    // we're on a fine Z face, take the average of the coarse value
+                    // between the two surrounding faces
+                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
+                        = 0.5 * (coarseField(ix, iy, iz) + coarseField(ix, iy, iz + 1));
+                }
+            }
+        }
+    }
+
+private:
+    SAMRAI::hier::Box const fineBox_;
+    SAMRAI::hier::Box const coarseBox_;
+    std::array<core::QtyCentering, dimension> const centerings_;
+};
+} // namespace PHARE::amr
+
+
+#endif // !PHARE_MAGNETIC_FIELD_REFINER_HPP

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -1,20 +1,22 @@
 #ifndef PHARE_HYBRID_HYBRID_MESSENGER_STRATEGY_HPP
 #define PHARE_HYBRID_HYBRID_MESSENGER_STRATEGY_HPP
 
-#include "communicators.hpp"
-#include "amr/data/field/coarsening/field_coarsen_operator.hpp"
-#include "amr/data/field/refine/field_refine_operator.hpp"
+#include "SAMRAI/hier/CoarseFineBoundary.h"
+#include "SAMRAI/hier/IntVector.h"
+#include "refiner_pool.hpp"
+#include "synchronizer_pool.hpp"
+#include "amr/data/field/coarsening/default_field_coarsener.hpp"
+#include "amr/data/field/coarsening/magnetic_field_coarsener.hpp"
+#include "amr/data/field/refine/field_refiner.hpp"
+#include "amr/data/field/refine/magnetic_field_refiner.hpp"
+#include "amr/data/field/refine/electric_field_refiner.hpp"
 #include "amr/data/field/time_interpolate/field_linear_time_interpolate.hpp"
-#include "amr/data/particles/refine/particles_data_split.hpp"
-#include "amr/data/particles/refine/split.hpp"
 #include "amr/messengers/messenger_info.hpp"
 #include "amr/messengers/hybrid_messenger_info.hpp"
 #include "amr/messengers/hybrid_messenger_strategy.hpp"
 #include "amr/resources_manager/amr_utils.hpp"
-#include "amr/resources_manager/resources_manager_utilities.hpp"
 
 #include "core/numerics/interpolator/interpolator.hpp"
-#include "core/numerics/moments/moments.hpp"
 #include "core/hybrid/hybrid_quantities.hpp"
 
 
@@ -27,6 +29,7 @@
 #include <optional>
 #include <utility>
 #include <iomanip>
+#include <iostream>
 
 
 namespace PHARE
@@ -95,7 +98,7 @@ namespace amr
             , resourcesManager_{std::move(manager)}
             , firstLevel_{firstLevel}
         {
-            resourcesManager_->registerResources(EM_old_);
+            // resourcesManager_->registerResources(EM_old_);
             resourcesManager_->registerResources(Jold_);
             resourcesManager_->registerResources(NiOldUser_);
             resourcesManager_->registerResources(ViOld_);
@@ -115,7 +118,7 @@ namespace amr
          */
         void allocate(SAMRAI::hier::Patch& patch, double const allocateTime) const override
         {
-            resourcesManager_->allocate(EM_old_, patch, allocateTime);
+            // resourcesManager_->allocate(Eavg_, patch, allocateTime);
             resourcesManager_->allocate(Jold_, patch, allocateTime);
             resourcesManager_->allocate(NiOldUser_, patch, allocateTime);
             resourcesManager_->allocate(ViOld_, patch, allocateTime);
@@ -180,6 +183,8 @@ namespace amr
             electricSharedNodes_.registerLevel(hierarchy, level);
             currentSharedNodes_.registerLevel(hierarchy, level);
 
+            magneticPatchGhosts_.registerLevel(hierarchy, level);
+            // magneticLevelGhosts_.registerLevel(hierarchy, level);
             magneticGhosts_.registerLevel(hierarchy, level);
             electricGhosts_.registerLevel(hierarchy, level);
             currentGhosts_.registerLevel(hierarchy, level);
@@ -212,27 +217,45 @@ namespace amr
 
         /**
          * @brief regrid performs the regriding communications for Hybrid to Hybrid messengers
-         *
-         * basically, all quantities that are in initialization refiners need to be regridded
+         , all quantities that are in initialization refiners need to be regridded
          */
         void regrid(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
                     const int levelNumber,
                     std::shared_ptr<SAMRAI::hier::PatchLevel> const& oldLevel,
                     IPhysicalModel& model, double const initDataTime) override
         {
-            auto level = hierarchy->getPatchLevel(levelNumber);
+            auto& hybridModel = dynamic_cast<HybridModel&>(model);
+            auto level        = hierarchy->getPatchLevel(levelNumber);
             magneticInit_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             electricInit_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             interiorParticles_.regrid(hierarchy, levelNumber, oldLevel, initDataTime);
             patchGhostParticles_.fill(levelNumber, initDataTime);
+
+            // regriding will fill the new level wherever it has points that overlap
+            // old level. This will include its level border points.
+            // These new level border points will thus take values that where previous
+            // domain values. Magnetic flux is thus not necessarily consistent with
+            // the Loring et al. method to sync the induction between coarse and fine faces.
+            // Specifically, we need all fine faces to have equal magnetic field and also
+            // equal to that of the shared coarse face.
+            // This means that we now need to fill ghosts and border included
+            auto& B = hybridModel.state.electromag.B;
+            auto& E = hybridModel.state.electromag.E;
+            // magneticSharedNodes_.fill(B, levelNumber, initDataTime);
+            magneticGhosts_.fill(B, levelNumber, initDataTime);
+            // electricSharedNodes_.fill(E, levelNumber, initDataTime);
+            electricGhosts_.fill(E, levelNumber, initDataTime);
+
+            fix_magnetic_divergence(*hierarchy, levelNumber, B);
+
             // we now call only levelGhostParticlesOld.fill() and not .regrid()
             // regrid() would refine from next coarser in regions of level not overlaping
-            // oldLevel, but copy from domain particles of oldLevel where there is an overlap
-            // while we do not a priori see why this could be wrong,but this led to occasional
-            // failures of the SAMRAI MPI module. See https://github.com/PHAREHUB/PHARE/issues/604
-            // calling .fill() ensures that levelGhostParticlesOld particles are filled
-            // exclusively from spliting next coarser domain ones like when a new finest level
-            // is created.
+            // oldLevel, but copy from domain particles of oldLevel where there is an
+            // overlap while we do not a priori see why this could be wrong,but this led to
+            // occasional failures of the SAMRAI MPI module. See
+            // https://github.com/PHAREHUB/PHARE/issues/604 calling .fill() ensures that
+            // levelGhostParticlesOld particles are filled exclusively from spliting next
+            // coarser domain ones like when a new finest level is created.
             levelGhostParticlesOld_.fill(levelNumber, initDataTime);
             copyLevelGhostOldToPushable_(*level, model);
 
@@ -268,8 +291,8 @@ namespace amr
 
 
         /**
-         * @brief initLevel is used to initialize hybrid data on the level levelNumer at time
-         * initDataTime from hybrid coarser data.
+         * @brief initLevel is used to initialize hybrid data on the level levelNumer at
+         * time initDataTime from hybrid coarser data.
          */
         void initLevel(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
                        double const initDataTime) override
@@ -313,29 +336,11 @@ namespace amr
            ------------------------------------------------------------------------ */
 
 
-        /**
-         * @brief see IMessenger::fillMagneticGhosts for documentation
-
-         * Note on the HybridHybrid version:
-         * The function throws if the given magnetic field B has not been registered
-         * in the ghostMagnetic field of the HybridMessengerInfo
-         *
-         * The method finds if the name of the VecField is
-         *
-         */
-        void fillMagneticGhosts(VecFieldT& B, int const levelNumber, double const fillTime) override
-        {
-            PHARE_LOG_SCOPE("HybridHybridMessengerStrategy::fillMagneticGhosts");
-            magneticSharedNodes_.fill(B, levelNumber, fillTime);
-            magneticGhosts_.fill(B, levelNumber, fillTime);
-        }
-
-
-
 
         void fillElectricGhosts(VecFieldT& E, int const levelNumber, double const fillTime) override
         {
             PHARE_LOG_SCOPE("HybridHybridMessengerStrategy::fillElectricGhosts");
+            std::cout << "filling electric ghosts\n";
             electricSharedNodes_.fill(E, levelNumber, fillTime);
             electricGhosts_.fill(E, levelNumber, fillTime);
         }
@@ -354,8 +359,9 @@ namespace amr
 
 
         /**
-         * @brief fillIonGhostParticles will fill the interior ghost particle array from neighbor
-         * patches of the same level. Before doing that, it empties the array for all populations
+         * @brief fillIonGhostParticles will fill the interior ghost particle array from
+         * neighbor patches of the same level. Before doing that, it empties the array for
+         * all populations
          */
         void fillIonGhostParticles(IonsT& ions, SAMRAI::hier::PatchLevel& level,
                                    double const fillTime) override
@@ -380,11 +386,10 @@ namespace amr
         /**
          * @brief fillIonMomentGhosts works on moment ghost nodes
          *
-         * patch border node moments are completed by the deposition of patch ghost particles
-         * for all populations
-         * level border nodes are completed by the deposition of level ghost [old,new] particles
-         * for all populations, linear time interpolation is used to get the contribution of old/new
-         * particles
+         * patch border node moments are completed by the deposition of patch ghost
+         * particles for all populations level border nodes are completed by the deposition
+         * of level ghost [old,new] particles for all populations, linear time interpolation
+         * is used to get the contribution of old/new particles
          */
         void fillIonPopMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
                                     double const afterPushTime) override
@@ -429,12 +434,11 @@ namespace amr
         }
 
 
-        /* pure (patch and level) ghost nodes are filled by applying a regular ghost schedule
-         * i.e. that does not overwrite the border patch node previously well calculated from
-         * particles
-         * Note : the ghost schedule only fills the total density and bulk velocity and NOT
-         * population densities and fluxes. These partial densities and fluxes are thus
-         * not available on ANY ghost node.*/
+        /* pure (patch and level) ghost nodes are filled by applying a regular ghost
+         * schedule i.e. that does not overwrite the border patch node previously well
+         * calculated from particles Note : the ghost schedule only fills the total density
+         * and bulk velocity and NOT population densities and fluxes. These partial
+         * densities and fluxes are thus not available on ANY ghost node.*/
         virtual void fillIonMomentGhosts(IonsT& ions, SAMRAI::hier::PatchLevel& level,
                                          double const afterPushTime) override
         {
@@ -443,14 +447,14 @@ namespace amr
         }
 
         /**
-         * @brief firstStep : in the HybridHybridMessengerStrategy, the firstStep method is used to
-         * get level border ghost particles from the next coarser level. These particles are defined
-         * in the future at the time the method is called because the coarser level is ahead in
-         * time. These particles are communicated only at first step of a substepping cycle. They
-         * will be used with the levelGhostParticlesOld particles to get the moments on level border
-         * nodes.
-         * The method is does nothing if the level is the root level because the root level
-         * cannot get levelGhost from next coarser (it has none).
+         * @brief firstStep : in the HybridHybridMessengerStrategy, the firstStep method is
+         * used to get level border ghost particles from the next coarser level. These
+         * particles are defined in the future at the time the method is called because the
+         * coarser level is ahead in time. These particles are communicated only at first
+         * step of a substepping cycle. They will be used with the levelGhostParticlesOld
+         * particles to get the moments on level border nodes. The method is does nothing if
+         * the level is the root level because the root level cannot get levelGhost from
+         * next coarser (it has none).
          */
         void firstStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& level,
                        std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& /*hierarchy*/,
@@ -481,12 +485,12 @@ namespace amr
 
 
         /**
-         * @brief lastStep is used to perform operations at the last step of a substepping cycle.
-         * It is called after the level is advanced. Here for hybrid-hybrid messages, the method
-         * moves levelGhostParticlesNew particles into levelGhostParticlesOld ones. Then
-         * levelGhostParticlesNew are emptied since it will be filled again at firstStep of the next
-         * substepping cycle. the new CoarseToFineOld content is then copied to levelGhostParticles
-         * so that they can be pushed during the next subcycle
+         * @brief lastStep is used to perform operations at the last step of a substepping
+         * cycle. It is called after the level is advanced. Here for hybrid-hybrid messages,
+         * the method moves levelGhostParticlesNew particles into levelGhostParticlesOld
+         * ones. Then levelGhostParticlesNew are emptied since it will be filled again at
+         * firstStep of the next substepping cycle. the new CoarseToFineOld content is then
+         * copied to levelGhostParticles so that they can be pushed during the next subcycle
          */
         void lastStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level) override
         {
@@ -537,13 +541,12 @@ namespace amr
         /**
          * @brief prepareStep is the concrete implementation of the
          * HybridMessengerStrategy::prepareStep method For hybrid-Hybrid communications.
-         * This method copies the current model electromagnetic field E,B, the current density J,
-         * and the density and bulk velocity, defined at t=n. Since prepareStep() is called just
-         * before advancing the level, this operation actually saves the t=n versions of E,B,J,Ni,Vi
-         * into the messenger. When the time comes that the next finer level needs to
-         * time interpolate the electromagnetic field and current at its ghost nodes, this level
-         * will be able to interpolate at required time because the t=n Vi,Ni,E,B,J
-         * fields of previous next coarser step will be in the messenger.
+         * This method copies the  density J, and the density and bulk velocity, defined at t=n.
+         * Since prepareStep() is called just before advancing the level, this operation actually
+         * saves the t=n versions of J, Ni, Vi into the messenger. When the time comes that the
+         * next finer level needs to time interpolate the electromagnetic field and current at its
+         * ghost nodes, this level will be able to interpolate at required time because the t=n
+         * Vi,Ni,J fields of previous next coarser step will be in the messenger.
          */
         void prepareStep(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
                          double currentTime) override
@@ -555,19 +558,16 @@ namespace amr
             {
                 auto dataOnPatch = resourcesManager_->setOnPatch(
                     *patch, hybridModel.state.electromag, hybridModel.state.J,
-                    hybridModel.state.ions, EM_old_, Jold_, NiOldUser_, ViOld_);
+                    hybridModel.state.ions, Jold_, NiOldUser_, ViOld_);
 
-                resourcesManager_->setTime(EM_old_, *patch, currentTime);
                 resourcesManager_->setTime(Jold_, *patch, currentTime);
                 resourcesManager_->setTime(NiOldUser_, *patch, currentTime);
                 resourcesManager_->setTime(ViOld_, *patch, currentTime);
 
-                auto& EM = hybridModel.state.electromag;
                 auto& J  = hybridModel.state.J;
                 auto& Vi = hybridModel.state.ions.velocity();
                 auto& Ni = hybridModel.state.ions.density();
 
-                EM_old_.copyData(EM);
                 Jold_.copyData(J);
                 ViOld_.copyData(Vi);
                 NiOldUser_.copyData(Ni);
@@ -585,10 +585,8 @@ namespace amr
 
             auto& hybridModel = static_cast<HybridModel&>(model);
 
-            magneticSharedNodes_.fill(hybridModel.state.electromag.B, levelNumber, initDataTime);
             electricSharedNodes_.fill(hybridModel.state.electromag.E, levelNumber, initDataTime);
 
-            magneticGhosts_.fill(hybridModel.state.electromag.B, levelNumber, initDataTime);
             electricGhosts_.fill(hybridModel.state.electromag.E, levelNumber, initDataTime);
             patchGhostParticles_.fill(levelNumber, initDataTime);
 
@@ -597,9 +595,10 @@ namespace amr
             //
             // Do we need J ghosts filled here?
             // This method is only called when root level is initialized
-            // but J ghosts are needed a priori for the laplacian when the first Ohm is calculated
-            // so I think we do, not having them here is just having the laplacian wrong on
-            // L0 borders for the initial E, which is not the end of the world...
+            // but J ghosts are needed a priori for the laplacian when the first Ohm is
+            // calculated so I think we do, not having them here is just having the
+            // laplacian wrong on L0 borders for the initial E, which is not the end of the
+            // world...
             //
             // do we need moment ghosts filled here?
             // a priori no because those are at this time only needed for coarsening, which
@@ -613,6 +612,7 @@ namespace amr
             PHARE_LOG_SCOPE("HybridHybridMessengerStrategy::synchronize");
 
             auto levelNumber = level.getLevelNumber();
+            std::cout << "synchronizing level " << levelNumber << "\n";
 
             // call coarsning schedules...
             magnetoSynchronizers_.sync(levelNumber);
@@ -622,22 +622,31 @@ namespace amr
         }
 
         // after coarsening, domain nodes have been updated and therefore patch ghost nodes
-        // will probably stop having the exact same value as their overlapped neighbor domain node
-        // we thus fill ghost nodes.
-        // note that we first fill shared border nodes with the sharedNode refiners so that
-        // these shared nodes agree on their value at MPI process boundaries.
-        // then regular refiner fill are called, which fill only pure ghost nodes.
-        // note also that moments are not filled on border nodes since already OK from particle
-        // deposition
+        // will probably stop having the exact same value as their overlapped neighbor
+        // domain node we thus fill ghost nodes. note that we first fill shared border nodes
+        // with the sharedNode refiners so that these shared nodes agree on their value at
+        // MPI process boundaries. then regular refiner fill are called, which fill only
+        // pure ghost nodes. note also that moments are not filled on border nodes since
+        // already OK from particle deposition
         void postSynchronize(IPhysicalModel& model, SAMRAI::hier::PatchLevel& level,
                              double const time) override
         {
             auto levelNumber  = level.getLevelNumber();
             auto& hybridModel = static_cast<HybridModel&>(model);
+
+            std::cout << "postSynchronize level " << levelNumber << "\n";
+
             magneticSharedNodes_.fill(hybridModel.state.electromag.B, levelNumber, time);
             electricSharedNodes_.fill(hybridModel.state.electromag.E, levelNumber, time);
 
-            magneticGhosts_.fill(hybridModel.state.electromag.B, levelNumber, time);
+            // we fill magnetic field ghosts only on patch ghost nodes and not on level
+            // ghosts the reason is that 1/ filling ghosts is necessary to prevent mismatch
+            // between ghost and overlaped neighboring patch domain nodes resulting from
+            // former coarsening which does not occur for level ghosts and 2/ overwriting
+            // level border with next coarser model B would invalidate divB on the first
+            // fine domain cell since its border face only received a fraction of the
+            // induction that has occured on the shared coarse face.
+            magneticPatchGhosts_.fill(hybridModel.state.electromag.B, levelNumber, time);
             electricGhosts_.fill(hybridModel.state.electromag.E, levelNumber, time);
             densityGhosts_.fill(levelNumber, time);
             bulkVelGhosts_.fill(hybridModel.state.ions.velocity(), levelNumber, time);
@@ -646,34 +655,39 @@ namespace amr
     private:
         void registerGhostComms_(std::unique_ptr<HybridMessengerInfo> const& info)
         {
-            auto const& Eold = EM_old_.E;
-            auto const& Bold = EM_old_.B;
+            auto makeKeys = [](auto const& descriptor) {
+                std::vector<std::string> keys;
+                std::transform(std::begin(descriptor), std::end(descriptor),
+                               std::back_inserter(keys), [](auto const& d) { return d.vecName; });
+                return keys;
+            };
+            fillStaticRefiners_(info->ghostMagnetic, BfieldNodeRefineOp_, magneticSharedNodes_,
+                                makeKeys(info->ghostMagnetic), /*ghosts=*/true);
 
-            fillRefiners_(info->ghostElectric, info->modelElectric, VecFieldDescriptor{Eold},
-                          electricSharedNodes_, fieldNodeRefineOp_);
-            fillRefiners_(info->ghostElectric, info->modelElectric, VecFieldDescriptor{Eold},
-                          electricGhosts_);
+            fillStaticRefiners_(info->ghostMagnetic, BfieldRefineOp_, magneticGhosts_,
+                                makeKeys(info->ghostMagnetic), /*ghosts=*/true);
 
-            fillRefiners_(info->ghostMagnetic, info->modelMagnetic, VecFieldDescriptor{Bold},
-                          magneticSharedNodes_, fieldNodeRefineOp_);
-            fillRefiners_(info->ghostMagnetic, info->modelMagnetic, VecFieldDescriptor{Bold},
-                          magneticGhosts_);
+            fillStaticRefiners_(info->modelMagnetic, BfieldRefineOp_, magneticPatchGhosts_,
+                                info->modelMagnetic.vecName, /*ghosts=*/true);
 
-            fillRefiners_(info->ghostCurrent, info->modelCurrent, VecFieldDescriptor{Jold_},
-                          currentSharedNodes_, fieldNodeRefineOp_);
-            fillRefiners_(info->ghostCurrent, info->modelCurrent, VecFieldDescriptor{Jold_},
-                          currentGhosts_);
+            fillStaticRefiners_(info->ghostElectric, EfieldNodeRefineOp_, electricSharedNodes_,
+                                makeKeys(info->ghostElectric), /*ghosts=*/true);
 
-            // no fillRefiners overload for a scalar so do it manually for the density
-            // density and bulk velocity are OK on border node because it is obtained from
-            // domain particles and either patch ghost particles or levelghost[old,new] particles
-            // so we only need to fill pure ghost nodes. Therefore there is no need for a
-            // SharedNodes refiner
-            densityGhosts_.add(info->modelIonDensity, fieldRefineOp_, info->modelIonDensity,
-                               resourcesManager_);
+            fillStaticRefiners_(info->ghostElectric, EfieldRefineOp_, electricGhosts_,
+                                makeKeys(info->ghostElectric), /*ghosts=*/true);
 
-            fillRefiners_(info->ghostBulkVelocity, info->modelIonBulkVelocity,
-                          VecFieldDescriptor{ViOld_}, bulkVelGhosts_);
+            fillTimeRefiners_(info->ghostCurrent, info->modelCurrent, VecFieldDescriptor{Jold_},
+                              currentSharedNodes_, EfieldNodeRefineOp_);
+
+            fillTimeRefiners_(info->ghostCurrent, info->modelCurrent, VecFieldDescriptor{Jold_},
+                              currentGhosts_, EfieldRefineOp_);
+
+            densityGhosts_.addTimeRefiner(info->modelIonDensity, info->modelIonDensity,
+                                          NiOldUser_.name, resourcesManager_, fieldRefineOp_,
+                                          fieldTimeOp_, info->modelIonDensity);
+
+            fillTimeRefiners_(info->ghostBulkVelocity, info->modelIonBulkVelocity,
+                              VecFieldDescriptor{ViOld_}, bulkVelGhosts_);
         }
 
 
@@ -688,27 +702,27 @@ namespace amr
                 return keys;
             };
 
-            fillRefiners_(info->initMagnetic, fieldRefineOp_, magneticInit_,
-                          makeKeys(info->initMagnetic));
+            fillStaticRefiners_(info->initMagnetic, BfieldRefineOp_, magneticInit_,
+                                makeKeys(info->initMagnetic));
 
-            fillRefiners_(info->initElectric, fieldRefineOp_, electricInit_,
-                          makeKeys(info->initElectric));
-
-
-            fillRefiners_(info->interiorParticles, interiorParticleRefineOp_, interiorParticles_,
-                          info->interiorParticles);
+            fillStaticRefiners_(info->initElectric, EfieldRefineOp_, electricInit_,
+                                makeKeys(info->initElectric));
 
 
-            fillRefiners_(info->levelGhostParticlesOld, levelGhostParticlesOldOp_,
-                          levelGhostParticlesOld_, info->levelGhostParticlesOld);
+            fillStaticRefiners_(info->interiorParticles, interiorParticleRefineOp_,
+                                interiorParticles_, info->interiorParticles);
 
 
-            fillRefiners_(info->levelGhostParticlesNew, levelGhostParticlesNewOp_,
-                          levelGhostParticlesNew_, info->levelGhostParticlesNew);
+            fillStaticRefiners_(info->levelGhostParticlesOld, levelGhostParticlesOldOp_,
+                                levelGhostParticlesOld_, info->levelGhostParticlesOld);
 
 
-            fillRefiners_(info->patchGhostParticles, nullptr, patchGhostParticles_,
-                          info->patchGhostParticles);
+            fillStaticRefiners_(info->levelGhostParticlesNew, levelGhostParticlesNewOp_,
+                                levelGhostParticlesNew_, info->levelGhostParticlesNew);
+
+
+            fillStaticRefiners_(info->patchGhostParticles, nullptr, patchGhostParticles_,
+                                info->patchGhostParticles);
         }
 
 
@@ -716,7 +730,7 @@ namespace amr
 
         void registerSyncComms(std::unique_ptr<HybridMessengerInfo> const& info)
         {
-            magnetoSynchronizers_.add(info->modelMagnetic, resourcesManager_, fieldCoarseningOp_,
+            magnetoSynchronizers_.add(info->modelMagnetic, resourcesManager_, magneticCoarseningOp_,
                                       info->modelMagnetic.vecName);
 
             electroSynchronizers_.add(info->modelElectric, resourcesManager_, fieldCoarseningOp_,
@@ -732,57 +746,71 @@ namespace amr
 
 
         /**
-         * @brief makeCommunicators_ adds to the ghost communicators all VecFieldDescriptor of
-         * the given vector field.
-         *
-         * Each of the ghost VecFieldDescriptor will have an entry in the ghost communicators
-         *
-         * @param ghostVec is the collection of VecFieldDescriptor. Each VecFieldDescriptor
-         * corresponds to a VecField for which ghosts will be needed.
-         * @param modelVec is VecFieldDescriptor for the model VecField associated with the
-         * VecField for which ghosts are needed. When ghosts are filled, this quantity is taken
-         * on the coarser level and is definer at t_coarse+dt_coarse
-         * @param oldModelVec is the VecFieldDescriptor for the VecField for which ghosts are
-         * needed, at t_coarse. These are typically internal variables of the messenger, like
-         * Eold or Bold.
+         * @brief fill the given pool of refiners with a new refiner per VecFieldDescriptor
+         * in ghostVecs. Data will be spatially refined using the specified refinement
+         * operator, and time interpolated between time n and n+1 of next coarser data,
+         * represented by modelVec and oldModelVec descriptors.
          */
         template<typename RefinerT, RefinerT RefineType>
-        void fillRefiners_(std::vector<VecFieldDescriptor> const& ghostVecs,
-                           VecFieldDescriptor const& modelVec,
-                           VecFieldDescriptor const& oldModelVec, RefinerPool<RefineType>& refiners,
-                           std::shared_ptr<SAMRAI::hier::RefineOperator>& refineOp)
+        void fillTimeRefiners_(std::vector<VecFieldDescriptor> const& ghostVecs,
+                               VecFieldDescriptor const& modelVec,
+                               VecFieldDescriptor const& oldModelVec,
+                               RefinerPool<RefineType>& refiners,
+                               std::shared_ptr<SAMRAI::hier::RefineOperator>& refineOp)
         {
             for (auto const& ghostVec : ghostVecs)
             {
-                refiners.add(ghostVec, modelVec, oldModelVec, resourcesManager_, refineOp,
-                             fieldTimeOp_, ghostVec.vecName);
+                refiners.addTimeRefiner(ghostVec, modelVec, oldModelVec, resourcesManager_,
+                                        refineOp, fieldTimeOp_, ghostVec.vecName);
             }
         }
 
 
+        /** @brief convenience overload of above with defauled field refinement operator*/
         template<typename RefinerT, RefinerT RefineType>
-        void fillRefiners_(std::vector<VecFieldDescriptor> const& ghostVecs,
-                           VecFieldDescriptor const& modelVec,
-                           VecFieldDescriptor const& oldModelVec, RefinerPool<RefineType>& refiners)
+        void fillTimeRefiners_(std::vector<VecFieldDescriptor> const& ghostVecs,
+                               VecFieldDescriptor const& modelVec,
+                               VecFieldDescriptor const& oldModelVec,
+                               RefinerPool<RefineType>& refiners)
         {
-            fillRefiners_(ghostVecs, modelVec, oldModelVec, refiners, fieldRefineOp_);
+            fillTimeRefiners_(ghostVecs, modelVec, oldModelVec, refiners, fieldRefineOp_);
         }
-
 
 
 
         template<typename Descriptors, typename RefinerPool>
-        void fillRefiners_(Descriptors const& descriptors,
-                           std::shared_ptr<SAMRAI::hier::RefineOperator> refineOp,
-                           RefinerPool& refiners, std::vector<std::string> keys)
+        void fillStaticRefiners_(Descriptors const& dest, Descriptors const& source,
+                                 std::shared_ptr<SAMRAI::hier::RefineOperator> refineOp,
+                                 RefinerPool& refiners, std::vector<std::string> keys,
+                                 bool ghosts = false)
         {
+            assert(dest.size() == source.size());
             auto key = std::begin(keys);
-            for (auto const& descriptor : descriptors)
+            for (std::size_t i = 0; i < dest.size(); ++i)
             {
-                refiners.add(descriptor, refineOp, *key++, resourcesManager_);
+                refiners.addStaticRefiner(dest[i], source[i], refineOp, *key++, resourcesManager_,
+                                          ghosts);
             }
         }
 
+        template<typename Descriptors, typename RefinerPool>
+        void fillStaticRefiners_(Descriptors const& descriptors,
+                                 std::shared_ptr<SAMRAI::hier::RefineOperator> refineOp,
+                                 RefinerPool& refiners, std::vector<std::string> keys,
+                                 bool ghosts = false)
+        {
+            fillStaticRefiners_(descriptors, descriptors, refineOp, refiners, keys, ghosts);
+        }
+
+
+        template<typename RefinerPool>
+        void fillStaticRefiners_(VecFieldDescriptor const& descriptor,
+                                 std::shared_ptr<SAMRAI::hier::RefineOperator> refineOp,
+                                 RefinerPool& refiners, std::string key, bool ghosts = false)
+        {
+            refiners.addStaticRefiner(descriptor, descriptor, refineOp, key, resourcesManager_,
+                                      ghosts);
+        }
 
 
         void copyLevelGhostOldToPushable_(SAMRAI::hier::PatchLevel& level, IPhysicalModel& model)
@@ -813,11 +841,230 @@ namespace amr
                    / (afterPushCoarseTime_[levelNumber] - beforePushCoarseTime_[levelNumber]);
         }
 
+        /*
+         *
+         * */
+        void fix_magnetic_divergence(SAMRAI::hier::PatchHierarchy const& hierarchy, int levelNumber,
+                                     VecFieldT& B)
+        {
+            auto lvlBoundary = SAMRAI::hier::CoarseFineBoundary(
+                hierarchy, levelNumber,
+                SAMRAI::hier::IntVector{SAMRAI::tbox::Dimension{dimension}, 0});
+
+            for (auto& patch : *hierarchy.getPatchLevel(levelNumber))
+            {
+                if constexpr (dimension == 2)
+                {
+                    auto _         = resourcesManager_->setOnPatch(*patch, B);
+                    auto layout    = layoutFromPatch<GridLayoutT>(*patch);
+                    auto& Bx       = B(Component::X);
+                    auto& By       = B(Component::Y);
+                    auto& Bz       = B(Component::Z);
+                    auto const& dx = layout.meshSize()[0];
+                    auto const& dy = layout.meshSize()[1];
+
+                    auto boundaries = lvlBoundary.getEdgeBoundaries(patch->getGlobalId());
+                    for (auto& boundary : boundaries)
+                    {
+                        int loc         = boundary.getLocationIndex();
+                        auto const& box = boundary.getBox();
+
+                        if (loc == 0) // x_lo
+                        {
+                            // we're on the left side border outside the domain
+                            // we need to get to the first domain cell
+                            auto ixAMR = box.lower()[0] + 1;
+
+                            // this is a X edge we need to fix By
+                            for (int iyAMR = box.lower()[1]; iyAMR <= box.upper()[1]; ++iyAMR)
+                            {
+                                // we want to change By only at fine faces not shared with
+                                // coarse faces.
+                                if (!(iyAMR % 2 == 0))
+                                {
+                                    auto localIdx = layout.AMRToLocal(Point{ixAMR, iyAMR});
+                                    auto ix       = localIdx[0];
+                                    auto iy       = localIdx[1];
+                                    By(ix, iy)
+                                        = By(ix, iy + 1) + dy / dx * (Bx(ix + 1, iy) - Bx(ix, iy));
+                                }
+                            }
+                        }
+                        else if (loc == 1) // x_hi
+                        {
+                            // we're on the right side border outside the domain
+                            // we need to get to the last domain cell
+                            auto ixAMR = box.upper()[0] - 1;
+
+                            // this is a X edge we need to fix By
+                            for (int iyAMR = box.lower()[1]; iyAMR <= box.upper()[1]; ++iyAMR)
+                            {
+                                // we want to change By only at fine faces not shared with
+                                // coarse faces.
+                                if (!(iyAMR % 2 == 0))
+                                {
+                                    auto localIdx = layout.AMRToLocal(Point{ixAMR, iyAMR});
+                                    auto ix       = localIdx[0];
+                                    auto iy       = localIdx[1];
+                                    By(ix, iy)
+                                        = By(ix, iy + 1) + dy / dx * (Bx(ix + 1, iy) - Bx(ix, iy));
+                                }
+                            }
+                        }
+                        else if (loc == 2) // y_lo
+                        {
+                            // we're on the bottom edge, we need the first domain cell
+                            auto iyAMR = box.lower()[1] + 1;
+
+                            // this is a Y edge we need to fix Bx
+                            for (int ixAMR = box.lower()[0]; ixAMR <= box.upper()[0]; ++ixAMR)
+                            {
+                                // we want to change By only at fine faces not shared with
+                                // coarse faces.
+                                if (!(ixAMR % 2 == 0))
+                                {
+                                    auto localIdx = layout.AMRToLocal(Point{ixAMR, iyAMR});
+                                    auto ix       = localIdx[0];
+                                    auto iy       = localIdx[1];
+                                    Bx(ix, iy)
+                                        = Bx(ix + 1, iy) + dx / dy * (By(ix, iy + 1) - By(ix, iy));
+                                }
+                            }
+                        }
+                        else if (loc == 3) // y_hi
+                        {
+                            // we're on the top edge, we need the last domain cell
+                            auto iyAMR = box.upper()[1] - 1;
+
+                            // this is a Y edge we need to fix Bx
+                            for (int ixAMR = box.lower()[0]; ixAMR <= box.upper()[0]; ++ixAMR)
+                            {
+                                // we want to change By only at fine faces not shared with
+                                // coarse faces.
+                                if (!(ixAMR % 2 == 0))
+                                {
+                                    auto localIdx = layout.AMRToLocal(Point{ixAMR, iyAMR});
+                                    auto ix       = localIdx[0];
+                                    auto iy       = localIdx[1];
+                                    Bx(ix, iy)
+                                        = Bx(ix + 1, iy) + dx / dy * (By(ix, iy + 1) - By(ix, iy));
+                                }
+                            }
+                        }
+                    } // end boundary loop
+
+                    // above we have treated boundaries as 1D lines
+                    // this is not treating corners well and we need to deal with them separatly
+                    //
+                    //__________________
+                    //      |    |     |
+                    //      | 4  BX 1  |
+                    //      |    |     |
+                    //      |_By_|_BY___
+                    //      |    |     |
+                    //      | 3 Bx  2  |
+                    //      |    |     |
+                    //      |____|_____
+                    //                 |
+                    //                 |
+                    //                 |
+                    //
+                    // above are the 4 fine top right corner cells and
+                    // above code have changed BX and BY but not Bx and By
+                    // faces. But these cells are not independant.
+                    // To fix divB in these 4 cells we will re-assigne the four
+                    // fine faces.
+                    // The idea is to give them the same values they would have had
+                    // if refined. By and BY would have the same value, equal to the
+                    // average of the coarse By on top and bottom faces of the coarse cell
+                    // we do not have access to the coarse cell here but we know that because
+                    // of the previous coarsening, these coarse faces have the same flux
+                    // as the average of the 2 shared fine faces
+                    // So By and BY will be 1/4 * sum of top and bottom fine By
+                    // Similarly, BX and Bx will take 1/4 the four fine Bx faces share with the
+                    // coarse ones
+                    //
+                    auto corners = lvlBoundary.getNodeBoundaries(patch->getGlobalId());
+                    for (auto& corner : corners)
+                    {
+                        int loc = corner.getLocationIndex();
+
+                        // the box we get should consist of just 1 cell
+                        // i.e. with lower==upper so it should not matter which
+                        // one we take in the following.
+                        auto const& box = corner.getBox();
+
+                        //* x_lo, y_lo: 0
+                        //* x_hi, y_lo: 1
+                        //* x_lo, y_hi: 2
+                        // * x_hi, y_hi: 3
+
+                        if (loc == 3) // x_hi, y_hi
+                        {
+                            // we're on the top right corner
+                            // and we want the domain cell
+                            // that is labeled cell 1 in above drawing
+                            // we fix BX and BY
+                            auto ixAMR    = box.lower()[0] - 1;
+                            auto iyAMR    = box.lower()[1] - 1;
+                            auto localIdx = layout.AMRToLocal(Point{ixAMR, iyAMR});
+                            auto ix       = localIdx[0];
+                            auto iy       = localIdx[1];
+
+                            std::cout << "BEFORE\n";
+                            std::cout << "cell 4 : "
+                                      << (Bx(ix, iy) - Bx(ix - 1, iy)) / dx
+                                             + (By(ix - 1, iy + 1) - By(ix - 1, iy)) / dy
+                                      << "\n";
+
+                            std::cout << "cell 2 : "
+                                      << (Bx(ix + 1, iy - 1) - Bx(ix, iy - 1)) / dx
+                                             + (By(ix, iy) - By(ix, iy - 1)) / dy
+                                      << "\n";
+
+                            std::cout << "cell 1 : "
+                                      << (Bx(ix + 1, iy) - Bx(ix, iy)) / dx
+                                             + (By(ix, iy + 1) - By(ix, iy)) / dy
+                                      << "\n";
+
+                            std::cout << "cell 3 : "
+                                      << (Bx(ix, iy - 1) - Bx(ix - 1, iy - 1)) / dx
+                                             + (By(ix - 1, iy) - By(ix - 1, iy - 1)) / dy
+                                      << "\n";
+
+                            Bx(ix, iy - 1)
+                                = Bx(ix + 1, iy - 1) + dx / dy * (By(ix, iy) - By(ix, iy - 1));
+
+                            By(ix - 1, iy)
+                                = By(ix - 1, iy + 1) + dy / dx * (Bx(ix, iy) - Bx(ix - 1, iy));
 
 
-        //! keeps a copy of the model electromagnetic field at t=n
-        ElectromagT EM_old_{stratName + "_EM_old"}; // TODO needs to be allocated somewhere and
-                                                    // updated to t=n before advanceLevel()
+                            std::cout << "AFTER";
+                            std::cout << "cell 4 : "
+                                      << (Bx(ix, iy) - Bx(ix - 1, iy)) / dx
+                                             + (By(ix - 1, iy + 1) - By(ix - 1, iy)) / dy
+                                      << "\n";
+
+                            std::cout << "cell 2 : "
+                                      << (Bx(ix + 1, iy - 1) - Bx(ix, iy - 1)) / dx
+                                             + (By(ix, iy) - By(ix, iy - 1)) / dy
+                                      << "\n";
+
+                            std::cout << "cell 1 : "
+                                      << (Bx(ix + 1, iy) - Bx(ix, iy)) / dx
+                                             + (By(ix, iy + 1) - By(ix, iy)) / dy
+                                      << "\n";
+
+                            std::cout << "cell 3 : "
+                                      << (Bx(ix, iy - 1) - Bx(ix - 1, iy - 1)) / dx
+                                             + (By(ix - 1, iy) - By(ix - 1, iy - 1)) / dy
+                                      << "\n";
+                        }
+                    } // end corner loops
+                }     // end if 2D
+            }         // end patch loop
+        }
+
 
         VecFieldT Jold_{stratName + "_Jold", core::HybridQuantity::Vector::J};
         VecFieldT ViOld_{stratName + "_VBulkOld", core::HybridQuantity::Vector::V};
@@ -836,26 +1083,31 @@ namespace amr
 
         core::Interpolator<dimension, interpOrder> interpolate_;
 
+        //! store communicators for magnetic fields that need to be initialized
+        RefinerPool<RefinerType::InitField> magneticInit_;
+        //! store communicators for electric fields that need to be initializes
+        RefinerPool<RefinerType::InitField> electricInit_;
+
+
 
         //! store communicators for magnetic fields that need ghosts to be filled
         RefinerPool<RefinerType::SharedBorder> magneticSharedNodes_;
         RefinerPool<RefinerType::GhostField> magneticGhosts_;
-
-        //! store communicators for magnetic fields that need to be initialized
-        RefinerPool<RefinerType::InitField> magneticInit_;
+        RefinerPool<RefinerType::PatchGhostField> magneticPatchGhosts_;
 
         //! store refiners for electric fields that need ghosts to be filled
         RefinerPool<RefinerType::SharedBorder> electricSharedNodes_;
         RefinerPool<RefinerType::GhostField> electricGhosts_;
 
-        //! store communicators for electric fields that need to be initializes
-        RefinerPool<RefinerType::InitField> electricInit_;
-
-
         RefinerPool<RefinerType::GhostField> currentSharedNodes_;
         RefinerPool<RefinerType::GhostField> currentGhosts_;
 
         // moment ghosts
+        // these do not need sharedNode refiners. The reason is that
+        // the border node is already complete by the deposit of ghost particles
+        // these refiners are used to fill ghost nodes, and therefore, owing to
+        // the GhostField tag, will only assign pur ghost nodes. Border nodes will
+        // be overwritten only on level borders, which does not seem to be an issue.
         RefinerPool<RefinerType::GhostField> densityGhosts_;
         RefinerPool<RefinerType::GhostField> bulkVelGhosts_;
 
@@ -869,7 +1121,8 @@ namespace amr
         //! store communicators for coarse to fine particles new
         RefinerPool<RefinerType::LevelBorderParticles> levelGhostParticlesNew_;
 
-        // keys : model particles (initialization and 2nd push), temporaryParticles (firstPush)
+        // keys : model particles (initialization and 2nd push), temporaryParticles
+        // (firstPush)
         RefinerPool<RefinerType::InteriorGhostParticles> patchGhostParticles_;
 
         SynchronizerPool<dimension> densitySynchronizers_;
@@ -878,14 +1131,26 @@ namespace amr
         SynchronizerPool<dimension> magnetoSynchronizers_;
 
 
+
+        std::shared_ptr<SAMRAI::hier::RefineOperator> fieldRefineOp_{std::make_shared<
+            FieldRefineOperator<GridLayoutT, FieldT, DefaultFieldRefiner<dimension>>>()};
+
         // see field_variable_fill_pattern.hpp for explanation about this "node_only" flag
         // Note that refinement operator, via the boolean argument, serve as a relay for the
         // the RefineAlgorithm to get the correct VariableFillPattern
-        std::shared_ptr<SAMRAI::hier::RefineOperator> fieldNodeRefineOp_{
-            std::make_shared<FieldRefineOperator<GridLayoutT, FieldT>>(/*node_only*/ true)};
+        std::shared_ptr<SAMRAI::hier::RefineOperator> BfieldNodeRefineOp_{std::make_shared<
+            FieldRefineOperator<GridLayoutT, FieldT, MagneticFieldRefiner<dimension>>>(
+            /*node_only*/ true)};
 
-        std::shared_ptr<SAMRAI::hier::RefineOperator> fieldRefineOp_{
-            std::make_shared<FieldRefineOperator<GridLayoutT, FieldT>>()};
+        std::shared_ptr<SAMRAI::hier::RefineOperator> BfieldRefineOp_{std::make_shared<
+            FieldRefineOperator<GridLayoutT, FieldT, MagneticFieldRefiner<dimension>>>()};
+
+        std::shared_ptr<SAMRAI::hier::RefineOperator> EfieldNodeRefineOp_{std::make_shared<
+            FieldRefineOperator<GridLayoutT, FieldT, ElectricFieldRefiner<dimension>>>(
+            /*node_only*/ true)};
+
+        std::shared_ptr<SAMRAI::hier::RefineOperator> EfieldRefineOp_{std::make_shared<
+            FieldRefineOperator<GridLayoutT, FieldT, ElectricFieldRefiner<dimension>>>()};
 
         // field data time op
         std::shared_ptr<SAMRAI::hier::TimeInterpolateOperator> fieldTimeOp_{
@@ -902,8 +1167,11 @@ namespace amr
             std::make_shared<CoarseToFineRefineOpNew>()};
 
 
-        std::shared_ptr<SAMRAI::hier::CoarsenOperator> fieldCoarseningOp_{
-            std::make_shared<FieldCoarsenOperator<GridLayoutT, FieldT>>()};
+        std::shared_ptr<SAMRAI::hier::CoarsenOperator> fieldCoarseningOp_{std::make_shared<
+            FieldCoarsenOperator<GridLayoutT, FieldT, DefaultFieldCoarsener<dimension>>>()};
+
+        std::shared_ptr<SAMRAI::hier::CoarsenOperator> magneticCoarseningOp_{std::make_shared<
+            FieldCoarsenOperator<GridLayoutT, FieldT, MagneticFieldCoarsener<dimension>>>()};
     };
 
     template<typename HybridModel, typename RefinementParams>

--- a/src/amr/messengers/hybrid_messenger.hpp
+++ b/src/amr/messengers/hybrid_messenger.hpp
@@ -41,7 +41,6 @@ namespace amr
      *
      * Ghost filling methods tuned for Hybrid quantities:
      *
-     * - fillMagneticGhosts()
      * - fillElectricGhosts()
      * - fillIonGhostParticles()
      * - fillIonMomentGhosts()
@@ -258,20 +257,6 @@ namespace amr
                             Start HybridMessenger Interface
            -------------------------------------------------------------------------*/
 
-
-
-
-        /**
-         * @brief fillMagneticGhosts is called by a ISolver solving hybrid equations to fill
-         * the ghost nodes of the magnetic field
-         * @param B is the magnetic field for which ghost nodes will be filled
-         * @param levelNumber
-         * @param fillTime
-         */
-        void fillMagneticGhosts(VecFieldT& B, int const levelNumber, double const fillTime)
-        {
-            strat_->fillMagneticGhosts(B, levelNumber, fillTime);
-        }
 
 
         /**

--- a/src/amr/messengers/hybrid_messenger_info.hpp
+++ b/src/amr/messengers/hybrid_messenger_info.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_HYBRID_MESSENGER_INFO_HPP
 #define PHARE_HYBRID_MESSENGER_INFO_HPP
 
@@ -41,7 +40,7 @@ namespace amr
         VecFieldDescriptor() = default;
 
         template<typename VecFieldT>
-        VecFieldDescriptor(VecFieldT const& v)
+        explicit VecFieldDescriptor(VecFieldT const& v)
             : vecName{v.name()}
             , xName{v.getComponentName(core::Component::X)}
             , yName{v.getComponentName(core::Component::Y)}
@@ -84,7 +83,6 @@ namespace amr
 
 
         //! name of the magnetic quantities that will be communicated by
-        //! HybridMessenger::fillMagneticGhosts()
         std::vector<VecFieldDescriptor> ghostMagnetic;
 
 

--- a/src/amr/messengers/hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_messenger_strategy.hpp
@@ -65,11 +65,6 @@ namespace amr
 
         // ghost filling
 
-        // used during solver advance
-        virtual void fillMagneticGhosts(VecFieldT& B, int const levelNumber, double const fillTime)
-            = 0;
-
-
         virtual void fillElectricGhosts(VecFieldT& E, int const levelNumber, double const fillTime)
             = 0;
 

--- a/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/mhd_hybrid_messenger_strategy.hpp
@@ -34,7 +34,8 @@ namespace amr
         }
 
         /**
-         * @brief allocate allocate the internal resources to the hybrid and MHD resourcesManagers
+         * @brief allocate the internal resources to the hybrid and MHD
+         * resourcesManagers
          */
         void allocate(SAMRAI::hier::Patch& patch, double const allocateTime) const override
         {
@@ -43,14 +44,11 @@ namespace amr
             hybridResourcesManager_->allocate(EM_old_, patch, allocateTime);
         }
 
-
-
         void registerQuantities(
             std::unique_ptr<IMessengerInfo> /*fromCoarserInfo*/,
             [[maybe_unused]] std::unique_ptr<IMessengerInfo> /*fromFinerInfo*/) override
         {
         }
-
 
         void registerLevel(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& /*hierarchy*/,
                            int const /*levelNumber*/) override
@@ -67,9 +65,6 @@ namespace amr
             return std::make_unique<HybridMessengerInfo>();
         }
 
-
-
-
         void regrid(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& /*hierarchy*/,
                     const int /*levelNumber*/,
                     std::shared_ptr<SAMRAI::hier::PatchLevel> const& /*oldLevel*/,
@@ -78,14 +73,9 @@ namespace amr
             //
         }
 
-
-
-
         std::string fineModelName() const override { return HybridModel::model_name; }
 
         std::string coarseModelName() const override { return MHDModel::model_name; }
-
-
 
         void initLevel(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
                        double const /*initDataTime*/) override
@@ -94,11 +84,6 @@ namespace amr
 
         virtual ~MHDHybridMessengerStrategy() = default;
 
-
-        void fillMagneticGhosts(VecFieldT& /*B*/, int const /*levelNumber*/,
-                                double const /*fillTime*/) override
-        {
-        }
         void fillElectricGhosts(VecFieldT& /*E*/, int const /*levelNumber*/,
                                 double const /*fillTime*/) override
         {
@@ -108,7 +93,6 @@ namespace amr
                                double const /*fillTime*/) override
         {
         }
-
 
         void fillIonGhostParticles(IonsT& /*ions*/, SAMRAI::hier::PatchLevel& /*level*/,
                                    double const /*fillTime*/) override
@@ -133,7 +117,6 @@ namespace amr
 
         void lastStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/) override {}
 
-
         void prepareStep(IPhysicalModel& /*model*/, SAMRAI::hier::PatchLevel& /*level*/,
                          double /*currentTime*/) final
         {
@@ -144,8 +127,6 @@ namespace amr
         {
         }
 
-
-
         void synchronize(SAMRAI::hier::PatchLevel& /*level*/) final
         {
             // call coarsning schedules...
@@ -155,9 +136,6 @@ namespace amr
                              double const /*time*/) override
         {
         }
-
-
-
 
     private:
         using Electromag = decltype(std::declval<HybridModel>().state.electromag);
@@ -172,9 +150,7 @@ namespace amr
     const std::string MHDHybridMessengerStrategy<MHDModel, HybridModel>::stratName
         = "MHDModel-HybridModel";
 
-
 } // namespace amr
 } // namespace PHARE
-
 
 #endif

--- a/src/amr/messengers/refiner_pool.hpp
+++ b/src/amr/messengers/refiner_pool.hpp
@@ -1,9 +1,8 @@
-#ifndef PHARE_COMMUNICATORS_HPP
-#define PHARE_COMMUNICATORS_HPP
+#ifndef PHARE_REFINER_POOL_HPP
+#define PHARE_REFINER_POOL_HPP
 
-#include "quantity_communicator.hpp"
+#include "communicator.hpp"
 
-#include <SAMRAI/hier/RefineOperator.h>
 
 #include <map>
 #include <memory>
@@ -17,6 +16,7 @@ namespace amr
 {
     enum class RefinerType {
         GhostField,
+        PatchGhostField,
         InitField,
         InitInteriorPart,
         LevelBorderParticles,
@@ -26,8 +26,8 @@ namespace amr
 
 
     /**
-     * @brief The Communicators class is used by a Messenger to manipulate SAMRAI algorithms and
-     * schedules It contains a QuantityCommunicator for all quantities registered to the Messenger
+     * @brief The RefinerPool class is used by a Messenger to manipulate SAMRAI algorithms and
+     * schedules It contains a Refiner for all quantities registered to the Messenger
      * for ghost, init etc.
      */
     template<RefinerType Type>
@@ -35,28 +35,41 @@ namespace amr
     {
     public:
         /**
-         * @brief add a QuantityCommunicator to the communicators based on the given Descriptor and
-         * the refinement operator refineOp. The method uses the ResourcesManager to check the
-         * quantities in the Descriptor are properly registered. The created QuantityCommunicator is
-         * associated with the given key.
-         *
+         * @brief add a Refiner to the pool based on the given Descriptor and
+         * the refinement operator refineOp.
          * This overload is used for communications that do not use time interpolation
          */
         template<typename Descriptor, typename ResourcesManager>
-        void add(Descriptor const& descriptor,
-                 std::shared_ptr<SAMRAI::hier::RefineOperator> const& refineOp,
-                 std::string const key, std::shared_ptr<ResourcesManager> const& rm)
+        void addStaticRefiner(Descriptor const& ghostDesc, Descriptor const& srcDesc,
+                              std::shared_ptr<SAMRAI::hier::RefineOperator> const& refineOp,
+                              std::string const key, std::shared_ptr<ResourcesManager> const& rm,
+                              bool ghosts = false)
         {
             auto const [it, success]
-                = refiners_.insert({key, makeRefiner(descriptor, rm, refineOp)});
+                = refiners_.insert({key, makeRefiner(ghostDesc, srcDesc, rm, refineOp, ghosts)});
 
             if (!success)
                 throw std::runtime_error(key + " is already registered");
         }
 
+        /**
+         * @brief convenience overload of above addStaticRefiner taking only one descriptor.
+         * used for communications from a quantity to the same quantity.
+         */
+        template<typename Descriptor, typename ResourcesManager>
+        void addStaticRefiner(Descriptor const& descriptor,
+                              std::shared_ptr<SAMRAI::hier::RefineOperator> const& refineOp,
+                              std::string const key, std::shared_ptr<ResourcesManager> const& rm,
+                              bool ghosts = false)
+        {
+            addStaticRefiner(descriptor, descriptor, refineOp, key, rm, ghosts);
+        }
+
+
 
         /**
-         * @brief add a QuantityCommunicator to the Communicators based on the given descroptors and
+         * @brief  Add a Refiner
+         * add a QuantityCommunicator to the Communicators based on the given descriptors and
          * spatial refinement operator and time interpolation operator. The created
          * QuantityCommunicator is associated with the given key.
          *
@@ -64,12 +77,13 @@ namespace amr
          * are only for ghost nodes, which is only for VecField E and B.
          */
         template<typename ResourcesManager>
-        void
-        add(VecFieldDescriptor const& ghostDescriptor, VecFieldDescriptor const& modelDescriptor,
-            VecFieldDescriptor const& oldModelDescriptor,
-            std::shared_ptr<ResourcesManager> const& rm,
-            std::shared_ptr<SAMRAI::hier::RefineOperator> const& refineOp,
-            std::shared_ptr<SAMRAI::hier::TimeInterpolateOperator> const& timeOp, std::string key)
+        void addTimeRefiner(VecFieldDescriptor const& ghostDescriptor,
+                            VecFieldDescriptor const& modelDescriptor,
+                            VecFieldDescriptor const& oldModelDescriptor,
+                            std::shared_ptr<ResourcesManager> const& rm,
+                            std::shared_ptr<SAMRAI::hier::RefineOperator> const& refineOp,
+                            std::shared_ptr<SAMRAI::hier::TimeInterpolateOperator> const& timeOp,
+                            std::string key)
         {
             auto const [it, success]
                 = refiners_.insert({key, makeRefiner(ghostDescriptor, modelDescriptor,
@@ -79,6 +93,21 @@ namespace amr
         }
 
 
+        template<typename ResourcesManager>
+        void addTimeRefiner(FieldDescriptor const& ghostDescriptor,
+                            FieldDescriptor const& modelDescriptor,
+                            FieldDescriptor const& oldModelDescriptor,
+                            std::shared_ptr<ResourcesManager> const& rm,
+                            std::shared_ptr<SAMRAI::hier::RefineOperator> const& refineOp,
+                            std::shared_ptr<SAMRAI::hier::TimeInterpolateOperator> const& timeOp,
+                            std::string key)
+        {
+            auto const [it, success]
+                = refiners_.insert({key, makeRefiner(ghostDescriptor, modelDescriptor,
+                                                     oldModelDescriptor, rm, refineOp, timeOp)});
+            if (!success)
+                throw std::runtime_error(key + " is already registered");
+        }
 
 
         /**
@@ -124,6 +153,13 @@ namespace amr
                             algo->createSchedule(level, level->getNextCoarserHierarchyLevelNumber(),
                                                  hierarchy),
                             levelNumber);
+                    }
+
+                    // the following schedule will only fill patch ghost nodes
+                    // not level border ghosts
+                    else if constexpr (Type == RefinerType::PatchGhostField)
+                    {
+                        refiner.add(algo, algo->createSchedule(level), levelNumber);
                     }
 
                     // this createSchedule overload is used to initialize fields.
@@ -279,65 +315,6 @@ namespace amr
     };
 
 
-
-
-    template<std::size_t dimension>
-    class SynchronizerPool
-    {
-    public:
-        template<typename Descriptor, typename ResourcesManager>
-        void add(Descriptor const& descriptor,
-                 std::shared_ptr<SAMRAI::hier::CoarsenOperator> const& coarsenOp, std::string key,
-                 std::shared_ptr<ResourcesManager> const& rm)
-        {
-            synchronizers_.insert(
-                {key, makeSynchronizer<ResourcesManager, dimension>(descriptor, rm, coarsenOp)});
-        }
-
-
-
-
-        template<typename ResourcesManager>
-        void add(VecFieldDescriptor const& descriptor, std::shared_ptr<ResourcesManager> const& rm,
-                 std::shared_ptr<SAMRAI::hier::CoarsenOperator> const& coarsenOp, std::string key)
-        {
-            auto const [it, success] = synchronizers_.insert(
-                {key, makeSynchronizer<ResourcesManager, dimension>(descriptor, rm, coarsenOp)});
-
-            if (!success)
-                throw std::runtime_error(key + " is already registered");
-        }
-
-
-
-        void registerLevel(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
-                           std::shared_ptr<SAMRAI::hier::PatchLevel> const& level)
-        {
-            auto levelNumber        = level->getLevelNumber();
-            auto const& coarseLevel = hierarchy->getPatchLevel(levelNumber - 1);
-
-            for (auto& [_, synchronizer] : synchronizers_)
-                for (auto& algo : synchronizer.algos)
-                    synchronizer.add(algo, algo->createSchedule(coarseLevel, level), levelNumber);
-        }
-
-
-
-        void sync(int const levelNumber)
-        {
-            for (auto& [key, synchronizer] : synchronizers_)
-            {
-                if (synchronizer.algos.size() == 0)
-                    throw std::runtime_error("Algorithms are not configured");
-
-                for (auto const& algo : synchronizer.algos)
-                    synchronizer.findSchedule(algo, levelNumber)->coarsenData();
-            }
-        }
-
-    private:
-        std::map<std::string, Communicator<Synchronizer, dimension>> synchronizers_;
-    };
 
 
 } // namespace amr

--- a/src/amr/messengers/synchronizer_pool.hpp
+++ b/src/amr/messengers/synchronizer_pool.hpp
@@ -1,0 +1,75 @@
+#ifndef PHARE_SYNCHRONIZER_POOL_HPP
+#define PHARE_SYNCHRONIZER_POOL_HPP
+
+#include "communicator.hpp"
+
+
+
+namespace PHARE::amr
+{
+
+
+template<std::size_t dimension>
+class SynchronizerPool
+{
+public:
+    template<typename Descriptor, typename ResourcesManager>
+    void add(Descriptor const& descriptor,
+             std::shared_ptr<SAMRAI::hier::CoarsenOperator> const& coarsenOp, std::string key,
+             std::shared_ptr<ResourcesManager> const& rm)
+    {
+        // check if key is in synchronizers_
+        auto const [it, success] = synchronizers_.insert(
+            {key, makeSynchronizer<ResourcesManager, dimension>(descriptor, rm, coarsenOp)});
+        if (!success)
+            throw std::runtime_error(key + " is already registered");
+    }
+
+
+
+
+    template<typename ResourcesManager>
+    void add(VecFieldDescriptor const& descriptor, std::shared_ptr<ResourcesManager> const& rm,
+             std::shared_ptr<SAMRAI::hier::CoarsenOperator> const& coarsenOp, std::string key)
+    {
+        auto const [it, success] = synchronizers_.insert(
+            {key, makeSynchronizer<ResourcesManager, dimension>(descriptor, rm, coarsenOp)});
+
+        if (!success)
+            throw std::runtime_error(key + " is already registered");
+    }
+
+
+
+    void registerLevel(std::shared_ptr<SAMRAI::hier::PatchHierarchy> const& hierarchy,
+                       std::shared_ptr<SAMRAI::hier::PatchLevel> const& level)
+    {
+        auto levelNumber        = level->getLevelNumber();
+        auto const& coarseLevel = hierarchy->getPatchLevel(levelNumber - 1);
+
+        for (auto& [_, synchronizer] : synchronizers_)
+            for (auto& algo : synchronizer.algos)
+                synchronizer.add(algo, algo->createSchedule(coarseLevel, level), levelNumber);
+    }
+
+
+
+    void sync(int const levelNumber)
+    {
+        for (auto& [key, synchronizer] : synchronizers_)
+        {
+            if (synchronizer.algos.size() == 0)
+                throw std::runtime_error("Algorithms are not configured");
+
+            for (auto const& algo : synchronizer.algos)
+                synchronizer.findSchedule(algo, levelNumber)->coarsenData();
+        }
+    }
+
+private:
+    std::map<std::string, Communicator<Synchronizer, dimension>> synchronizers_;
+};
+
+
+} // namespace PHARE::amr
+#endif

--- a/src/amr/multiphysics_integrator.hpp
+++ b/src/amr/multiphysics_integrator.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_MULTIPHYSICS_INTEGRATOR_HPP
 #define PHARE_MULTIPHYSICS_INTEGRATOR_HPP
 
@@ -49,7 +48,10 @@ namespace solver
     };
 
 
-    inline bool isRootLevel(int levelNumber) { return levelNumber == 0; }
+    inline bool isRootLevel(int levelNumber)
+    {
+        return levelNumber == 0;
+    }
 
 
     /**

--- a/src/amr/physical_models/hybrid_model.hpp
+++ b/src/amr/physical_models/hybrid_model.hpp
@@ -1,6 +1,3 @@
-
-
-
 #ifndef PHARE_HYBRID_MODEL_HPP
 #define PHARE_HYBRID_MODEL_HPP
 
@@ -150,12 +147,12 @@ void HybridModel<GridLayoutT, Electromag, Ions, Electrons, AMR_Types>::fillMesse
     modelInfo.modelIonBulkVelocity = amr::VecFieldDescriptor{state.ions.velocity()};
     modelInfo.modelCurrent         = amr::VecFieldDescriptor{state.J};
 
-    modelInfo.initElectric.emplace_back(state.electromag.E);
-    modelInfo.initMagnetic.emplace_back(state.electromag.B);
+    modelInfo.initElectric.emplace_back(amr::VecFieldDescriptor{state.electromag.E});
+    modelInfo.initMagnetic.emplace_back(amr::VecFieldDescriptor{state.electromag.B});
 
     modelInfo.ghostElectric.push_back(modelInfo.modelElectric);
     modelInfo.ghostMagnetic.push_back(modelInfo.modelMagnetic);
-    modelInfo.ghostCurrent.push_back(state.J);
+    modelInfo.ghostCurrent.push_back(amr::VecFieldDescriptor{state.J});
     modelInfo.ghostBulkVelocity.push_back(modelInfo.modelIonBulkVelocity);
 
 

--- a/src/core/data/field/field.hpp
+++ b/src/core/data/field/field.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_CORE_DATA_FIELD_FIELD_BASE_HPP
 #define PHARE_CORE_DATA_FIELD_FIELD_BASE_HPP
 
@@ -34,10 +33,10 @@ namespace core
         using NdArrayImpl::dimension;
 
 
-        Field()                    = delete;
-        Field(Field const& source) = delete;
-        Field(Field&& source)      = default;
-        Field& operator=(Field&& source) = delete;
+        Field()                               = delete;
+        Field(Field const& source)            = delete;
+        Field(Field&& source)                 = default;
+        Field& operator=(Field&& source)      = delete;
         Field& operator=(Field const& source) = delete;
 
         template<typename... Dims>

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -37,7 +37,10 @@ namespace core
     constexpr bool has_physicalQuantity_v = has_physicalQuantity<T>::value;
 
 
-    constexpr int centering2int(QtyCentering c) { return static_cast<int>(c); }
+    constexpr int centering2int(QtyCentering c)
+    {
+        return static_cast<int>(c);
+    }
 
 
     template<std::size_t interpOrder>
@@ -1140,6 +1143,15 @@ namespace core
             evalOnBox_(field, fn, indices);
         }
 
+        template<typename Field, typename Fn>
+        void evalOnGhostBox(Field& field, Fn&& fn) const
+        {
+            auto indices = [&](auto const& centering, auto const direction) {
+                return this->ghostStartToEnd(centering, direction);
+            };
+
+            evalOnBox_(field, fn, indices);
+        }
 
 
     private:

--- a/src/core/logger.hpp
+++ b/src/core/logger.hpp
@@ -1,4 +1,3 @@
-
 #ifndef PHARE_CORE_LOGGER_HPP
 #define PHARE_CORE_LOGGER_HPP
 

--- a/src/core/numerics/faraday/faraday.hpp
+++ b/src/core/numerics/faraday/faraday.hpp
@@ -39,9 +39,12 @@ public:
         auto& Bynew = Bnew(Component::Y);
         auto& Bznew = Bnew(Component::Z);
 
-        layout_->evalOnBox(Bxnew, [&](auto&... args) mutable { BxEq_(Bx, E, Bxnew, args...); });
-        layout_->evalOnBox(Bynew, [&](auto&... args) mutable { ByEq_(By, E, Bynew, args...); });
-        layout_->evalOnBox(Bznew, [&](auto&... args) mutable { BzEq_(Bz, E, Bznew, args...); });
+        layout_->evalOnGhostBox(Bxnew,
+                                [&](auto&... args) mutable { BxEq_(Bx, E, Bxnew, args...); });
+        layout_->evalOnGhostBox(Bynew,
+                                [&](auto&... args) mutable { ByEq_(By, E, Bynew, args...); });
+        layout_->evalOnGhostBox(Bznew,
+                                [&](auto&... args) mutable { BzEq_(Bz, E, Bznew, args...); });
     }
 
 

--- a/tests/amr/data/field/coarsening/test_coarsen_field.py
+++ b/tests/amr/data/field/coarsening/test_coarsen_field.py
@@ -4,14 +4,15 @@
 
 import os
 import sys
-import numpy as np
 
-from pyphare.core.box import Box
+import numpy as np
 import pyphare.core.box as boxm
 from pyphare.core import gridlayout
+from pyphare.core.box import Box
 from pyphare.core.gridlayout import directions
 from pyphare.core.phare_utilities import refinement_ratio
 from pyphare.pharesee.hierarchy import FieldData
+
 
 def exec_fn(xyz, fn):
     ndim = len(xyz)
@@ -69,7 +70,7 @@ def dump(ndim, path, quantity):
         afterCoarse = np.copy(coarse)
 
         coarseField = FieldData(coarseLayout, quantity, data=coarse)
-        fineField   = FieldData(fineLayout, quantity, data=fine)
+        fineField = FieldData(fineLayout, quantity, data=fine)
         coarsen(quantity, coarseField, fineField, coarseBox, fine, afterCoarse)
 
         if fn_idx == 0:
@@ -91,7 +92,6 @@ def dump(ndim, path, quantity):
         np.savetxt(os.path.join(path, filename), data, delimiter=" ")
 
 
-
 def main(path="./"):
 
     if len(sys.argv) > 1:
@@ -103,15 +103,10 @@ def main(path="./"):
                 dump(ndim, path, EM + qty)
 
 
-
 def coarsen(qty, coarseField, fineField, coarseBox, fineData, coarseData):
     coarseLayout = coarseField.layout
     fineLayout = fineField.layout
     ndim = coarseLayout.box.ndim
-
-    nGhosts = coarseLayout.nbrGhostFor(qty)
-    coarseStartIndex = coarseLayout.physicalStartIndices(qty)
-    fineOffset = fineLayout.box.lower - boxm.refine(coarseLayout.box, 2).lower
 
     is_primal = []
     for direction in directions[:ndim]:
@@ -131,12 +126,18 @@ def coarsen(qty, coarseField, fineField, coarseBox, fineData, coarseData):
             fineIndex = fineLocal(index, 0)
             coarseLocalIndex = coarseLocal(index, 0)
             if is_primal[0]:
-                coarseData[coarseLocalIndex] = (
-                    fineData[fineIndex - 1] * .25 + fineData[fineIndex] * .5 + fineData[fineIndex + 1] * .25
-                )
+                if qty == "Bx":
+                    coarseData[coarseLocalIndex] = fineData[fineIndex]
+                else:
+                    coarseData[coarseLocalIndex] = (
+                        fineData[fineIndex - 1] * 0.25
+                        + fineData[fineIndex] * 0.5
+                        + fineData[fineIndex + 1] * 0.25
+                    )
             else:
+                # ind 1D it is the same formula for By and Bz as for other quantities
                 coarseData[coarseLocalIndex] = (
-                    fineData[fineIndex] * .5 + fineData[fineIndex + 1] * .5
+                    fineData[fineIndex] * 0.5 + fineData[fineIndex + 1] * 0.5
                 )
 
     if ndim == 2:
@@ -149,46 +150,70 @@ def coarsen(qty, coarseField, fineField, coarseBox, fineData, coarseData):
                 coarseLocalIndexY = coarseLocal(indexY, 1)
                 left, middle, right = 0, 0, 0
                 if all(is_primal):
-                    left += fineData[fineIndexX - 1][fineIndexY - 1]  * .25
-                    left += fineData[fineIndexX - 1][fineIndexY]      * .5
-                    left += fineData[fineIndexX - 1][fineIndexY + 1]  * .25
-                    middle += fineData[fineIndexX][fineIndexY - 1]    * .25
-                    middle += fineData[fineIndexX][fineIndexY]        * .5
-                    middle += fineData[fineIndexX][fineIndexY + 1]    * .25
-                    right += fineData[fineIndexX + 1][fineIndexY - 1] * .25
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .25
+                    left += fineData[fineIndexX - 1][fineIndexY - 1] * 0.25
+                    left += fineData[fineIndexX - 1][fineIndexY] * 0.5
+                    left += fineData[fineIndexX - 1][fineIndexY + 1] * 0.25
+                    middle += fineData[fineIndexX][fineIndexY - 1] * 0.25
+                    middle += fineData[fineIndexX][fineIndexY] * 0.5
+                    middle += fineData[fineIndexX][fineIndexY + 1] * 0.25
+                    right += fineData[fineIndexX + 1][fineIndexY - 1] * 0.25
+                    right += fineData[fineIndexX + 1][fineIndexY] * 0.5
+                    right += fineData[fineIndexX + 1][fineIndexY + 1] * 0.25
                     coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
-                        left * .25 + middle * .5 + right * .25
+                        left * 0.25 + middle * 0.5 + right * 0.25
                     )
 
                 if is_primal[0] and not is_primal[1]:
-                    left += fineData[fineIndexX - 1][fineIndexY]      * .5
-                    left += fineData[fineIndexX - 1][fineIndexY + 1]  * .5
-                    middle += fineData[fineIndexX][fineIndexY]        * .5
-                    middle += fineData[fineIndexX][fineIndexY + 1]    * .5
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .5
-                    coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
-                        left * .25 + middle * .5 + right * .25
-                    )
+                    if qty == "Bx":
+                        coarseData[coarseLocalIndexX, coarseLocalIndexY] = 0.5 * (
+                            fineData[fineIndexX, fineIndexY]
+                            + fineData[fineIndexX, fineIndexY + 1]
+                        )
+                    else:
+                        left += fineData[fineIndexX - 1][fineIndexY] * 0.5
+                        left += fineData[fineIndexX - 1][fineIndexY + 1] * 0.5
+                        middle += fineData[fineIndexX][fineIndexY] * 0.5
+                        middle += fineData[fineIndexX][fineIndexY + 1] * 0.5
+                        right += fineData[fineIndexX + 1][fineIndexY] * 0.5
+                        right += fineData[fineIndexX + 1][fineIndexY + 1] * 0.5
+                        coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
+                            left * 0.25 + middle * 0.5 + right * 0.25
+                        )
 
                 if not is_primal[0] and is_primal[1]:
-                    left += fineData[fineIndexX][fineIndexY - 1]      * .25
-                    left += fineData[fineIndexX][fineIndexY]          * .5
-                    left += fineData[fineIndexX][fineIndexY + 1]      * .25
-                    right += fineData[fineIndexX + 1][fineIndexY - 1] * .25
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .25
-                    coarseData[coarseLocalIndexX][coarseLocalIndexY] = (left * .5 + right * .5)
+                    if qty == "By":
+                        coarseData[coarseLocalIndexX, coarseLocalIndexY] = 0.5 * (
+                            fineData[fineIndexX, fineIndexY]
+                            + fineData[fineIndexX + 1, fineIndexY]
+                        )
+
+                    else:
+                        left += fineData[fineIndexX][fineIndexY - 1] * 0.25
+                        left += fineData[fineIndexX][fineIndexY] * 0.5
+                        left += fineData[fineIndexX][fineIndexY + 1] * 0.25
+                        right += fineData[fineIndexX + 1][fineIndexY - 1] * 0.25
+                        right += fineData[fineIndexX + 1][fineIndexY] * 0.5
+                        right += fineData[fineIndexX + 1][fineIndexY + 1] * 0.25
+                        coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
+                            left * 0.5 + right * 0.5
+                        )
 
                 if not any(is_primal):
-                    left += fineData[fineIndexX][fineIndexY]          * .5
-                    left += fineData[fineIndexX][fineIndexY + 1]      * .5
-                    right += fineData[fineIndexX + 1][fineIndexY]     * .5
-                    right += fineData[fineIndexX + 1][fineIndexY + 1] * .5
-                    coarseData[coarseLocalIndexX][coarseLocalIndexY] = (left * .5 + right * .5)
-
+                    if qty == "Bz":
+                        coarseData[coarseLocalIndexX, coarseLocalIndexY] = 0.25 * (
+                            fineData[fineIndexX, fineIndexY]
+                            + fineData[fineIndexX, fineIndexY + 1]
+                            + fineData[fineIndexX + 1, fineIndexY + 1]
+                            + fineData[fineIndexX + 1, fineIndexY]
+                        )
+                    else:
+                        left += fineData[fineIndexX][fineIndexY] * 0.5
+                        left += fineData[fineIndexX][fineIndexY + 1] * 0.5
+                        right += fineData[fineIndexX + 1][fineIndexY] * 0.5
+                        right += fineData[fineIndexX + 1][fineIndexY + 1] * 0.5
+                        coarseData[coarseLocalIndexX][coarseLocalIndexY] = (
+                            left * 0.5 + right * 0.5
+                        )
 
 
 if __name__ == "__main__":

--- a/tests/amr/data/field/refine/test_field_refine.cpp
+++ b/tests/amr/data/field/refine/test_field_refine.cpp
@@ -77,7 +77,7 @@ TYPED_TEST(aFieldRefineOperator, canBeCreated)
     using GridYee = GridLayout<GridLayoutImplYee<dim, interp>>;
     using FieldT  = Field<NdArrayVector<dim>, HybridQuantity::Scalar>;
 
-    FieldRefineOperator<GridYee, FieldT> linearRefine{};
+    FieldRefineOperator<GridYee, FieldT, DefaultFieldRefiner<dim>> linearRefine{};
 }
 
 
@@ -103,7 +103,8 @@ TYPED_TEST(aFieldRefine, canBeCreated)
     SAMRAI::hier::Box sourceGhostBox{dimension};
     SAMRAI::hier::IntVector ratio{dimension, 2};
 
-    FieldRefiner<dim> fieldLinearRefine{centering, destinationGhostBox, sourceGhostBox, ratio};
+    DefaultFieldRefiner<dim> fieldLinearRefine{centering, destinationGhostBox, sourceGhostBox,
+                                               ratio};
 }
 
 

--- a/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.hpp
+++ b/tests/amr/data/field/refine/test_field_refinement_on_hierarchy.hpp
@@ -4,6 +4,7 @@
 
 #include "amr/data/field/field_variable.hpp"
 #include "amr/data/field/refine/field_refine_operator.hpp"
+#include "amr/data/field/refine/field_refiner.hpp"
 #include "core/data/grid/gridlayout.hpp"
 #include "test_tag_strategy.hpp"
 
@@ -104,7 +105,8 @@ public:
               dimension_, "ChopAndPackLoadBalancer",
               inputDatabase_->getDatabase("ChopAndPackLoadBalancer"))}
 
-        , refineOperator_{std::make_shared<FieldRefineOperator<GridLayoutT, FieldT>>()}
+        , refineOperator_{std::make_shared<
+              FieldRefineOperator<GridLayoutT, FieldT, DefaultFieldRefiner<dimension>>>()}
 
 
         , tagStrategy_{std::make_shared<TagStrategy<GridLayoutT, FieldT>>(variablesIds_,

--- a/tests/amr/data/field/refine/test_refine_field.py
+++ b/tests/amr/data/field/refine/test_refine_field.py
@@ -5,153 +5,47 @@ from pyphare.core.gridlayout import GridLayout
 from pyphare.core.phare_utilities import refinement_ratio
 from pyphare.pharesee.hierarchy import FieldData
 
+# in this module, we assume the refinement ratio is 2
+refinement_ratio = 2
 
-# assumes refinement_ratio is 2
+# below is a drawing  representing a 1D coarse FieldData, its ghost box and the
+# associated refined  FieldData this module aims at creating.
+# o : coarse primal node
+# + : fine primal node
+# * : fine primal nodes created for simplicity of the refinement algorithm but
+#     which are later discarded
+
+#                              Field ghost box
+#     ________________________________________________________________
+#    |                                                                |
+#    v                                                                v
+#                                 Field box
+#                 _________________________________________
+#                |                                         |
+#                v                                         v
+# 0     1     2     3     4     5     6     7     8     9    10    11    12
+#             |                                               |
+# o     o     o     o     o     o     o     o     o     o     o     o     o
+#             |                                               |
+# *  *  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  +  *  *
+#             |                                               |
+# 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
+#
+#
 
 
-def refine(field, **kwargs):
-    """
-    optional kwargs
-      data : for overriding the field dataset so you don't have to make a temporary copy of a field just to have a different dataset
-    """
-    assert isinstance(field, FieldData)
-    kwarg_keys = ["data"]
-    assert any([key in kwarg_keys for key in list(kwargs.keys())])
-
-    refinement_ratio = 2
-    primal_directions = field.primal_directions()
-
-    data = kwargs.get("data", field.dataset[:])
-    if "data" in kwargs:
-        assert data.shape == field.dataset.shape
-
-    fine_layout = GridLayout(
+def fine_layout_from(field):
+    return GridLayout(
         boxm.refine(field.box, refinement_ratio),
         field.origin,
         field.layout.dl / refinement_ratio,
         interp_order=field.layout.interp_order,
     )
 
-    # fine box has extra ghosts for padding against coarser such that at the normal number of ghosts are filled
-    fine_box = boxm.shrink(
-        boxm.refine(field.ghost_box, refinement_ratio), field.ghosts_nbr
-    )
-    fine_data = np.zeros(fine_box.shape + primal_directions + (field.ghosts_nbr * 2))
 
-    ghostX = field.ghosts_nbr[0]
-    assert ghostX > 1
-
-    cadence = 2
-    assert cadence == refinement_ratio
-
-    gX = 2  # level 0 ghost buffer from edge of normal coarse data box
-    rgX = 4 # level 1 ghost buffer from edge of extra large fine data box
-
-    if field.box.ndim == 1:
-        if primal_directions[0]:
-            # coarse primal on top of fine
-            fine_data[rgX:-rgX:cadence] = data[gX:-gX]
-            fine_data[rgX + 1 : -(rgX - 1) : cadence] = (
-                0.5 * data[gX:-gX] + 0.5 * data[gX + 1 : -(gX - 1)]
-            )
-        else:
-            fine_data[rgX : -(rgX + 1) : cadence] = (
-                0.25 * data[gX - 1 : -(gX + 1)] + 0.75 * data[gX:-gX]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cadence] = (
-                0.25 * data[gX + 1 : -(gX - 1)] + 0.75 * data[gX:-gX]
-            )
-
-    if fine_box.ndim > 1:
-        assert field.ghosts_nbr[1] > 1
-        gY = 2
-        rgY = 4
-        cad = cadence
-
-    if fine_box.ndim == 2:
-        if all(primal_directions):
-            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = data[gX:-gX, gY:-gY]
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = (
-                0.5 * data[gX:-gX, gY:-gY] + 0.5 * data[gX + 1 : -(gX - 1), gY:-gY]
-            )
-            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = (
-                0.5 * data[gX:-gX, gY:-gY] + 0.5 * data[gX:-gX, gY + 1 : -(gY - 1)]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = (
-                0.25 * data[gX:-gX, gY:-gY]
-                + 0.25 * data[gX + 1 : -(gX - 1), gY:-gY]
-                + 0.25 * data[gX:-gX, gY + 1 : -(gY - 1)]
-                + 0.25 * data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
-            )
-
-        elif primal_directions[0] and not primal_directions[1]:
-            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = (
-                0.25 * data[gX:-gX, gY - 1 : -(gY + 1)] + 0.75 * data[gX:-gX, gY:-gY]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = 0.75 * (
-                0.5 * data[gX + 1 : -(gX - 1), gY:-gY] + 0.5 * data[gX:-gX, gY:-gY]
-            ) + 0.25 * (
-                0.5 * data[gX + 1 : -(gX - 1), gY - 1 : -(gY + 1)]
-                + 0.5 * data[gX:-gX, gY - 1 : -(gY + 1)]
-            )
-            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = (
-                0.25 * data[gX:-gX, gY + 1 : -(gY - 1)] + 0.75 * data[gX:-gX, gY:-gY]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = 0.75 * (
-                0.5 * data[gX + 1 : -(gX - 1), gY:-gY] + 0.5 * data[gX:-gX, gY:-gY]
-            ) + 0.25 * (
-                0.5 * data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
-                + 0.5 * data[gX:-gX, gY + 1 : -(gY - 1)]
-            )
-
-        elif not primal_directions[0] and primal_directions[1]:
-            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = (
-                0.25 * data[gX - 1 : -(gX + 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = (
-                0.25 * data[gX + 1 : -(gX - 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            )
-            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = 0.5 * (
-                0.25 * data[gX - 1 : -(gX + 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            ) + 0.5 * (
-                0.25 * data[gX - 1 : -(gX + 1), gY + 1 : -(gY - 1)]
-                + 0.75 * data[gX:-gX, gY + 1 : -(gY - 1)]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = 0.5 * (
-                0.25 * data[gX + 1 : -(gX - 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            ) + 0.5 * (
-                0.25 * data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
-                + 0.75 * data[gX:-gX, gY + 1 : -(gY - 1)]
-            )
-
-        elif not any(primal_directions):
-            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = 0.75 * (
-                0.25 * data[gX - 1 : -(gX + 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            ) + 0.25 * (
-                0.25 * data[gX - 1 : -(gX + 1), gY - 1 : -(gY + 1)]
-                + 0.75 * data[gX:-gX, gY - 1 : -(gY + 1)]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = 0.75 * (
-                0.25 * data[gX + 1 : -(gX - 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            ) + 0.25 * (
-                0.25 * data[gX + 1 : -(gX - 1), gY - 1 : -(gY + 1)]
-                + 0.75 * data[gX:-gX, gY - 1 : -(gY + 1)]
-            )
-            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = 0.75 * (
-                0.25 * data[gX - 1 : -(gX + 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            ) + 0.25 * (
-                0.25 * data[gX - 1 : -(gX + 1), gY + 1 : -(gY - 1)]
-                + 0.75 * data[gX:-gX, gY + 1 : -(gY - 1)]
-            )
-            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = 0.75 * (
-                0.25 * data[gX + 1 : -(gX - 1), gY:-gY] + 0.75 * data[gX:-gX, gY:-gY]
-            ) + 0.25 * (
-                0.25 * data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
-                + 0.75 * data[gX:-gX, gY + 1 : -(gY - 1)]
-            )
-
-
-    # the fine data is ghost_nbr larger than expected to include ghost values from the coarser, so we drop the outer values
+def cropToFieldData(fine_data, field):
+    # reminder: we were working on "fine_data" that covers the whole ghost box of the given coarse field
+    # here we drop the parts of data that are beyond the refined patch ghost box.
     if field.box.ndim == 1:
         fine_data = fine_data[field.ghosts_nbr[0] : -field.ghosts_nbr[0]]
     elif field.box.ndim == 2:
@@ -165,7 +59,297 @@ def refine(field, **kwargs):
             field.ghosts_nbr[1] : -field.ghosts_nbr[1],
             field.ghosts_nbr[2] : -field.ghosts_nbr[2],
         ]
+    fine_layout = fine_layout_from(field)
     return FieldData(fine_layout, field.field_name, data=fine_data)
+
+
+def refine_electric(field, **kwargs):
+    """
+    This function refines the electric field from the given field
+    See electric_field_refiner.hpp for more details on the refinement algo.
+    """
+    fine_data = makeDataset(field, **kwargs)
+    coarse_data = kwargs.get("data", field.dataset[:])
+    if "data" in kwargs:
+        assert coarse_data.shape == field.dataset.shape
+    primal_directions = field.primal_directions()
+
+    if field.box.ndim == 1:
+        # in 1D Ex, Ey and Ey cell edges are on top of coarse cell edges
+        # the algo for electric refinement is that fine edges falling on top of coarse
+        # ones share their value. So here we just take the coarse value whatever the
+        # centering.
+        print(field.field_name)
+        print(field.box.shape)
+        print(field.dataset.shape)
+        fine_data[::2] = coarse_data
+        fine_data[1::2] = coarse_data
+
+    elif field.box.ndim == 2:
+        if primal_directions[0] and not primal_directions[1]:
+            # this is Ex
+            # in 2D along X Ex fine edges are collocate with coarse edges
+            # but along Y only even edges do, ones fall in  between 2 coarse edges
+            # and take the average of their value
+
+            # first do even Y indices
+            # same for even and odd X fine indices
+            fine_data[::2, ::2] = coarse_data[:, :]
+            fine_data[1::2, ::2] = coarse_data[:, :]
+
+            # now odd Y indices take the average of surrounding coarse edges
+            # again, same for odd and even X fine indices
+            fine_data[::2, 1::2] = 0.5 * (coarse_data[:, 1:] + coarse_data[:, :-1])
+            fine_data[1::2, 1::2] = 0.5 * (coarse_data[:, 1:] + coarse_data[:, :-1])
+
+    return cropToFieldData(fine_data, field)
+
+
+def refine_magnetic(field, **kwargs):
+    """
+    This function refines the magnetic field from the given field
+    See magnetic_field_refiner.hpp for more details on the refinement algo.
+    """
+
+    # reminder the "fine_data" we get covers the whole ghost box of the given coarse field
+    fine_data = makeDataset(field, **kwargs)
+
+    coarse_data = kwargs.get("data", field.dataset[:])
+    if "data" in kwargs:
+        assert coarse_data.shape == field.dataset.shape
+
+    primal_directions = field.primal_directions()
+
+    if field.box.ndim == 1:
+        if primal_directions[0]:
+            #  we're primal and 1D so this is Bx
+            # even primal fine nodes fall on top of coarse ones so take the value
+            # odd primal fine nodes fall in the middle of coarse ones so take the average
+            fine_data[::2] = coarse_data
+            fine_data[1::2] = 0.5 * (coarse_data[:-1] + coarse_data[1:])
+
+        else:
+            # we're 1D and dual so this is By or Bz
+            # by flux conservation, fine dual nodes take the same value as the one
+            # of the coarse cell they fall in
+            # this means that the coarse values are  copied in both even and odd fine dual nodes
+            # note that because the refinement ratio is  2 the number of fine cells is always even
+            fine_data[::2] = coarse_data[:]
+            fine_data[1::2] = fine_data[::2]
+
+    elif field.box.ndim == 2:
+        if primal_directions[0] and not primal_directions[1]:
+            # this is Bx. even x faces fall on top of coarse x faces
+            # the coarse face value is copied into even and odd fine faces
+            fine_data[::2, ::2] = coarse_data[:, :]
+            fine_data[::2, 1::2] = coarse_data[:, :]
+
+            # odd x faces are in the middle of coarse x faces
+            # and  take the average of their flux
+            # as before the coarse face values are just copied into fine odd and even faces along y
+            fine_data[1::2, ::2] = 0.5 * (coarse_data[:-1:, :] + coarse_data[1:, :])
+            fine_data[1::2, 1::2] = fine_data[1::2, ::2]
+
+        elif not primal_directions[0] and primal_directions[1]:
+            # this is now By
+            # even y indices fall on top of coarse faces so just take their value
+            # copy the coarse value to odd and even x fine indices
+            fine_data[::2, ::2] = coarse_data[:, :]
+            fine_data[1::2, ::2] = fine_data[::2, ::2]
+
+            # now odd y indices  are fine faces falling in between coarse faces
+            # so we need to average the surrounding coarse faces in the y direction
+            # as before we do that for even and odd x indices
+            fine_data[::2, 1::2] = 0.5 * (coarse_data[:, 1:] + coarse_data[:, :-1])
+            fine_data[1::2, 1::2] = fine_data[::2, 1::2]
+
+        elif not all(primal_directions):
+            # all directions are dual, this is Bz
+            # Bz is easy since all 4 fine faces take the same value as the coarse one
+            # and since we are in 2D the fine face is always colocated with the coarse one
+            fine_data[::2, ::2] = coarse_data[:, :]
+            fine_data[::2, 1::2] = fine_data[::2, ::2]
+            fine_data[1::2, ::2] = fine_data[::2, ::2]
+            fine_data[1::2, 1::2] = fine_data[::2, ::2]
+
+        else:
+            raise RuntimeError("impossible layout for a magnetic field")
+
+    return cropToFieldData(fine_data, field)
+
+
+def makeDataset(field, **kwargs):
+    """
+    this function returns the dataset for a refined field given a FieldData
+
+    This is done by refining the coarse field given as argument over its whole
+    ghost box and then crop it to obtain the final fine field.
+
+    in the drawing above, this means that the  fine data is computed on the * and +
+    nodes (here for primal)
+
+    """
+    assert isinstance(field, FieldData)
+    kwarg_keys = ["data"]
+    assert any([key in kwarg_keys for key in list(kwargs.keys())])
+
+    refinement_ratio = 2
+    primal_directions = field.primal_directions()
+
+    # fine box has extra ghosts for padding against coarser such that at the normal number of ghosts are filled
+    fine_box = boxm.shrink(
+        boxm.refine(field.ghost_box, refinement_ratio), field.ghosts_nbr
+    )
+    fine_data = np.zeros(fine_box.shape + primal_directions + (field.ghosts_nbr * 2))
+
+    return fine_data
+
+
+def default_refine(field, **kwargs):
+    """
+    This function returns a FieldData refined from the given field, and which
+    domain overlaps the domain of the given field.
+
+    this refinement is the "default" refinement, not used for the electric or
+    magnetic field.
+
+    optional kwargs
+      data : for overriding the field dataset so you don't have to make a temporary copy of a field just to have a different dataset
+    """
+
+    # reminder the "fine_data" we get covers the whole ghost box of the given coarse field
+    fine_data = makeDataset(field, **kwargs)
+    ghostX = field.ghosts_nbr[0]
+    assert ghostX > 1
+
+    coarse_data = kwargs.get("data", field.dataset[:])
+    if "data" in kwargs:
+        assert coarse_data.shape == field.dataset.shape
+
+    cadence = 2
+    assert cadence == refinement_ratio
+    primal_directions = field.primal_directions()
+
+    gX = 2  # level 0 ghost buffer from edge of normal coarse data box
+    rgX = 4  # level 1 ghost buffer from edge of extra large fine data box
+
+    if field.box.ndim == 1:
+        if primal_directions[0]:
+            # coarse primal on top of fine
+            fine_data[rgX:-rgX:cadence] = coarse_data[gX:-gX]
+            fine_data[rgX + 1 : -(rgX - 1) : cadence] = (
+                0.5 * coarse_data[gX:-gX] + 0.5 * coarse_data[gX + 1 : -(gX - 1)]
+            )
+        else:
+            fine_data[rgX : -(rgX + 1) : cadence] = (
+                0.25 * coarse_data[gX - 1 : -(gX + 1)] + 0.75 * coarse_data[gX:-gX]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cadence] = (
+                0.25 * coarse_data[gX + 1 : -(gX - 1)] + 0.75 * coarse_data[gX:-gX]
+            )
+
+    if field.box.ndim == 2:
+        assert field.ghosts_nbr[1] > 1
+        gY = 2
+        rgY = 4
+        cad = cadence
+
+        if all(primal_directions):
+            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = coarse_data[gX:-gX, gY:-gY]
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = (
+                0.5 * coarse_data[gX:-gX, gY:-gY]
+                + 0.5 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+            )
+            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = (
+                0.5 * coarse_data[gX:-gX, gY:-gY]
+                + 0.5 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = (
+                0.25 * coarse_data[gX:-gX, gY:-gY]
+                + 0.25 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.25 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+                + 0.25 * coarse_data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
+            )
+
+        elif primal_directions[0] and not primal_directions[1]:
+            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = (
+                0.25 * coarse_data[gX:-gX, gY - 1 : -(gY + 1)]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = 0.75 * (
+                0.5 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.5 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.25 * (
+                0.5 * coarse_data[gX + 1 : -(gX - 1), gY - 1 : -(gY + 1)]
+                + 0.5 * coarse_data[gX:-gX, gY - 1 : -(gY + 1)]
+            )
+            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = (
+                0.25 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = 0.75 * (
+                0.5 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.5 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.25 * (
+                0.5 * coarse_data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
+                + 0.5 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+            )
+
+        elif not primal_directions[0] and primal_directions[1]:
+            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            )
+            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = 0.5 * (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.5 * (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY + 1 : -(gY - 1)]
+                + 0.75 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = 0.5 * (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.5 * (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
+                + 0.75 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+            )
+
+        elif not any(primal_directions):
+            fine_data[rgX:-rgX:cad, rgY:-rgY:cad] = 0.75 * (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.25 * (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY - 1 : -(gY + 1)]
+                + 0.75 * coarse_data[gX:-gX, gY - 1 : -(gY + 1)]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY:-rgY:cad] = 0.75 * (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.25 * (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY - 1 : -(gY + 1)]
+                + 0.75 * coarse_data[gX:-gX, gY - 1 : -(gY + 1)]
+            )
+            fine_data[rgX:-rgX:cad, rgY + 1 : -(rgY - 1) : cad] = 0.75 * (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.25 * (
+                0.25 * coarse_data[gX - 1 : -(gX + 1), gY + 1 : -(gY - 1)]
+                + 0.75 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+            )
+            fine_data[rgX + 1 : -(rgX - 1) : cad, rgY + 1 : -(rgY - 1) : cad] = 0.75 * (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY:-gY]
+                + 0.75 * coarse_data[gX:-gX, gY:-gY]
+            ) + 0.25 * (
+                0.25 * coarse_data[gX + 1 : -(gX - 1), gY + 1 : -(gY - 1)]
+                + 0.75 * coarse_data[gX:-gX, gY + 1 : -(gY - 1)]
+            )
+
+    return cropToFieldData(fine_data, field)
 
 
 def refine_time_interpolate(
@@ -196,6 +380,13 @@ def refine_time_interpolate(
     assert len(coarse_before_patches) == len(coarse_after_patches)
 
     for qty in quantities:
+        if qty[0] == "B":
+            refine_algo = refine_magnetic
+        elif qty[0] == "E":
+            refine_algo = refine_electric
+        else:
+            refine_algo = default_refine
+
         for fine_subcycle_time in fine_subcycle_times:
             interpolated_fields[qty][fine_subcycle_time] = []
             for coarsePatch_idx in range(len(coarse_before_patches)):
@@ -205,7 +396,7 @@ def refine_time_interpolate(
                 coarseBefore_pd = coarse_before_patch.patch_datas[qty]
                 coarseAfter_pd = coarse_after_patch.patch_datas[qty]
                 interpolated_fields[qty][fine_subcycle_time] += [
-                    refine(
+                    refine_algo(
                         coarseBefore_pd,
                         data=time_interpolate(
                             coarsest_time_before,

--- a/tests/core/data/maxwellian_particle_initializer/test_maxwellian_particle_initializer.cpp
+++ b/tests/core/data/maxwellian_particle_initializer/test_maxwellian_particle_initializer.cpp
@@ -1,4 +1,3 @@
-
 #include <type_traits>
 
 
@@ -62,7 +61,6 @@ TEST_F(AMaxwellianParticleInitializer1D, loadsTheCorrectNbrOfParticles)
 TEST_F(AMaxwellianParticleInitializer1D, loadsParticlesInTheDomain)
 {
     initializer->loadParticles(particles, layout);
-    auto i = 0u;
     for (auto const& particle : particles)
     {
         EXPECT_TRUE(particle.iCell[0] >= 50 && particle.iCell[0] <= 99);
@@ -72,7 +70,6 @@ TEST_F(AMaxwellianParticleInitializer1D, loadsParticlesInTheDomain)
         if (!((pos[0] > 0.) and (pos[0] < endDomain)))
             std::cout << "position : " << pos[0] << " not in domain (0," << endDomain << ")\n";
         EXPECT_TRUE(pos[0] > 0. && pos[0] < endDomain);
-        i++;
     }
 }
 

--- a/tests/simulator/advance/test_fields_advance_1d.py
+++ b/tests/simulator/advance/test_fields_advance_1d.py
@@ -20,66 +20,96 @@ interp_orders = [1, 2, 3]
 def per_interp(dic):
     return [(interp, dic) for interp in interp_orders]
 
+
 @ddt
 class AdvanceTest(AdvanceTestBase):
-
     @data(
-      *per_interp({}),
-      *per_interp({"L0": [Box1D(10, 19)]}),
-      *per_interp({"L0": [Box1D(8, 20)]}),
+        *per_interp({}),
+        *per_interp({"L0": [Box1D(10, 19)]}),
+        *per_interp({"L0": [Box1D(8, 20)]}),
     )
     @unpack
     def test_overlaped_fields_are_equal(self, interp_order, refinement_boxes):
         print(f"{self._testMethodName}_{ndim}d")
-        time_step_nbr=3
-        time_step=0.001
-        diag_outputs=f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
-        datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", diag_outputs=diag_outputs,
-                                  time_step=time_step, time_step_nbr=time_step_nbr, ndim=ndim)
+        time_step_nbr = 3
+        time_step = 0.001
+        diag_outputs = f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
+        datahier = self.getHierarchy(
+            interp_order,
+            refinement_boxes,
+            "eb",
+            diag_outputs=diag_outputs,
+            time_step=time_step,
+            time_step_nbr=time_step_nbr,
+            ndim=ndim,
+        )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 
-
     @data(
-      *per_interp({}),
-      *per_interp({"L0": [Box1D(10, 19)]}),
+        *per_interp({}),
+        *per_interp({"L0": [Box1D(10, 19)]}),
     )
     @unpack
-    def test_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts(self, interp_order, refinement_boxes):
+    def test_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts(
+        self, interp_order, refinement_boxes
+    ):
         print(f"{self._testMethodName}_{ndim}d")
-        time_step_nbr=3
-        time_step=0.001
+        time_step_nbr = 3
+        time_step = 0.001
         from pyphare.pharein.simulation import check_patch_size
-        diag_outputs=f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts/{ndim}/{interp_order}/{self.ddt_test_id()}"
-        largest_patch_size, smallest_patch_size = check_patch_size(ndim, interp_order=interp_order, cells=[60] * ndim)
-        datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", diag_outputs=diag_outputs,
-                                  smallest_patch_size=smallest_patch_size, largest_patch_size=smallest_patch_size,
-                                  time_step=time_step, time_step_nbr=time_step_nbr, ndim=ndim)
+
+        diag_outputs = f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts/{ndim}/{interp_order}/{self.ddt_test_id()}"
+        largest_patch_size, smallest_patch_size = check_patch_size(
+            ndim, interp_order=interp_order, cells=[60] * ndim
+        )
+        datahier = self.getHierarchy(
+            interp_order,
+            refinement_boxes,
+            "eb",
+            diag_outputs=diag_outputs,
+            smallest_patch_size=smallest_patch_size,
+            largest_patch_size=smallest_patch_size,
+            time_step=time_step,
+            time_step_nbr=time_step_nbr,
+            ndim=ndim,
+        )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 
-
     @data(
-       *per_interp(({"L0": {"B0": Box1D(10, 19)}})),
-       *per_interp(({"L0": {"B0": Box1D(10, 14), "B1": Box1D(15, 19)}})),
-       *per_interp(({"L0": {"B0": Box1D(6, 23)}})),
-       *per_interp(({"L0": {"B0": Box1D( 2, 12), "B1": Box1D(13, 25)}})),
-       *per_interp(({"L0": {"B0": Box1D( 5, 20)}, "L1": {"B0": Box1D(15, 19)}})),
-       *per_interp(({"L0": {"B0": Box1D( 5, 20)}, "L1": {"B0": Box1D(12, 38)}, "L2": {"B0": Box1D(30, 52)} })),
+        *per_interp(({"L0": {"B0": Box1D(10, 19)}})),
+        *per_interp(({"L0": {"B0": Box1D(10, 14), "B1": Box1D(15, 19)}})),
+        *per_interp(({"L0": {"B0": Box1D(6, 23)}})),
+        *per_interp(({"L0": {"B0": Box1D(2, 12), "B1": Box1D(13, 25)}})),
+        *per_interp(({"L0": {"B0": Box1D(5, 20)}, "L1": {"B0": Box1D(15, 19)}})),
+        *per_interp(
+            (
+                {
+                    "L0": {"B0": Box1D(5, 20)},
+                    "L1": {"B0": Box1D(12, 38)},
+                    "L2": {"B0": Box1D(30, 52)},
+                }
+            )
+        ),
     )
     @unpack
     def test_field_coarsening_via_subcycles(self, interp_order, refinement_boxes):
         print(f"{self._testMethodName}_{ndim}d")
         self._test_field_coarsening_via_subcycles(ndim, interp_order, refinement_boxes)
 
-
-    @data( # only supports a hierarchy with 2 levels
-       *per_interp(({"L0": [Box1D(5, 9)]})),
-       *per_interp(({"L0": [Box1D(5, 24)]})),
-       *per_interp(({"L0": [Box1D(5, 9), Box1D(20, 24)]})),
+    @unittest.skip("should change to work on moments")
+    @data(  # only supports a hierarchy with 2 levels
+        *per_interp(({"L0": [Box1D(5, 9)]})),
+        *per_interp(({"L0": [Box1D(5, 24)]})),
+        *per_interp(({"L0": [Box1D(5, 9), Box1D(20, 24)]})),
     )
     @unpack
-    def test_field_level_ghosts_via_subcycles_and_coarser_interpolation(self, interp_order, refinement_boxes):
+    def test_field_level_ghosts_via_subcycles_and_coarser_interpolation(
+        self, interp_order, refinement_boxes
+    ):
         print(f"{self._testMethodName}_{ndim}d")
-        self._test_field_level_ghosts_via_subcycles_and_coarser_interpolation(ndim, interp_order, refinement_boxes)
+        self._test_field_level_ghosts_via_subcycles_and_coarser_interpolation(
+            ndim, interp_order, refinement_boxes
+        )
 
 
 if __name__ == "__main__":

--- a/tests/simulator/advance/test_fields_advance_2d.py
+++ b/tests/simulator/advance/test_fields_advance_2d.py
@@ -17,71 +17,106 @@ ndim = 2
 interp_orders = [1, 2, 3]
 ppc = 25
 
+
 def per_interp(dic):
     return [(interp, dic) for interp in interp_orders]
 
+
 @ddt
 class AdvanceTest(AdvanceTestBase):
-
     @data(
-      *per_interp({}),
-      *per_interp({"L0": [Box2D(10, 19)]}),
-      *per_interp({"L0": [Box2D(8, 20)]}),
+        *per_interp({}),
+        *per_interp({"L0": [Box2D(10, 19)]}),
+        *per_interp({"L0": [Box2D(8, 20)]}),
     )
     @unpack
     def test_overlaped_fields_are_equal(self, interp_order, refinement_boxes):
         print(f"{self._testMethodName}_{ndim}d")
-        time_step_nbr=3
-        time_step=0.001
-        diag_outputs=f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
-        datahier = self.getHierarchy(interp_order, refinement_boxes, "fields", diag_outputs=diag_outputs,
-                                  time_step=time_step, time_step_nbr=time_step_nbr, ndim=ndim, nbr_part_per_cell=ppc)
+        time_step_nbr = 3
+        time_step = 0.001
+        diag_outputs = f"phare_overlaped_fields_are_equal_{ndim}_{self.ddt_test_id()}"
+        datahier = self.getHierarchy(
+            interp_order,
+            refinement_boxes,
+            "fields",
+            diag_outputs=diag_outputs,
+            time_step=time_step,
+            time_step_nbr=time_step_nbr,
+            ndim=ndim,
+            nbr_part_per_cell=ppc,
+        )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 
-
     @data(
-      *per_interp({}),
-      *per_interp({"L0": [Box2D(10, 19)]}),
+        *per_interp({}),
+        *per_interp({"L0": [Box2D(10, 19)]}),
     )
     @unpack
-    def test_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts(self, interp_order, refinement_boxes):
+    def test_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts(
+        self, interp_order, refinement_boxes
+    ):
         print(f"{self._testMethodName}_{ndim}d")
-        time_step_nbr=3
-        time_step=0.001
+        time_step_nbr = 3
+        time_step = 0.001
         from pyphare.pharein.simulation import check_patch_size
-        diag_outputs=f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts/{ndim}/{interp_order}/{self.ddt_test_id()}"
-        largest_patch_size, smallest_patch_size = check_patch_size(ndim, interp_order=interp_order, cells=[60] * ndim)
-        datahier = self.getHierarchy(interp_order, refinement_boxes, "eb", diag_outputs=diag_outputs,
-                                  smallest_patch_size=smallest_patch_size, largest_patch_size=smallest_patch_size,
-                                  time_step=time_step, time_step_nbr=time_step_nbr, ndim=ndim, nbr_part_per_cell=ppc)
+
+        diag_outputs = f"phare_overlaped_fields_are_equal_with_min_max_patch_size_of_max_ghosts/{ndim}/{interp_order}/{self.ddt_test_id()}"
+        largest_patch_size, smallest_patch_size = check_patch_size(
+            ndim, interp_order=interp_order, cells=[60] * ndim
+        )
+        datahier = self.getHierarchy(
+            interp_order,
+            refinement_boxes,
+            "eb",
+            diag_outputs=diag_outputs,
+            smallest_patch_size=smallest_patch_size,
+            largest_patch_size=smallest_patch_size,
+            time_step=time_step,
+            time_step_nbr=time_step_nbr,
+            ndim=ndim,
+            nbr_part_per_cell=ppc,
+        )
         self._test_overlaped_fields_are_equal(datahier, time_step_nbr, time_step)
 
-
     @data(
-       *per_interp(({"L0": {"B0": Box2D(10, 14)}})),
-       *per_interp(({"L0": {"B0": Box2D(10, 14), "B1": Box2D(15, 19)}})),
-       *per_interp(({"L0": {"B0": Box2D(6, 23)}})),
-       *per_interp(({"L0": {"B0": Box2D( 2, 12), "B1": Box2D(13, 25)}})),
-       *per_interp(({"L0": {"B0": Box2D( 5, 20)}, "L1": {"B0": Box2D(15, 19)}})),
-       *per_interp(({"L0": {"B0": Box2D( 5, 20)}, "L1": {"B0": Box2D(12, 38)}, "L2": {"B0": Box2D(30, 52)} })),
+        *per_interp(({"L0": {"B0": Box2D(10, 14)}})),
+        *per_interp(({"L0": {"B0": Box2D(10, 14), "B1": Box2D(15, 19)}})),
+        *per_interp(({"L0": {"B0": Box2D(6, 23)}})),
+        *per_interp(({"L0": {"B0": Box2D(2, 12), "B1": Box2D(13, 25)}})),
+        *per_interp(({"L0": {"B0": Box2D(5, 20)}, "L1": {"B0": Box2D(15, 19)}})),
+        *per_interp(
+            (
+                {
+                    "L0": {"B0": Box2D(5, 20)},
+                    "L1": {"B0": Box2D(12, 38)},
+                    "L2": {"B0": Box2D(30, 52)},
+                }
+            )
+        ),
     )
     @unpack
     def test_field_coarsening_via_subcycles(self, interp_order, refinement_boxes):
         print(f"{self._testMethodName}_{ndim}d")
-        self._test_field_coarsening_via_subcycles(ndim, interp_order, refinement_boxes, dl=.3)
+        self._test_field_coarsening_via_subcycles(
+            ndim, interp_order, refinement_boxes, dl=0.3
+        )
 
-
-    @data( # only supports a hierarchy with 2 levels
-       *per_interp(({"L0": [Box2D(0, 4)]})),
-       *per_interp(({"L0": [Box2D(10, 14)]})),
-       *per_interp(({"L0": [Box2D(0, 4), Box2D(10, 14)]})),
-       *per_interp(({"L0": [Box2D(0, 4), Box2D(5, 9), Box2D(10, 14)]})),
-       *per_interp(({"L0": [Box2D(20, 24)]})),
+    @unittest.skip("should change with moments")
+    @data(  # only supports a hierarchy with 2 levels
+        *per_interp(({"L0": [Box2D(0, 4)]})),
+        *per_interp(({"L0": [Box2D(10, 14)]})),
+        *per_interp(({"L0": [Box2D(0, 4), Box2D(10, 14)]})),
+        *per_interp(({"L0": [Box2D(0, 4), Box2D(5, 9), Box2D(10, 14)]})),
+        *per_interp(({"L0": [Box2D(20, 24)]})),
     )
     @unpack
-    def test_field_level_ghosts_via_subcycles_and_coarser_interpolation(self, interp_order, refinement_boxes):
+    def test_field_level_ghosts_via_subcycles_and_coarser_interpolation(
+        self, interp_order, refinement_boxes
+    ):
         print(f"{self._testMethodName}_{ndim}d")
-        self._test_field_level_ghosts_via_subcycles_and_coarser_interpolation(ndim, interp_order, refinement_boxes)
+        self._test_field_level_ghosts_via_subcycles_and_coarser_interpolation(
+            ndim, interp_order, refinement_boxes
+        )
 
 
 if __name__ == "__main__":

--- a/tests/simulator/refinement/test_2d_10_core.py
+++ b/tests/simulator/refinement/test_2d_10_core.py
@@ -13,12 +13,16 @@ import matplotlib as mpl
 import numpy as np
 import pyphare.core.box as boxm
 import pyphare.pharein as ph  # lgtm [py/import-and-import-from]
-from pyphare.pharein import (ElectromagDiagnostics, ElectronModel,
-                             FluidDiagnostics, MaxwellianFluidModel,
-                             Simulation)
+from pyphare.pharein import (
+    ElectromagDiagnostics,
+    ElectronModel,
+    FluidDiagnostics,
+    MaxwellianFluidModel,
+    Simulation,
+)
 from pyphare.simulator.simulator import Simulator, startMPI
 
-mpl.use('Agg')
+mpl.use("Agg")
 
 
 def config(diag_outputs, model_init={}, refinement_boxes=None):
@@ -27,22 +31,28 @@ def config(diag_outputs, model_init={}, refinement_boxes=None):
     Simulation(
         smallest_patch_size=10,
         largest_patch_size=20,
-        time_step_nbr= 1,
-        final_time= 0.001,
-        #boundary_types="periodic",
+        time_step_nbr=1,
+        final_time=0.001,
+        # boundary_types="periodic",
         cells=(50, 100),
         dl=(0.40, 0.40),
-        #refinement="tagging",
-        #max_nbr_levels = 3,
+        # refinement="tagging",
+        # max_nbr_levels = 3,
         refinement_boxes=refinement_boxes,
         hyper_resistivity=0.0050,
         resistivity=0.001,
-        diag_options={"format": "phareh5",
-                      "options": {"dir": diag_outputs,
-                                  "mode":"overwrite", "fine_dump_lvl_max": 10}}
+        diag_options={
+            "format": "phareh5",
+            "options": {
+                "dir": diag_outputs,
+                "mode": "overwrite",
+                "fine_dump_lvl_max": 10,
+            },
+        },
     )
+
     def density(x, y):
-        return 1.
+        return 1.0
 
     def bx(x, y):
         return 0.1
@@ -51,19 +61,19 @@ def config(diag_outputs, model_init={}, refinement_boxes=None):
         return 0.2
 
     def bz(x, y):
-        return 1.
+        return 1.0
 
     def T(x, y):
-        return 1.
+        return 1.0
 
     def vx(x, y):
         return 1.0
 
     def vy(x, y):
-        return 0.
+        return 0.0
 
     def vz(x, y):
-        return 0.
+        return 0.0
 
     def vthx(x, y):
         return np.sqrt(T(x, y))
@@ -75,21 +85,24 @@ def config(diag_outputs, model_init={}, refinement_boxes=None):
         return np.sqrt(T(x, y))
 
     vvv = {
-        "vbulkx": vx, "vbulky": vy, "vbulkz": vz,
-        "vthx": vthx, "vthy": vthy, "vthz": vthz,
-        "nbr_part_per_cell":100,
+        "vbulkx": vx,
+        "vbulky": vy,
+        "vbulkz": vz,
+        "vthx": vthx,
+        "vthy": vthy,
+        "vthz": vthz,
+        "nbr_part_per_cell": 100,
         "init": model_init,
     }
 
     MaxwellianFluidModel(
-        bx=bx, by=by, bz=bz,
-        protons={"charge": 1, "density": density,  **vvv}
+        bx=bx, by=by, bz=bz, protons={"charge": 1, "density": density, **vvv}
     )
 
     ElectronModel(closure="isothermal", Te=0.0)
     sim = ph.global_vars.sim
-    dt =  1*sim.time_step
-    nt = sim.final_time/dt+1
+    dt = 1 * sim.time_step
+    nt = sim.final_time / dt + 1
     timestamps = dt * np.arange(nt)
 
     for quantity in ["E", "B"]:
@@ -104,27 +117,31 @@ def config(diag_outputs, model_init={}, refinement_boxes=None):
             quantity=quantity,
             write_timestamps=timestamps,
             compute_timestamps=timestamps,
-            )
+        )
 
     return sim
 
-def get_time(path, time=None, datahier = None):
+
+def get_time(path, time=None, datahier=None):
     if time is not None:
         time = "{:.10f}".format(time)
     from pyphare.pharesee.hierarchy import hierarchy_from
-    datahier = hierarchy_from(h5_filename=path+"/EM_E.h5", time=time, hier=datahier)
-    datahier = hierarchy_from(h5_filename=path+"/EM_B.h5", time=time, hier=datahier)
+
+    datahier = hierarchy_from(h5_filename=path + "/EM_E.h5", time=time, hier=datahier)
+    datahier = hierarchy_from(h5_filename=path + "/EM_B.h5", time=time, hier=datahier)
     return datahier
+
 
 def get_hier(path):
     return get_time(path)
+
 
 from pyphare.cpp import cpp_lib
 
 from tests.simulator.test_advance import AdvanceTestBase
 
 cpp = cpp_lib()
-test = AdvanceTestBase(rethrow=True) # change to False for debugging images
+test = AdvanceTestBase(rethrow=True)  # change to False for debugging images
 L0_diags = "phare_outputs/test_x_homo_0"
 L0L1_diags = "phare_outputs/test_x_homo_1"
 
@@ -132,19 +149,25 @@ L0L1_diags = "phare_outputs/test_x_homo_1"
 def make_fig(hier, fig_name, ilvl, extra_collections=[]):
     if cpp.mpi_rank() == 0:
         l0_in_l1 = [boxm.refine(p.box, 2) for p in hier.level(0).patches]
-        collections=[{
-            "boxes": l0_in_l1,
-            "facecolor": "grey",
-        }]
+        collections = [
+            {
+                "boxes": l0_in_l1,
+                "facecolor": "grey",
+            }
+        ]
         if 1 in hier.levels():
             l1_over_l0 = [p.box for p in hier.level(1).patches]
-            collections += [{
-                "boxes": l1_over_l0,
-                "facecolor": "yellow",
-            }]
-        hier.plot_2d_patches(1,
+            collections += [
+                {
+                    "boxes": l1_over_l0,
+                    "facecolor": "yellow",
+                }
+            ]
+        hier.plot_2d_patches(
+            1,
             collections=collections + extra_collections,
-        ).savefig(fig_name+".png")
+        ).savefig(fig_name + ".png")
+
 
 def check_hier(hier):
     for ilvl, lvl in hier.levels().items():
@@ -152,29 +175,35 @@ def check_hier(hier):
             assert all(patch.box.shape > 5)
     return hier
 
+
 def post_advance(new_time):
     if cpp.mpi_rank() == 0:
         L0_datahier = check_hier(get_hier(L0_diags))
         L0L1_datahier = check_hier(get_hier(L0L1_diags))
         extra_collections = []
         errors = test.base_test_overlaped_fields_are_equal(L0L1_datahier, new_time)
-        errors = test.base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(L0_datahier, L0L1_datahier)
+        # errors = test.base_test_field_level_ghosts_via_subcycles_and_coarser_interpolation(L0_datahier, L0L1_datahier)
         print(f"errors {type(errors)}")
         if isinstance(errors, list):
-            extra_collections += [{
-                "boxes": errors,
-                "facecolor": "black",
-            }]
+            extra_collections += [
+                {
+                    "boxes": errors,
+                    "facecolor": "black",
+                }
+            ]
         make_fig(L0L1_datahier, L0L1_diags.split("/")[-1], 1, extra_collections)
+
 
 def main():
     import random
+
     startMPI()
     rando = random.randint(0, int(1e10))
     Simulator(config(L0_diags, {"seed": rando})).run().reset()
-    refinement_boxes={"L0": {"B0": [( 7,  40), ( 20, 60)]}}
+    refinement_boxes = {"L0": {"B0": [(7, 40), (20, 60)]}}
     sim = config(L0L1_diags, {"seed": rando}, refinement_boxes)
     Simulator(sim, post_advance=post_advance).run()
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Add a new way to Coarsen a field, specialized for the magnetic field: 

- adds magnetic field coarsener
   - caveat : this is not 3D  
- previous coarsener becomes the `DefaultFieldCoarsener` and is used for the density and bulk velocity
- `FieldCoarserOperator`now takes a `FieldCoarsenerPolicy` as a template parameter


## Adding specific ways to refine the magnetic and electric fields: 

- `FieldRefineOperator` now takes a `FieldRefinerPolicy` as a template parameter, which is used in `refine()` to fill the fine filed given the coarse field and a coarse index.
- add objects `ElectricFieldRefiner` and `MagneticFieldRefiner`
- previous `FieldRefiner` now becomes `DefaultFieldRefiner` and is used by density and bulk velocity

## Conserving magnetic flux at level interfaces

- magnetic field components are defined on cell faces and its value on a face only depends on the electric components on the edges of that face. Hence knowing the electric field everywhere on the ghost box we can calculate B everywhere on the ghost box. 
    - Hence, B is now calculated over the whole **ghost** box using faraday.
    - This adds `evalOnGhostBox` in `GridLayout` which is called in `Faraday` instead of `evalOnBox`
    - Magnetic field ghosts are not filled anymore. the messenger method fillMagneticGhost is removed.
    - magnetic patch ghosts **only** are filled in `postSynchronize`. This is needed because reset of field data by coarsened values may break overlap consistency with neighbor patches. 
        - This uses the new `RefinerType::PatchGhostField` in `refiner_pool.hpp`
        - This adds a new type of schedule created for intra level only, associated with constexpr `RefinerType::PatchGhostField`
        - The hybridModel is the only one registering a magnetic field in `ghostMagnetic` (as opposed to also the SolverPPC which was also registering Bpred)
     - the electric field on level ghost nodes, obtained from refinement, cannot be anymore obtained with space/time inteprolation as before. This is because we need the magnetic field obtained at the end of the 4 fine substeps on fine level border faces, to be **exactly** the one obtained on the shared coarse faces during the underlying coarse step. This means that the electric field Faraday evaluates on level ghost nodes, must be the same as the one that was last used on next coarser overlaped nodes to obtain the coarse magnetic field. This means  : 
         - solverPPC now sets `Eavg` in the modelInfo `ghostElectric`  instead of `Epred`, since Eavg is the one the next coarser level uses last to update its magnetic field
         - the hybridhybrid messenger strat now adds various convenience method such as `fillStaticRefiner_` and the refiner pool `addStaticRefiner` and all necessary overloads for scalar and vector quantities.  

## bug fix
- density ghost nodes was previously filled with only spatial interpolation. This was a mistake since as a result the density on level ghost nodes was obtained from refining the next coarser values, defined in the future. This is now fixed by using the new refiner pool method `addTimeRefiner` in the `registerGhostComms_()` method. 
- the refiner pool `addTimeRefiner` overload for vector fields is now also used to register ghost communications for the bulk velocity (through calling `fillTimeRefiners_` 

## Regriding trick

During regriding, a level may shrink or grow. In the first case, some parts of the new level border end up on faces that were formerly fine domain faces. These fine faces had their magnetic field self consistently obtained from Faraday. Each face has its own value, i.e. fine level border faces enclosed in the same coarse face do not have equal values. This is inconsistent with flux conservation since next fine step we assume fine faces evolve based on the same electric induction to arrive at the same flux as the coarse level. Border fine faces thus need to be reset by refinement, which will get them equal both to the underlying coarse face's value. The drawback is that when changing the fine face value obtained self-consistently on the border, we screw-up divB in these fine border cells. Since the refined value is obtained from next coarser, which previously through coarsening recieved the averaged of both fine faces, the re-assignement does not change the total flux through the border faces, but only screw up divB of enclosed fine cells.


In the latter case, i.e. when the level grows, new level faces (on border or not) must take their value from refinement from next coarser. But fixing these faces' values will screw up divB in the fine level at the former level boundary since at this former boundary, one side has self consistent fine flux, and the other is set by refinement from coarser. 



## tests

 - I have disabled test_field_coarsening_via_subcycles in both 1D and 2D test_fields_advance. These tests assert that levelghotst of E and B are, as expected, the space/time interpolation of next coarser values. But the code does not refine B onto ghosts anymore, and does not time interpolate E anymore so the test is useless as is. It could be re-factored into testing the same thing for moments, which this PR now make time/space interpolated, but that is an issue in itself (#748).



## Misc. : 


- quantity_communicator.hpp becomes communicator.hpp
- communicator.hpp is split in two files :  refiner_pool.hpp and synchronizer_pool.hpp 
- a new overload of Communicator::makeRefiner() is created to communicated a scalar quantity with space and time refinement.


![image](https://github.com/PHAREHUB/PHARE/assets/3200931/21a7b10a-20e6-45bf-88eb-e50a650d8e5c)

This is the divergence of the magnetic field in `run051`  Harris sheet on 3 levels and 80 cores.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `evalOnGhostBox` function for more efficient field evaluations.
- Refactor: Improved grid layout and field coarsening with clearer variable names and better function signatures.
- New Feature: Added `DefaultFieldCoarsener` and `MagneticFieldCoarsener` for more precise field coarsening.
- New Feature: Introduced `ElectricFieldRefiner` and `MagneticFieldRefiner` for enhanced field refinement.
- Refactor: Streamlined level initialization and multiphysics integration for better performance.
- New Feature: Enhanced `makeRefiner` function for improved communication between scalar and vector quantities.
- New Feature: Introduced `SynchronizerPool` for efficient synchronization and management of refiners.
- Refactor: Updated `HybridModel` and `SolverPPC` for better handling of physical models and solvers.
- Test: Updated and improved readability of various test cases for better error handling and testing efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->