### PR TITLE
eb-less particles - mesh to particle eb handled directory in boris

### DIFF
--- a/src/core/data/particles/particle.hpp
+++ b/src/core/data/particles/particle.hpp
@@ -61,26 +61,17 @@ struct Particle
     std::array<double, dim> delta = ConstArray<double, dim>();
     std::array<double, 3> v       = ConstArray<double, 3>();
 
-    double Ex = 0, Ey = 0, Ez = 0;
-    double Bx = 0, By = 0, Bz = 0;
-
     NO_DISCARD bool operator==(Particle<dim> const& that) const
     {
         return (this->weight == that.weight) && //
                (this->charge == that.charge) && //
                (this->iCell == that.iCell) &&   //
                (this->delta == that.delta) &&   //
-               (this->v == that.v) &&           //
-               (this->Ex == that.Ex) &&         //
-               (this->Ey == that.Ey) &&         //
-               (this->Ez == that.Ez) &&         //
-               (this->Bx == that.Bx) &&         //
-               (this->By == that.By) &&         //
-               (this->Bz == that.Bz);
+               (this->v == that.v);
     }
 
     template<std::size_t dimension>
-    friend std::ostream& operator<<(std::ostream& out, const Particle<dimension>& particle);
+    friend std::ostream& operator<<(std::ostream& out, Particle<dimension> const& particle);
 };
 
 template<std::size_t dim>
@@ -102,8 +93,6 @@ std::ostream& operator<<(std::ostream& out, Particle<dim> const& particle)
         out << v << ",";
     }
     out << "), charge : " << particle.charge << ", weight : " << particle.weight;
-    out << ", Exyz : " << particle.Ex << "," << particle.Ey << "," << particle.Ez;
-    out << ", Bxyz : " << particle.Bx << "," << particle.By << "," << particle.Bz;
     out << '\n';
     return out;
 }
@@ -132,9 +121,9 @@ inline constexpr auto is_phare_particle_type
 
 template<std::size_t dim, template<std::size_t> typename ParticleA,
          template<std::size_t> typename ParticleB>
-NO_DISCARD typename std::enable_if_t<is_phare_particle_type<dim, ParticleA<dim>>
-                                         and is_phare_particle_type<dim, ParticleB<dim>>,
-                                     bool>
+NO_DISCARD typename std::enable_if_t<
+    is_phare_particle_type<dim, ParticleA<dim>> and is_phare_particle_type<dim, ParticleB<dim>>,
+    bool>
 operator==(ParticleA<dim> const& particleA, ParticleB<dim> const& particleB)
 {
     return particleA.weight == particleB.weight and //

--- a/src/core/data/particles/particle_array.hpp
+++ b/src/core/data/particles/particle_array.hpp
@@ -231,6 +231,8 @@ public:
     NO_DISCARD auto& vector() { return particles_; }
     NO_DISCARD auto& vector() const { return particles_; }
 
+    auto& box() const { return box_; }
+
 private:
     Vector particles_;
     box_t box_;

--- a/src/core/numerics/pusher/boris.hpp
+++ b/src/core/numerics/pusher/boris.hpp
@@ -15,6 +15,8 @@
 
 namespace PHARE::core
 {
+
+
 template<std::size_t dim, typename ParticleRange, typename Electromag, typename Interpolator,
          typename BoundaryCondition, typename GridLayout>
 class BorisPusher
@@ -85,29 +87,32 @@ public:
         // rangeIn : t=n, rangeOut : t=n+1/2
         // Do not partition on this step - this is to keep all domain and ghost
         //   particles consistent. see: https://github.com/PHAREHUB/PHARE/issues/571
-        pushStep_(rangeIn, rangeOut, PushStep::PrePush);
+        prePushStep_(rangeIn, rangeOut);
 
         rangeOut = firstSelector(rangeOut);
 
-        //  get electromagnetic fields interpolated on the particles of rangeOut
-        //  stop at newEnd.
-        interpolator(rangeOut, emFields, layout);
 
-        //  get the particle velocity from t=n to t=n+1
-        accelerate_(rangeOut, rangeOut, mass);
+        double const dto2m = 0.5 * dt_ / mass;
+        for (auto idx = rangeOut.ibegin(); idx < rangeOut.iend(); ++idx)
+        {
+            auto& currPart = rangeOut.array()[idx];
 
-        // now advance the particles from t=n+1/2 to t=n+1 using v_{n+1} just calculated
-        // and get a pointer to the first leaving particle
-        pushStep_(rangeOut, rangeOut, PushStep::PostPush);
+            //  get electromagnetic fields interpolated on the particles of rangeOut stop at newEnd.
+            //  get the particle velocity from t=n to t=n+1
+            accelerate_(currPart, interpolator(currPart, emFields, layout), dto2m);
+
+            // now advance the particles from t=n+1/2 to t=n+1 using v_{n+1} just calculated
+            // and get a pointer to the first leaving particle
+            postPushStep_(rangeOut, idx);
+        }
 
         return secondSelector(rangeOut);
     }
 
 
 
-
     /** see Pusher::move() documentation*/
-    virtual void setMeshAndTimeStep(std::array<double, dim> ms, double ts) override
+    void setMeshAndTimeStep(std::array<double, dim> ms, double ts) override
     {
         std::transform(std::begin(ms), std::end(ms), std::begin(halfDtOverDl_),
                        [ts](double& x) { return 0.5 * ts / x; });
@@ -117,8 +122,6 @@ public:
 
 
 private:
-    enum class PushStep { PrePush, PostPush };
-
     /** move the particle partIn of half a time step and store it in partOut
      */
     template<typename Particle>
@@ -148,7 +151,7 @@ private:
      * @return the function returns and iterator on the first leaving particle, as
      * detected by the ParticleSelector
      */
-    void pushStep_(ParticleRange const& rangeIn, ParticleRange& rangeOut, PushStep step)
+    void prePushStep_(ParticleRange const& rangeIn, ParticleRange& rangeOut)
     {
         auto& inParticles  = rangeIn.array();
         auto& outParticles = rangeOut.array();
@@ -164,88 +167,89 @@ private:
             // not strictly speaking this function's business
             // to take advantage that we're already looping
             // over rangeIn particles.
-            if (step == PushStep::PrePush)
-            {
-                outParticles[outIdx].charge = inParticles[inIdx].charge;
-                outParticles[outIdx].weight = inParticles[inIdx].weight;
-                outParticles[outIdx].v      = inParticles[inIdx].v;
-            }
+
+            outParticles[outIdx].charge = inParticles[inIdx].charge;
+            outParticles[outIdx].weight = inParticles[inIdx].weight;
+            outParticles[outIdx].v      = inParticles[inIdx].v;
+
             auto newCell = advancePosition_(inParticles[inIdx], outParticles[outIdx]);
             if (newCell != inParticles[inIdx].iCell)
                 outParticles.change_icell(newCell, outIdx);
         }
     }
 
+    void postPushStep_(ParticleRange& range, std::size_t idx)
+    {
+        auto& particles = range.array();
+        auto newCell    = advancePosition_(particles[idx], particles[idx]);
+        if (newCell != particles[idx].iCell)
+            particles.change_icell(newCell, idx);
+    }
 
 
     /** Accelerate the particles in rangeIn and put the new velocity in rangeOut
      */
-    void accelerate_(ParticleRange rangeIn, ParticleRange rangeOut, double mass)
+    template<typename Particle_t, typename ParticleEB>
+    void accelerate_(Particle_t& part, ParticleEB const& particleEB, double const& dto2m)
     {
-        double dto2m = 0.5 * dt_ / mass;
-
-        auto& inParticles  = rangeIn.array();
-        auto& outParticles = rangeOut.array();
-
-        for (auto inIdx = rangeIn.ibegin(), outIdx = rangeOut.ibegin(); inIdx < rangeIn.iend();
-             ++inIdx, ++outIdx)
-        {
-            auto& inPart  = inParticles[inIdx];
-            auto& outPart = outParticles[inIdx];
-            double coef1  = inPart.charge * dto2m;
-
-            // We now apply the 3 steps of the BORIS PUSHER
-
-            // 1st half push of the electric field
-            double velx1 = inPart.v[0] + coef1 * inPart.Ex;
-            double vely1 = inPart.v[1] + coef1 * inPart.Ey;
-            double velz1 = inPart.v[2] + coef1 * inPart.Ez;
+        auto& [pE, pB]        = particleEB;
+        auto& [pEx, pEy, pEz] = pE;
+        auto& [pBx, pBy, pBz] = pB;
 
 
-            // preparing variables for magnetic rotation
-            double const rx = coef1 * inPart.Bx;
-            double const ry = coef1 * inPart.By;
-            double const rz = coef1 * inPart.Bz;
+        double const coef1 = part.charge * dto2m;
 
-            double const rx2  = rx * rx;
-            double const ry2  = ry * ry;
-            double const rz2  = rz * rz;
-            double const rxry = rx * ry;
-            double const rxrz = rx * rz;
-            double const ryrz = ry * rz;
+        // We now apply the 3 steps of the BORIS PUSHER
 
-            double const invDet = 1. / (1. + rx2 + ry2 + rz2);
-
-            // preparing rotation matrix due to the magnetic field
-            // m = invDet*(I + r*r - r x I) - I where x denotes the cross product
-            double const mxx = 1. + rx2 - ry2 - rz2;
-            double const mxy = 2. * (rxry + rz);
-            double const mxz = 2. * (rxrz - ry);
-
-            double const myx = 2. * (rxry - rz);
-            double const myy = 1. + ry2 - rx2 - rz2;
-            double const myz = 2. * (ryrz + rx);
-
-            double const mzx = 2. * (rxrz + ry);
-            double const mzy = 2. * (ryrz - rx);
-            double const mzz = 1. + rz2 - rx2 - ry2;
-
-            // magnetic rotation
-            double const velx2 = (mxx * velx1 + mxy * vely1 + mxz * velz1) * invDet;
-            double const vely2 = (myx * velx1 + myy * vely1 + myz * velz1) * invDet;
-            double const velz2 = (mzx * velx1 + mzy * vely1 + mzz * velz1) * invDet;
+        // 1st half push of the electric field
+        double velx1 = part.v[0] + coef1 * pEx;
+        double vely1 = part.v[1] + coef1 * pEy;
+        double velz1 = part.v[2] + coef1 * pEz;
 
 
-            // 2nd half push of the electric field
-            velx1 = velx2 + coef1 * inPart.Ex;
-            vely1 = vely2 + coef1 * inPart.Ey;
-            velz1 = velz2 + coef1 * inPart.Ez;
+        // preparing variables for magnetic rotation
+        double const rx = coef1 * pBx;
+        double const ry = coef1 * pBy;
+        double const rz = coef1 * pBz;
 
-            // Update particle velocity
-            outPart.v[0] = velx1;
-            outPart.v[1] = vely1;
-            outPart.v[2] = velz1;
-        }
+        double const rx2  = rx * rx;
+        double const ry2  = ry * ry;
+        double const rz2  = rz * rz;
+        double const rxry = rx * ry;
+        double const rxrz = rx * rz;
+        double const ryrz = ry * rz;
+
+        double const invDet = 1. / (1. + rx2 + ry2 + rz2);
+
+        // preparing rotation matrix due to the magnetic field
+        // m = invDet*(I + r*r - r x I) - I where x denotes the cross product
+        double const mxx = 1. + rx2 - ry2 - rz2;
+        double const mxy = 2. * (rxry + rz);
+        double const mxz = 2. * (rxrz - ry);
+
+        double const myx = 2. * (rxry - rz);
+        double const myy = 1. + ry2 - rx2 - rz2;
+        double const myz = 2. * (ryrz + rx);
+
+        double const mzx = 2. * (rxrz + ry);
+        double const mzy = 2. * (ryrz - rx);
+        double const mzz = 1. + rz2 - rx2 - ry2;
+
+        // magnetic rotation
+        double const velx2 = (mxx * velx1 + mxy * vely1 + mxz * velz1) * invDet;
+        double const vely2 = (myx * velx1 + myy * vely1 + myz * velz1) * invDet;
+        double const velz2 = (mzx * velx1 + mzy * vely1 + mzz * velz1) * invDet;
+
+
+        // 2nd half push of the electric field
+        velx1 = velx2 + coef1 * pEx;
+        vely1 = vely2 + coef1 * pEy;
+        velz1 = velz2 + coef1 * pEz;
+
+        // Update particle velocity
+        part.v[0] = velx1;
+        part.v[1] = vely1;
+        part.v[2] = velz1;
     }
 
 

--- a/src/core/utilities/box/box.hpp
+++ b/src/core/utilities/box/box.hpp
@@ -25,6 +25,9 @@ class box_iterator;
 template<typename Type, std::size_t dim>
 struct Box
 {
+    static const size_t dimension = dim;
+
+
     Point<Type, dim> lower;
     Point<Type, dim> upper;
 
@@ -257,8 +260,8 @@ NO_DISCARD bool isIn(Point const& point,
 }
 
 
-template<typename Type, std::size_t dim>
-Box<Type, dim> grow(Box<Type, dim> const& box, Type const& size)
+template<typename Type, std::size_t dim, typename OType>
+Box<Type, dim> grow(Box<Type, dim> const& box, OType const& size)
 {
     auto copy{box};
     copy.grow(size);

--- a/src/core/utilities/point/point.hpp
+++ b/src/core/utilities/point/point.hpp
@@ -85,7 +85,7 @@ namespace core
         NO_DISCARD bool operator!=(Point const& other) const { return !(*this == other); }
 
 
-        template<typename DestType>
+        template<typename DestType = Type>
         NO_DISCARD auto toArray() const
         {
             std::array<DestType, dimension> destArray;

--- a/tests/amr/data/particles/copy/test_particledata_copyNd.cpp
+++ b/tests/amr/data/particles/copy/test_particledata_copyNd.cpp
@@ -121,12 +121,6 @@ TYPED_TEST(AParticlesDataND, PreservesAllParticleAttributesAfterCopy)
                 Pointwise(DoubleEq(), this->particle.delta));
     EXPECT_THAT(this->destData.domainParticles[0].weight, DoubleEq(this->particle.weight));
     EXPECT_THAT(this->destData.domainParticles[0].charge, DoubleEq(this->particle.charge));
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Ex, this->particle.Ex);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Ey, this->particle.Ey);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Ez, this->particle.Ez);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Bx, this->particle.Bx);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].By, this->particle.By);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Bz, this->particle.Bz);
 
     // particle is in the domain of the source patchdata
     // and in last ghost of the destination patchdata
@@ -142,12 +136,6 @@ TYPED_TEST(AParticlesDataND, PreservesAllParticleAttributesAfterCopy)
                 Pointwise(DoubleEq(), this->particle.delta));
     EXPECT_THAT(this->destData.patchGhostParticles[0].weight, DoubleEq(this->particle.weight));
     EXPECT_THAT(this->destData.patchGhostParticles[0].charge, DoubleEq(this->particle.charge));
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Ex, this->particle.Ex);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Ey, this->particle.Ey);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Ez, this->particle.Ez);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Bx, this->particle.Bx);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].By, this->particle.By);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Bz, this->particle.Bz);
 }
 
 

--- a/tests/amr/data/particles/copy_overlap/test_particledata_copy_periodicNd.cpp
+++ b/tests/amr/data/particles/copy_overlap/test_particledata_copy_periodicNd.cpp
@@ -139,12 +139,6 @@ TYPED_TEST(twoParticlesDataNDTouchingPeriodicBorders, preserveParticleAttributes
     EXPECT_THAT(this->destPdat.patchGhostParticles[0].delta, Eq(this->particle.delta));
     EXPECT_THAT(this->destPdat.patchGhostParticles[0].weight, Eq(this->particle.weight));
     EXPECT_THAT(this->destPdat.patchGhostParticles[0].charge, Eq(this->particle.charge));
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Ex, this->particle.Ex);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Ey, this->particle.Ey);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Ez, this->particle.Ez);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Bx, this->particle.Bx);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].By, this->particle.By);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Bz, this->particle.Bz);
 }
 
 

--- a/tests/amr/data/particles/stream_pack/test_main.cpp
+++ b/tests/amr/data/particles/stream_pack/test_main.cpp
@@ -228,12 +228,6 @@ TYPED_TEST(StreamPackTest,
     EXPECT_THAT(destData.domainParticles[0].delta, Eq(particle.delta));
     EXPECT_THAT(destData.domainParticles[0].weight, Eq(particle.weight));
     EXPECT_THAT(destData.domainParticles[0].charge, Eq(particle.charge));
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Ex, particle.Ex);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Ey, particle.Ey);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Ez, particle.Ez);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Bx, particle.Bx);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].By, particle.By);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Bz, particle.Bz);
 }
 
 
@@ -271,12 +265,6 @@ TYPED_TEST(StreamPackTest,
     EXPECT_THAT(destData.patchGhostParticles[0].delta, Eq(particle.delta));
     EXPECT_THAT(destData.patchGhostParticles[0].weight, Eq(particle.weight));
     EXPECT_THAT(destData.patchGhostParticles[0].charge, Eq(particle.charge));
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Ex, particle.Ex);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Ey, particle.Ey);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Ez, particle.Ez);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Bx, particle.Bx);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].By, particle.By);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Bz, particle.Bz);
 }
 
 

--- a/tests/core/data/gridlayout/gridlayout_test.hpp
+++ b/tests/core/data/gridlayout/gridlayout_test.hpp
@@ -5,6 +5,7 @@
 #include "core/data/grid/gridlayoutimplyee.hpp"
 #include "core/utilities/types.hpp"
 
+#include "test_gridlayout.hpp"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/tests/core/data/gridlayout/gridlayout_test.hpp
+++ b/tests/core/data/gridlayout/gridlayout_test.hpp
@@ -24,22 +24,5 @@ public:
     Param<GridLayoutImpl> param;
 };
 
-template<typename GridLayout>
-class TestGridLayout : public GridLayout
-{ // to expose a default constructor
-public:
-    auto static constexpr dim = GridLayout::dimension;
-
-    TestGridLayout() = default;
-
-    TestGridLayout(std::uint32_t cells)
-        : GridLayout{PHARE::core::ConstArray<double, dim>(1.0 / cells),
-                     PHARE::core::ConstArray<std::uint32_t, dim>(cells),
-                     PHARE::core::Point<double, dim>{PHARE::core::ConstArray<double, dim>(0)}}
-    {
-    }
-
-    auto static make(std::uint32_t cells) { return TestGridLayout{cells}; }
-};
 
 #endif

--- a/tests/core/data/gridlayout/test_gridlayout.hpp
+++ b/tests/core/data/gridlayout/test_gridlayout.hpp
@@ -1,0 +1,27 @@
+#ifndef TESTS_CORE_DATA_GRIDLAYOUT_TEST_GRIDLAYOUT_HPP
+#define TESTS_CORE_DATA_GRIDLAYOUT_TEST_GRIDLAYOUT_HPP
+
+#include "core/data/grid/gridlayout.hpp"
+#include "core/data/grid/gridlayoutimplyee.hpp"
+#include "core/utilities/types.hpp"
+
+
+template<typename GridLayout>
+class TestGridLayout : public GridLayout
+{ // to expose a default constructor
+public:
+    auto static constexpr dim = GridLayout::dimension;
+
+    TestGridLayout() = default;
+
+    TestGridLayout(std::uint32_t cells)
+        : GridLayout{PHARE::core::ConstArray<double, dim>(1.0 / cells),
+                     PHARE::core::ConstArray<std::uint32_t, dim>(cells),
+                     PHARE::core::Point<double, dim>{PHARE::core::ConstArray<double, dim>(0)}}
+    {
+    }
+
+    auto static make(std::uint32_t cells) { return TestGridLayout{cells}; }
+};
+
+#endif /*TESTS_CORE_DATA_GRIDLAYOUT_TEST_GRIDLAYOUT_HPP*/

--- a/tests/core/data/particles/test_main.cpp
+++ b/tests/core/data/particles/test_main.cpp
@@ -38,17 +38,6 @@ TEST_F(AParticle, ParticleChargeIsInitiliazedOK)
     EXPECT_DOUBLE_EQ(1., part.charge);
 }
 
-TEST_F(AParticle, ParticleFieldsAreInitializedToZero)
-{
-    EXPECT_DOUBLE_EQ(0.0, part.Ex);
-    EXPECT_DOUBLE_EQ(0.0, part.Ey);
-    EXPECT_DOUBLE_EQ(0.0, part.Ez);
-
-    EXPECT_DOUBLE_EQ(0.0, part.Bx);
-    EXPECT_DOUBLE_EQ(0.0, part.By);
-    EXPECT_DOUBLE_EQ(0.0, part.Bz);
-}
-
 
 TEST_F(AParticle, ParticleVelocityIsInitializedOk)
 {

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -298,19 +298,17 @@ TYPED_TEST(A1DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by1d_);
     this->em.B.setBuffer("EM_B_z", &this->bz1d_);
 
-
     for (auto const& part : this->particles)
     {
         auto const [E, B]        = this->interp(part, this->em, this->layout);
         auto const& [Ex, Ey, Ez] = E;
-        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
-        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
-        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
-
         auto const& [Bx, By, Bz] = B;
-        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
-        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
-        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+        EXPECT_NEAR(Ex, this->ex0, 1e-8);
+        EXPECT_NEAR(Ey, this->ey0, 1e-8);
+        EXPECT_NEAR(Ez, this->ez0, 1e-8);
+        EXPECT_NEAR(Bx, this->bx0, 1e-8);
+        EXPECT_NEAR(By, this->by0, 1e-8);
+        EXPECT_NEAR(Bz, this->bz0, 1e-8);
     }
 
     this->em.E.setBuffer("EM_E_x", nullptr);
@@ -413,14 +411,13 @@ TYPED_TEST(A2DInterpolator, canComputeAllEMfieldsAtParticle)
     {
         auto const [E, B]        = this->interp(part, this->em, this->layout);
         auto const& [Ex, Ey, Ez] = E;
-        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
-        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
-        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
-
         auto const& [Bx, By, Bz] = B;
-        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
-        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
-        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+        EXPECT_NEAR(Ex, this->ex0, 1e-8);
+        EXPECT_NEAR(Ey, this->ey0, 1e-8);
+        EXPECT_NEAR(Ez, this->ez0, 1e-8);
+        EXPECT_NEAR(Bx, this->bx0, 1e-8);
+        EXPECT_NEAR(By, this->by0, 1e-8);
+        EXPECT_NEAR(Bz, this->bz0, 1e-8);
     }
 
     this->em.E.setBuffer("EM_E_x", nullptr);
@@ -529,14 +526,13 @@ TYPED_TEST(A3DInterpolator, canComputeAllEMfieldsAtParticle)
     {
         auto const [E, B]        = this->interp(part, this->em, this->layout);
         auto const& [Ex, Ey, Ez] = E;
-        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
-        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
-        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
-
         auto const& [Bx, By, Bz] = B;
-        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
-        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
-        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+        EXPECT_NEAR(Ex, this->ex0, 1e-8);
+        EXPECT_NEAR(Ey, this->ey0, 1e-8);
+        EXPECT_NEAR(Ez, this->ez0, 1e-8);
+        EXPECT_NEAR(Bx, this->bx0, 1e-8);
+        EXPECT_NEAR(By, this->by0, 1e-8);
+        EXPECT_NEAR(Bz, this->bz0, 1e-8);
     }
 
 

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -298,32 +298,20 @@ TYPED_TEST(A1DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by1d_);
     this->em.B.setBuffer("EM_B_z", &this->bz1d_);
 
-    this->interp(makeIndexRange(this->particles), this->em, this->layout);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ex - this->ex0) < 1e-8; }));
+    for (auto const& part : this->particles)
+    {
+        auto const [E, B]        = this->interp(part, this->em, this->layout);
+        auto const& [Ex, Ey, Ez] = E;
+        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ey - this->ey0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ez - this->ez0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bx - this->bx0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.By - this->by0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bz - this->bz0) < 1e-8; }));
-
+        auto const& [Bx, By, Bz] = B;
+        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
+        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
+        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+    }
 
     this->em.E.setBuffer("EM_E_x", nullptr);
     this->em.E.setBuffer("EM_E_y", nullptr);
@@ -421,32 +409,19 @@ TYPED_TEST(A2DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by_);
     this->em.B.setBuffer("EM_B_z", &this->bz_);
 
-    this->interp(makeIndexRange(this->particles), this->em, this->layout);
+    for (auto const& part : this->particles)
+    {
+        auto const [E, B]        = this->interp(part, this->em, this->layout);
+        auto const& [Ex, Ey, Ez] = E;
+        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ex - this->ex0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ey - this->ey0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ez - this->ez0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bx - this->bx0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.By - this->by0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bz - this->bz0) < 1e-8; }));
-
+        auto const& [Bx, By, Bz] = B;
+        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
+        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
+        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+    }
 
     this->em.E.setBuffer("EM_E_x", nullptr);
     this->em.E.setBuffer("EM_E_y", nullptr);
@@ -549,31 +524,20 @@ TYPED_TEST(A3DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by_);
     this->em.B.setBuffer("EM_B_z", &this->bz_);
 
-    this->interp(makeIndexRange(this->particles), this->em, this->layout);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ex - this->ex0) < 1e-8; }));
+    for (auto const& part : this->particles)
+    {
+        auto const [E, B]        = this->interp(part, this->em, this->layout);
+        auto const& [Ex, Ey, Ez] = E;
+        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ey - this->ey0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ez - this->ez0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bx - this->bx0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.By - this->by0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bz - this->bz0) < 1e-8; }));
+        auto const& [Bx, By, Bz] = B;
+        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
+        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
+        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+    }
 
 
     this->em.E.setBuffer("EM_E_x", nullptr);

--- a/tools/bench/core/bench.hpp
+++ b/tools/bench/core/bench.hpp
@@ -169,9 +169,16 @@ private:
 namespace PHARE::core
 {
 template<typename Box_t, typename RValue = std::uint32_t>
-struct LocalisedCellFlattener
+class LocalisedCellFlattener
 {
-    static const size_t dim = Box_t::dimension;
+public:
+    static constexpr std::size_t dim = Box_t::dimension;
+
+    LocalisedCellFlattener(Box_t const& b)
+        : box{b}
+        , shape{box.shape().toArray()}
+    {
+    }
 
     RValue operator()(std::array<int, dim> icell) const
     {
@@ -190,8 +197,11 @@ struct LocalisedCellFlattener
         return (*this)(particle.iCell);
     }
 
+
     Box_t const box;
-    std::array<int, dim> shape = box.shape().toArray();
+
+private:
+    std::array<int, dim> const shape = box.shape().toArray();
 };
 } // namespace PHARE::core
 

--- a/tools/bench/hi5/write_particles.cpp
+++ b/tools/bench/hi5/write_particles.cpp
@@ -1,5 +1,5 @@
 
-#include "benchmark/benchmark.hpp"
+#include "benchmark/benchmark.h"
 #define PHARE_DIAG_DOUBLES 0
 #include "diagnostic/detail/h5writer.hpp"
 #include "diagnostic/detail/h5_utils.hpp"


### PR DESCRIPTION
mesh to particle for GPGPU will likely be per particle anyway

I would argue this is also better for cache, as there's only one particle loop now for interpoloate/accelerate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new search functionality with a dedicated search bar for improved user experience.
  - Added a `box()` function to the `ParticleArray` class for enhanced data access.

- **Improvements**
  - Enhanced the `Interpolator` class to support single particle processing, providing more precise electromagnetic field interpolation.
  - Refined the `BorisPusher` class with new pre-push and post-push step functions for better particle movement control.
  - Added a `dimension` constant to the `Box` struct for clearer dimensionality representation.
  - Implemented a default template argument in the `Point` class's `toArray` method for increased flexibility.

- **Bug Fixes**
  - Removed unnecessary particle attribute assertions from various test cases to align with updated particle data handling.

- **Refactor**
  - Streamlined the `Particle` struct by removing unused electromagnetic field variables and updating related functions.
  - Simplified test cases for interpolators by using range-based loops for better readability and maintainability.

- **Documentation**
  - Updated test case descriptions to reflect the removal of specific particle attribute checks.

- **Chores**
  - Updated include directives from "benchmark/benchmark.hpp" to "benchmark/benchmark.h" across several files.

- **Style**
  - Applied consistent formatting changes to various test cases and classes for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->