### PR TITLE
log errors during caliper run for debug

### DIFF
--- a/src/core/numerics/interpolator/interpolator.hpp
+++ b/src/core/numerics/interpolator/interpolator.hpp
@@ -473,8 +473,6 @@ public:
     template<typename Particle_t, typename Electromag, typename GridLayout>
     inline auto operator()(Particle_t& currPart, Electromag const& Em, GridLayout const& layout)
     {
-        PHARE_LOG_SCOPE("Interpolator::operator()");
-
         using E_B_tuple = std::tuple<std::array<double, 3>, std::array<double, 3>>;
         using Scalar    = HybridQuantity::Scalar;
 
@@ -483,8 +481,6 @@ public:
         // electromagnetic component, we use Interpol to actually perform the
         // interpolation. the trick here is that the StartIndex and weights have only been
         // calculated twice, and not for each E,B component.
-
-        PHARE_LOG_START("MeshToParticle::operator()");
 
         auto& iCell = currPart.iCell;
         auto& delta = currPart.delta;
@@ -509,7 +505,6 @@ public:
         pBy = meshToParticle_.template operator()<GridLayout, Scalar::By>(By, indexWeights);
         pBz = meshToParticle_.template operator()<GridLayout, Scalar::Bz>(Bz, indexWeights);
 
-        PHARE_LOG_STOP("MeshToParticle::operator()");
         return particle_EB;
     }
 

--- a/src/core/utilities/cellmap.hpp
+++ b/src/core/utilities/cellmap.hpp
@@ -234,7 +234,6 @@ template<std::size_t dim, typename cell_index_t>
 template<typename Array, typename CellExtractor, typename>
 inline void CellMap<dim, cell_index_t>::add(Array const& items, CellExtractor extract)
 {
-    PHARE_LOG_SCOPE("CellMap::add (array)");
     for (std::size_t itemIndex = 0; itemIndex < items.size(); ++itemIndex)
     {
         addToCell(extract(items[itemIndex]), itemIndex);
@@ -247,7 +246,6 @@ inline void CellMap<dim, cell_index_t>::add(Array const& items, std::size_t firs
                                             CellExtractor extract)
 
 {
-    PHARE_LOG_SCOPE("CellMap::add (iterator)");
     for (auto itemIndex = first; itemIndex <= last; ++itemIndex)
     {
         addToCell(extract(items[itemIndex]), itemIndex);
@@ -260,7 +258,6 @@ template<typename Array, typename CellExtractor, typename>
 inline void CellMap<dim, cell_index_t>::add(Array const& items, std::size_t itemIndex,
                                             CellExtractor extract)
 {
-    PHARE_LOG_SCOPE("CellMap::add (add 1 index)");
     addToCell(extract(items[itemIndex]), itemIndex);
 }
 

--- a/tools/ctest_exec_mp.py
+++ b/tools/ctest_exec_mp.py
@@ -1,5 +1,3 @@
-
-
 import os
 import sys
 from pathlib import Path
@@ -18,12 +16,18 @@ def run_tests_log_to_file(data_dir, n_cores, tests):
     """ ctest seems to merge stdout and stderr so we only need one output file """
     import concurrent.futures
 
+    stdout_dir = data_dir/"stdout"
+    stdout_dir.mkdir(parents=True, exist_ok=True)
+    stderr_dir = data_dir/"stderr"
+    stderr_dir.mkdir(parents=True, exist_ok=True)
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_cores) as executor:
         jobs = [
           executor.submit(
             run, cmake.test_cmd(test, verbose=True),
-            shell=True, capture_output=False, check=True,
-            stdout=open(os.path.join(str(data_dir), test), "w"))
+            shell=True, capture_output=False, check=False,
+            stdout=open(os.path.join(str(stdout_dir), test), "w"),
+            stderr=open(os.path.join(str(stderr_dir), test), "w"))
             for i, test in enumerate(tests)
         ]
         results = []
@@ -37,11 +41,13 @@ def run_tests_log_to_file(data_dir, n_cores, tests):
 def main():
     with pushd(os.path.join(str(root), "build")):
         current_git_hash = git.hashes(1)[0]
-        data_dir = Path(os.path.join(str(root), "data_out", current_git_hash, "ctest_logs"))
-        os.makedirs(str(data_dir), exist_ok=True)
+        data_dir = Path(os.path.join(str(root), "data_out", current_git_hash))
         N_CORES= int(os.environ["N_CORES"]) if "N_CORES" in os.environ else 1
         print(f"Launching ctests with N_CORES {N_CORES}")
-        run_tests_log_to_file(data_dir, N_CORES, cmake.list_tests())
+        results = run_tests_log_to_file(data_dir, N_CORES, cmake.list_tests())
+        if any([result.returncode > 0 for result in results]):
+            sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I'm guessing there's an error in the caliper run so it just hangs as a result

it's kinda strange we don't see it regularly

I'm running this change on kaa atm

TC build unnecessary 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved test execution handling, including separate directories for stdout and stderr and enhanced return code checks.
  - Streamlined logging within the `Interpolator` class to enhance performance and reduce output clutter.
  - Adjusted logging in the `CellMap` class for a cleaner and more efficient runtime behavior.

- **Chores**
  - General code maintenance for better clarity and maintainability.

*Please note that these changes are aimed at improving the overall user experience and system reliability, although they may not result in direct visible changes to end-users.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->