### PR TITLE
add serialized simulation to diagnostics files

### DIFF
--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -251,9 +251,14 @@ def populateDict():
     addInitFunction(maginit_path + "y_component", fn_wrapper(modelDict["by"]))
     addInitFunction(maginit_path + "z_component", fn_wrapper(modelDict["bz"]))
 
+    serialized_sim = serialize_sim(simulation)
+
     #### adding diagnostics
+
     diag_path = "simulation/diagnostics/"
     for diag in list(simulation.diagnostics.values()):
+        diag.attributes["serialized_simulation"] = serialized_sim
+
         type_path = diag_path + diag.type + "/"
         name_path = type_path + diag.name
         add_string(name_path + "/" + "type", diag.type)
@@ -265,6 +270,7 @@ def populateDict():
         pp.add_array_as_vector(
             name_path + "/" + "compute_timestamps", diag.compute_timestamps
         )
+
         add_size_t(name_path + "/" + "n_attributes", len(diag.attributes))
         for attr_idx, attr_key in enumerate(diag.attributes):
             add_string(name_path + "/" + f"attribute_{attr_idx}_key", attr_key)
@@ -343,7 +349,7 @@ def populateDict():
                 restarts_path + "write_timestamps", restart_options["timestamps"]
             )
 
-        add_string(restarts_path + "serialized_simulation", serialize_sim(simulation))
+        add_string(restarts_path + "serialized_simulation", serialized_sim)
     #### restarts added
 
     #### adding electrons

--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ..core import phare_utilities
 from . import global_vars
 
@@ -44,8 +46,6 @@ def diagnostics_checker(func):
 
     return wrapper
 
-
-import numpy as np
 
 # ------------------------------------------------------------------------------
 def validate_timestamps(clazz, key, **kwargs):
@@ -173,7 +173,6 @@ class ElectromagDiagnostics(Diagnostics):
         )
 
     def _setSubTypeAttributes(self, **kwargs):
-
         if kwargs["quantity"] not in ElectromagDiagnostics.em_quantities:
             error_msg = "Error: '{}' not a valid electromag diagnostics : " + ", ".join(
                 ElectromagDiagnostics.em_quantities
@@ -201,7 +200,6 @@ def population_in_model(population):
 
 
 class FluidDiagnostics_(Diagnostics):
-
     fluid_quantities = [
         "density",
         "mass_density",
@@ -327,7 +325,6 @@ class ParticleDiagnostics(Diagnostics):
         self.quantity = "/ions/pop/" + self.population_name + "/" + self.quantity
 
     def space_box(self, **kwargs):
-
         if "extent" not in kwargs and self.quantity == "space_box":
             raise ValueError(
                 "Error: missing 'extent' parameter required by 'space_box' the ParticleDiagnostics type"
@@ -352,7 +349,6 @@ class ParticleDiagnostics(Diagnostics):
 
 
 class MetaDiagnostics(Diagnostics):
-
     meta_quantities = ["tags"]
     type = "info"
 

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -581,6 +581,7 @@ class PatchHierarchy(object):
         self.refinement_ratio = refinement_ratio
 
         self.data_files = {}
+        self._sim = None
 
         if data_files is not None:
             self.data_files.update(data_files)
@@ -607,6 +608,21 @@ class PatchHierarchy(object):
 
     def __getitem__(self, qty):
         return self.__dict__[qty]
+
+    @property
+    def sim(self):
+        if self._sim:
+            return self._sim
+
+        if "py_attrs" not in self.data_files:
+            raise ValueError("Simulation is not available for deserialization")
+
+        from ..pharein.simulation import deserialize
+
+        self._sim = deserialize(
+            self.data_files["py_attrs"].attrs["serialized_simulation"]
+        )
+        return self._sim
 
     def __call__(self, qty=None, **kwargs):
         # take slice/slab of 1/2d array from 2/3d array

--- a/pyphare/pyphare/pharesee/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy.py
@@ -619,9 +619,12 @@ class PatchHierarchy(object):
 
         from ..pharein.simulation import deserialize
 
-        self._sim = deserialize(
-            self.data_files["py_attrs"].attrs["serialized_simulation"]
-        )
+        try:
+            self._sim = deserialize(
+                self.data_files["py_attrs"].attrs["serialized_simulation"]
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to deserialize simulation from data file : {e}")
         return self._sim
 
     def __call__(self, qty=None, **kwargs):

--- a/pyphare/pyphare/pharesee/run.py
+++ b/pyphare/pyphare/pharesee/run.py
@@ -111,7 +111,6 @@ def _divB2D(Bx, By, xBx, yBy):
 
 
 def _compute_divB(patchdatas, **kwargs):
-
     reference_pd = patchdatas["Bx"]  # take Bx as a reference, but could be any other
     ndim = reference_pd.box.ndim
 

--- a/tests/simulator/test_diagnostics.py
+++ b/tests/simulator/test_diagnostics.py
@@ -160,7 +160,7 @@ class DiagnosticsTest(unittest.TestCase):
         simInput["refinement_boxes"] = {"L0": {"B0": b0}}
 
         py_attrs = [f"{dep}_version" for dep in ["samrai", "highfive", "pybind"]]
-        py_attrs += ["git_hash"]
+        py_attrs += ["git_hash", "serialized_simulation"]
 
         for interp in range(1, 4):
             print("test_dump_diags dim/interp:{}/{}".format(dim, interp))
@@ -202,6 +202,13 @@ class DiagnosticsTest(unittest.TestCase):
                 h5_py_attrs = h5_file["py_attrs"].attrs.keys()
                 for py_attr in py_attrs:
                     self.assertIn(py_attr, h5_py_attrs)
+
+                assert (
+                    ph.simulation.deserialize(
+                        h5_file["py_attrs"].attrs["serialized_simulation"]
+                    ).electrons.closure.Te
+                    == 0.12
+                )
 
                 hier = hierarchy_from(h5_filename=h5_filepath)
                 if h5_filepath.endswith("domain.h5"):

--- a/tests/simulator/test_diagnostics.py
+++ b/tests/simulator/test_diagnostics.py
@@ -211,6 +211,9 @@ class DiagnosticsTest(unittest.TestCase):
                 )
 
                 hier = hierarchy_from(h5_filename=h5_filepath)
+
+                assert hier.sim.electrons.closure.Te == 0.12
+
                 if h5_filepath.endswith("domain.h5"):
                     particle_files += 1
                     self.assertTrue("pop_mass" in h5_file.attrs)


### PR DESCRIPTION
how to use

```
import pyphare.pharein as ph
from pyphare.pharesee.run import Run

b = Run(".").GetB(0)
sim = ph.simulation.deserialize(b.data_files["py_attrs"].attrs["serialized_simulation"])
print(sim.electrons.closure.Te)
```

this next form is provided for convenience

```
import pyphare.pharein as ph
from pyphare.pharesee.run import Run

b = Run(".").GetB(0)
print(b.sim.electrons.closure.Te)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduce functionality to store and utilize serialized simulation data for diagnostics and restarts.

- **Refactor**
	- Minor code reorganization and formatting improvements in diagnostics handling.
	- Removed an unnecessary empty line for code cleanliness.

- **Tests**
	- Enhanced diagnostics tests to include checks for serialized simulation data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->