### PR TITLE
allow fp32 diags in python tests

### DIFF
--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -122,6 +122,18 @@ class FloatingPoint_comparator:
         return fp_gtr_equal(self.fp, other.fp, self.atol)
 
 
+def is_fp32(item):
+    if is_nd_array(item):
+        return item.dtype == np.single
+    return isinstance(item, float)
+
+
+def assert_fp_any_all_close(a, b, atol=1e-16, rtol=0, atol_fp32=None):
+    if any([is_fp32(el) for el in [a, b]]):
+        atol = atol_fp32 if atol_fp32 else atol * 1e8
+    np.testing.assert_allclose(a, b, atol=atol, rtol=rtol)
+
+
 def decode_bytes(input, errors="ignore"):
     return input.decode("ascii", errors=errors)
 

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -8,7 +8,7 @@ import numpy as np
 import pyphare.core.box as boxm
 from ddt import ddt
 from pyphare.core.box import Box
-from pyphare.core.phare_utilities import np_array_ify
+from pyphare.core.phare_utilities import assert_fp_any_all_close, np_array_ify
 from pyphare.pharein import ElectronModel, MaxwellianFluidModel
 from pyphare.pharein.diagnostics import (
     ElectromagDiagnostics,
@@ -289,14 +289,12 @@ class AdvanceTestBase(SimulatorTest):
                         ]
 
                     try:
-                        assert slice1.dtype == np.float64
-
                         # empirical max absolute observed 5.2e-15
                         # https://hephaistos.lpp.polytechnique.fr/teamcity/buildConfiguration/Phare_Phare_BuildGithubPrClang/78544
                         # seems correct considering ghosts are filled with schedules
                         # involving linear/spatial interpolations and so on where
                         # rounding errors may occur.... setting atol to 5.5e-15
-                        np.testing.assert_allclose(slice1, slice2, atol=5.5e-15, rtol=0)
+                        assert_fp_any_all_close(slice1, slice2, atol=5.5e-15, rtol=0)
                         checks += 1
                     except AssertionError as e:
                         print("AssertionError", pd1.name, e)
@@ -531,7 +529,7 @@ class AdvanceTestBase(SimulatorTest):
                                 # https://hephaistos.lpp.polytechnique.fr/teamcity/buildConfiguration/Phare_Phare_BuildGithubPrClang/78507?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandPull+Request+Details=true&expandBuildProblemsSection=true&expandBuildChangesSection=true&showLog=78507_7510_4947&logView=flowAware
                                 # raising the bar at 2e-15 since clang failed for mpi test at 1.07.... e-15
                                 try:
-                                    np.testing.assert_allclose(
+                                    assert_fp_any_all_close(
                                         coarse_pdDataset,
                                         afterCoarse,
                                         atol=2e-15,
@@ -665,7 +663,7 @@ class AdvanceTestBase(SimulatorTest):
                                         )
 
                                     try:
-                                        np.testing.assert_allclose(
+                                        assert_fp_any_all_close(
                                             fine_ghostbox_data,
                                             refinedInterpGhostBox_data,
                                             atol=1e-15,

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 from ddt import ddt
 from pyphare.core.box import nDBox
+from pyphare.core.phare_utilities import assert_fp_any_all_close
 from pyphare.pharein import ElectronModel, MaxwellianFluidModel
 from pyphare.pharein.diagnostics import (
     ElectromagDiagnostics,
@@ -295,9 +296,9 @@ class InitializationTest(SimulatorTest):
 
                 if dim == 1:
                     # discrepancy in 1d for some reason : https://github.com/PHAREHUB/PHARE/issues/580
-                    np.testing.assert_allclose(bx, bx_fn(xbx), atol=1e-15, rtol=0)
-                    np.testing.assert_allclose(by, by_fn(xby), atol=1e-15, rtol=0)
-                    np.testing.assert_allclose(bz, bz_fn(xbz), atol=1e-15, rtol=0)
+                    assert_fp_any_all_close(bx, bx_fn(xbx), atol=1e-15, rtol=0)
+                    assert_fp_any_all_close(by, by_fn(xby), atol=1e-15, rtol=0)
+                    assert_fp_any_all_close(bz, bz_fn(xbz), atol=1e-15, rtol=0)
 
                 if dim >= 2:
                     ybx = bx_pd.y[:]
@@ -315,11 +316,11 @@ class InitializationTest(SimulatorTest):
                         a.flatten() for a in np.meshgrid(xbz, ybz, indexing="ij")
                     ]
 
-                    np.testing.assert_allclose(bx, bx_fn(xbx, ybx), atol=1e-16, rtol=0)
-                    np.testing.assert_allclose(
+                    assert_fp_any_all_close(bx, bx_fn(xbx, ybx), atol=1e-16, rtol=0)
+                    assert_fp_any_all_close(
                         by, by_fn(xby, yby).reshape(by.shape), atol=1e-16, rtol=0
                     )
-                    np.testing.assert_allclose(
+                    assert_fp_any_all_close(
                         bz, bz_fn(xbz, ybz).reshape(bz.shape), atol=1e-16, rtol=0
                     )
 


### PR DESCRIPTION
we could turn off fp64 diags in the github actions build to test this

tested locally otherwise

![image](https://github.com/PHAREHUB/PHARE/assets/30491/6d73a56a-3c71-46a8-b7bd-d6b77238c939)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced floating-point comparison functions for increased precision in numerical operations.

- **Refactor**
  - Improved numerical comparison logic in tests for more accurate simulation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->