### PR TITLE
AMRtoLocal returns unsigned ints

### DIFF
--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -812,7 +812,7 @@ namespace core
         NO_DISCARD auto AMRToLocal(Point<T, dimension> AMRPoint) const
         {
             static_assert(std::is_integral_v<T>, "Error, must be MeshIndex (integral Point)");
-            Point<T, dimension> localPoint;
+            Point<std::uint32_t, dimension> localPoint;
 
             // any direction, it's the same because we want cells
             auto localStart = physicalStartIndex(QtyCentering::dual, Direction::X);
@@ -820,7 +820,9 @@ namespace core
             //
             for (auto i = 0u; i < dimension; ++i)
             {
-                localPoint[i] = AMRPoint[i] - (AMRBox_.lower[i] - localStart);
+                int local = AMRPoint[i] - (AMRBox_.lower[i] - localStart);
+                assert(local >= 0);
+                localPoint[i] = local;
             }
             return localPoint;
         }
@@ -834,7 +836,7 @@ namespace core
         NO_DISCARD auto AMRToLocal(Box<T, dimension> AMRBox) const
         {
             static_assert(std::is_integral_v<T>, "Error, must be MeshIndex (integral Point)");
-            auto localBox = Box<T, dimension>{};
+            auto localBox = Box<std::uint32_t, dimension>{};
 
             localBox.lower = AMRToLocal(AMRBox.lower);
             localBox.upper = AMRToLocal(AMRBox.upper);

--- a/tests/core/data/gridlayout/gridlayout_amr.cpp
+++ b/tests/core/data/gridlayout/gridlayout_amr.cpp
@@ -84,7 +84,7 @@ TEST(GridLayout, canTransformAnAMRBoxIntoALocalBox)
 
     int nGhosts           = layout.nbrGhosts(QtyCentering::dual);
     auto AMRBox           = Box{Point{55}, Point{65}};
-    auto expectedLocalBox = Box{Point{nGhosts + 5}, Point{nGhosts + 15}};
+    auto expectedLocalBox = Box<std::uint32_t, 1>{Point{nGhosts + 5}, Point{nGhosts + 15}};
 
     EXPECT_EQ(expectedLocalBox, layout.AMRToLocal(AMRBox));
 }


### PR DESCRIPTION
Concerns #558. 
Cleaned up the previous commits and added the edit to gridlayout_amr following Philip's advice in #777. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the return types for grid layout conversion functions to ensure type consistency and safety.
	- Improved error checking with new assertions to validate non-negative local values in grid calculations.

- **Tests**
	- Adjusted test cases to align with the updated data types in grid layout functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->