### PR TITLE
highfive version correction

### DIFF
--- a/src/hdf5/phare_hdf5.hpp
+++ b/src/hdf5/phare_hdf5.hpp
@@ -4,6 +4,13 @@
 
 #if PHARE_HAS_HIGHFIVE
 
+#include "highfive/H5Version.hpp"
+
+#ifndef HIGHFIVE_VERSION_STRING
+#pragma message("Highfive must be at least version 2.7.1")
+#error // highfive is too old
+#endif
+
 #define _PHARE_WITH_HIGHFIVE(...) __VA_ARGS__
 #else
 #define _PHARE_WITH_HIGHFIVE(...)

--- a/src/python3/cpp_etc.cpp
+++ b/src/python3/cpp_etc.cpp
@@ -40,7 +40,7 @@ PYBIND11_MODULE(cpp_etc, m)
     m.def("phare_deps", []() {
         std::unordered_map<std::string, std::string> versions{{"pybind", pybind_version()},
                                                               {"samrai", samrai_version()}};
-        _PHARE_WITH_HIGHFIVE(versions["highfive"] = PHARE_TO_STR(HIGHFIVE_VERSION));
+        _PHARE_WITH_HIGHFIVE(versions["highfive"] = HIGHFIVE_VERSION_STRING);
         return versions;
     });
 

--- a/tests/simulator/test_diagnostics.py
+++ b/tests/simulator/test_diagnostics.py
@@ -203,7 +203,11 @@ class DiagnosticsTest(unittest.TestCase):
                 for py_attr in py_attrs:
                     self.assertIn(py_attr, h5_py_attrs)
 
-                assert (
+                h5_version = h5_file["py_attrs"].attrs["highfive_version"].split(".")
+                self.assertTrue(len(h5_version) == 3)
+                self.assertTrue(all(i.isdigit() for i in h5_version))
+
+                self.assertTrue(
                     ph.simulation.deserialize(
                         h5_file["py_attrs"].attrs["serialized_simulation"]
                     ).electrons.closure.Te
@@ -212,7 +216,7 @@ class DiagnosticsTest(unittest.TestCase):
 
                 hier = hierarchy_from(h5_filename=h5_filepath)
 
-                assert hier.sim.electrons.closure.Te == 0.12
+                self.assertTrue(hier.sim.electrons.closure.Te == 0.12)
 
                 if h5_filepath.endswith("domain.h5"):
                     particle_files += 1


### PR DESCRIPTION
fix highfive version in diagsnotics

currently it looks like this

```
[('git_hash', '3ce9013'), ('highfive_version', 'HIGHFIVE_VERSION'), ('pybind_version', '2.11.0.dev1'), ('samrai_version', '4.2.0')]
```

which is wrong

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a version check for the HighFive library to ensure compatibility.
- **Bug Fixes**
	- Updated the method for reporting the HighFive version in dependencies.
- **Tests**
	- Introduced a new test to verify the version attribute format in HDF5 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->