### PR TITLE
PIC model

### DIFF
--- a/src/amr/CMakeLists.txt
+++ b/src/amr/CMakeLists.txt
@@ -59,6 +59,7 @@ set( SOURCES_INC
      physical_models/physical_model.hpp
      physical_models/hybrid_model.hpp
      physical_models/mhd_model.hpp
+     physical_models/pic_model.hpp
      multiphysics_integrator.hpp
      messenger_registration.hpp
      level_initializer/level_initializer.hpp

--- a/src/amr/physical_models/pic_model.hpp
+++ b/src/amr/physical_models/pic_model.hpp
@@ -1,0 +1,210 @@
+#ifndef PHARE_PIC_MODEL_HPP
+#define PHARE_PIC_MODEL_HPP
+
+#include <string>
+#include <cmath>
+
+#include "initializer/data_provider.hpp"
+#include "core/models/pic_state.hpp"
+#include "amr/physical_models/physical_model.hpp"
+#include "core/data/ions/particle_initializers/particle_initializer_factory.hpp"
+#include "amr/resources_manager/resources_manager.hpp"
+#include "amr/messengers/hybrid_messenger_info.hpp"
+#include "core/data/vecfield/vecfield.hpp"
+#include "core/def.hpp"
+
+
+
+namespace PHARE::solver
+{
+/**
+ * @brief The PICModel class is a concrete implementation of a IPhysicalModel. The class
+ * holds a PICState and a ResourcesManager.
+ */
+template<typename GridLayoutT, typename Electromag, typename Fermions, typename AMR_Types>
+class PICModel : public IPhysicalModel<AMR_Types>
+{
+public:
+    using patch_t   = typename AMR_Types::patch_t;
+    using level_t   = typename AMR_Types::level_t;
+    using Interface = IPhysicalModel<AMR_Types>;
+
+    static const std::string model_name;
+    static constexpr auto dimension = GridLayoutT::dimension;
+    static constexpr auto interp_order = GridLayoutT::interp_order;
+    using resources_manager_type    = amr::ResourcesManager<GridLayoutT>;
+
+    core::PICState<Electromag, Fermions> state; 
+    std::shared_ptr<resources_manager_type> resourcesManager;
+
+
+
+    virtual void initialize(level_t& level) override;
+
+    /**
+     * @brief allocate uses the ResourcesManager to allocate PICState physical quantities on
+     * the given Patch at the given allocateTime
+     */
+    virtual void allocate(patch_t& patch, double const allocateTime) override
+    {
+        resourcesManager->allocate(state, patch, allocateTime);
+    }
+
+    // TODO check purpose
+    auto patch_data_ids() const { return resourcesManager->restart_patch_data_ids(*this); }
+
+    /**
+     * @brief fillMessengerInfo describes which variables of the model are to be initialized or
+     * filled at ghost nodes.
+     */
+    virtual void
+    fillMessengerInfo(std::unique_ptr<amr::IMessengerInfo> const& info) const override
+    {
+    }
+
+    NO_DISCARD auto setOnPatch(patch_t& patch)
+    {
+        return resourcesManager->setOnPatch(patch, *this);
+    }
+
+   
+    explicit PICModel(PHARE::initializer::PHAREDict const& dict,
+                      std::shared_ptr<resources_manager_type> const& _resourcesManager)
+                    : IPhysicalModel<AMR_Types>{model_name}
+                    , state{dict}
+                    , resourcesManager{std::move(_resourcesManager)}
+    {
+    }
+
+    virtual ~PICModel() override = default;
+
+    //-------------------------------------------------------------------------
+    //                  start the ResourcesUser interface
+    //-------------------------------------------------------------------------
+
+    NO_DISCARD bool isUsable() const { return state.isUsable(); }
+
+    NO_DISCARD bool isSettable() const { return state.isSettable(); }
+
+    NO_DISCARD auto getCompileTimeResourcesUserList() const { return std::forward_as_tuple(state); }
+
+    NO_DISCARD auto getCompileTimeResourcesUserList() { return std::forward_as_tuple(state); }
+
+    //-------------------------------------------------------------------------
+    //                  ends the ResourcesUser interface
+    //-------------------------------------------------------------------------
+
+    std::unordered_map<std::string, std::shared_ptr<core::NdArrayVector<dimension, int>>> tags;
+
+};
+
+template<typename GridLayoutT, typename VecFieldT, typename AMR_Types>
+const std::string PICModel<GridLayoutT, Electromag, Fermions, AMR_Types>::model_name = "PICModel";
+
+//-------------------------------------------------------------------------
+//                             definitions
+//-------------------------------------------------------------------------
+
+
+template<typename GridLayoutT, typename Electromag, typename Fermions,
+         typename AMR_Types>
+void PICModel<GridLayoutT, Electromag, Fermions, AMR_Types>::initialize(level_t& level)
+{
+    double T = 0.0;
+
+    for (auto& patch : level)
+    {
+        // first initialize the ions
+        auto layout = amr::layoutFromPatch<gridlayout_type>(*patch);
+        auto& fermions  = state.fermions;
+        auto& ions = fermions.ions;
+        auto& electrons = fermions.electrons;
+        auto _      = this->resourcesManager->setOnPatch(*patch, state.electromag, fermions);
+
+        for (auto& pop : ions)
+        {
+            auto const& info         = pop.particleInitializerInfo();
+            auto particleInitializer = ParticleInitializerFactory::create(info);
+            particleInitializer->loadParticles(pop.domainParticles(), layout);
+
+            // this should ideally be done only once, but it's a way to get the temperature
+            T = info["thermal_velocity_x"] * info["thermal_velocity_x"] * pop.mass();
+            
+        }
+        // then the electrons
+        for (auto& pop : electrons)
+        {
+            auto const& info         = pop.particleInitializerInfo(); 
+            info["nbrParticlesPerCell"] = ions.density();
+            info["bulk_velocity_x"] = ions.velocity()[0]; // as per hybrid model
+            info["bulk_velocity_y"] = ions.velocity()[1];
+            info["bulk_velocity_z"] = ions.velocity()[2];
+            info["thermal_velocity_x"] = sqrt( T / pop.mass() ); 
+            info["thermal_velocity_y"] = info["thermal_velocity_x"];
+            info["thermal_velocity_z"] = info["thermal_velocity_x"];
+
+            auto particleInitializer = ParticleInitializerFactory::create(info);
+            particleInitializer->loadParticles(pop.domainParticles(), layout);
+        }
+        state.electromag.initialize(layout);
+    }
+
+    resourcesManager->registerForRestarts(*this);
+}
+
+// TODO adapt to PIC messenger
+template<typename GridLayoutT, typename Electromag, typename Fermions, typename AMR_Types>
+void PICModel<GridLayoutT, Electromag, Fermions, AMR_Types>::fillMessengerInfo(
+    std::unique_ptr<amr::IMessengerInfo> const& info) const
+{
+    auto& hybridInfo = dynamic_cast<amr::HybridMessengerInfo&>(*info);
+    auto& ions = state.fermions.ions;
+
+    hybridInfo.modelMagnetic        = core::VecFieldNames{state.electromag.B};
+    hybridInfo.modelElectric        = core::VecFieldNames{state.electromag.E};
+    hybridInfo.modelIonDensity      = ions.densityName();
+    hybridInfo.modelIonBulkVelocity = core::VecFieldNames{ions.velocity()};
+    hybridInfo.modelCurrent         = core::VecFieldNames{state.J};
+
+    hybridInfo.initElectric.emplace_back(core::VecFieldNames{state.electromag.E});
+    hybridInfo.initMagnetic.emplace_back(core::VecFieldNames{state.electromag.B});
+
+    hybridInfo.ghostElectric.push_back(hybridInfo.modelElectric);
+    hybridInfo.ghostMagnetic.push_back(hybridInfo.modelMagnetic);
+    hybridInfo.ghostCurrent.push_back(core::VecFieldNames{state.J});
+    hybridInfo.ghostBulkVelocity.push_back(hybridInfo.modelIonBulkVelocity);
+
+
+    auto transform_ = [](auto& ions, auto& inserter) {
+        std::transform(std::begin(ions), std::end(ions), std::back_inserter(inserter),
+                       [](auto const& pop) { return pop.name(); });
+    };
+    transform_(ions, hybridInfo.interiorParticles);
+    transform_(ions, hybridInfo.levelGhostParticlesOld);
+    transform_(ions, hybridInfo.levelGhostParticlesNew);
+    transform_(ions, hybridInfo.patchGhostParticles);
+}
+
+
+/* 
+Used to define certain behaviors at compile. Used in diagnotics and restart. Useless unless those
+files are modified, which will happen at some point.
+*/
+template<typename... Args>
+PICModel<Args...> pic_model_from_type_list(core::type_list<Args...>);
+
+template<typename TypeList>
+struct type_list_to_pic_model
+{
+    using type = decltype(pic_model_from_type_list(std::declval<TypeList>()));
+};
+
+template<typename TypeList>
+using type_list_to_pic_model_t = typename type_list_to_pic_model<TypeList>::type;
+
+
+
+
+} // namespace PHARE::solver
+
+#endif

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,6 +25,7 @@ set( SOURCES_INC
      data/vecfield/vecfield_component.hpp
      data/vecfield/vecfield_initializer.hpp
      hybrid/hybrid_quantities.hpp
+     pic/pic_quantities.hpp
      numerics/boundary_condition/boundary_condition.hpp
      numerics/interpolator/interpolator.hpp
      numerics/pusher/boris.hpp
@@ -38,6 +39,7 @@ set( SOURCES_INC
      models/physical_state.hpp
      models/hybrid_state.hpp
      models/mhd_state.hpp
+     models/pic_state.hpp
      utilities/box/box.hpp
      utilities/algorithm.hpp
      utilities/constants.hpp

--- a/src/core/models/pic_state.hpp
+++ b/src/core/models/pic_state.hpp
@@ -1,0 +1,80 @@
+#ifndef PHARE_PIC_STATE_HPP
+#define PHARE_PIC_STATE_HPP
+
+#include "core/pic/pic_quantities.hpp"
+#include "core/models/physical_state.hpp"
+#include "initializer/data_provider.hpp"
+#include "core/def.hpp"
+#include "core/utilities/algorithm.hpp"
+
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace PHARE::core
+{
+
+/**
+ * @brief The PICState class is a concrete implementation of a IPhysicalState.
+ * It holds an Electromag and an Fermion object manipulated by a  PIC concrete type of
+ * ISolver
+ */
+template<typename Electromag, typename Fermions>
+class PICState : public IPhysicalState
+{
+
+using VecField = typename Electromag::vecfield_type;
+    
+public:
+
+    static constexpr auto dimension = Fermions::dimension;
+
+    PICState(PHARE::initializer::PHAREDict const& dict)
+        : electromag{dict["electromag"]}
+        , fermions{} // TODO
+        , J{"J", PICQuantity::Vector::J}
+    {
+    }
+
+    Electromag electromag;
+    Fermions fermions;
+    VecField J;
+
+    //-------------------------------------------------------------------------
+    //                  start the ResourcesUser interface
+    //-------------------------------------------------------------------------
+
+        NO_DISCARD bool isUsable() const
+        {
+            return electromag.isUsable() && fermions.isUsable() && J.isUsable();
+        }
+
+
+
+        NO_DISCARD bool isSettable() const
+        {
+            return electromag.isSettable() && fermions.isSettable() && J.isSettable();
+        }
+
+
+        NO_DISCARD auto getCompileTimeResourcesUserList() const
+        {
+            return std::forward_as_tuple(electromag, fermions);
+        }
+
+        NO_DISCARD auto getCompileTimeResourcesUserList()
+        {
+            return std::forward_as_tuple(electromag, fermions);
+        }
+
+    //-------------------------------------------------------------------------
+    //                  ends the ResourcesUser interface
+    //-------------------------------------------------------------------------
+
+};// end PICState 
+
+} // namespace PHARE::core
+
+
+#endif // PHARE_PIC_STATE_HPP

--- a/src/core/pic/pic_quantities.hpp
+++ b/src/core/pic/pic_quantities.hpp
@@ -1,0 +1,94 @@
+#ifndef PHARE_CORE_PIC_PIC_QUANTITIES_HPP
+#define PHARE_CORE_PIC_PIC_QUANTITIES_HPP
+
+#include "core/def.hpp"
+
+#include <array>
+#include <tuple>
+#include <stdexcept>
+
+
+namespace PHARE::core
+{
+class PICQuantity
+{
+public:
+    enum class Scalar {
+        Bx, // magnetic field components
+        By,
+        Bz,
+        Ex, // electric field components
+        Ey,
+        Ez,
+        Jx, // current density components
+        Jy,
+        Jz,
+        rho, // charge density
+        Vx,  // bulk velocity components for ions
+        Vy,
+        Vz,
+        Mxx, // momentum tensor components
+        Mxy,
+        Mxz,
+        Myy,
+        Myz,
+        Mzz,
+        Vex,  // bulk velocity components for electrons
+        Vey,
+        Vez,
+        count
+    };
+    enum class Vector { B, E, J, V, Ve };
+    enum class Tensor { M, count };
+
+    template<std::size_t rank, typename = std::enable_if_t<rank == 1 or rank == 2, void>>
+    using TensorType = std::conditional_t<rank == 1, Vector, Tensor>;
+
+    NO_DISCARD static constexpr auto B() { return componentsQuantities(Vector::B); }
+    NO_DISCARD static constexpr auto E() { return componentsQuantities(Vector::E); }
+    NO_DISCARD static constexpr auto J() { return componentsQuantities(Vector::J); }
+    NO_DISCARD static constexpr auto V() { return componentsQuantities(Vector::V); }
+    NO_DISCARD static constexpr auto Ve() { return componentsQuantities(Vector::Ve); }
+
+    NO_DISCARD static constexpr std::array<Scalar, 3> componentsQuantities(Vector qty)
+    {
+        if (qty == Vector::B)
+            return {{Scalar::Bx, Scalar::By, Scalar::Bz}};
+
+        if (qty == Vector::E)
+            return {{Scalar::Ex, Scalar::Ey, Scalar::Ez}};
+
+        if (qty == Vector::J)
+            return {{Scalar::Jx, Scalar::Jy, Scalar::Jz}};
+
+        if (qty == Vector::V)
+            return {{Scalar::Vx, Scalar::Vy, Scalar::Vz}};
+
+        if (qty == Vector::Ve)
+            return {{Scalar::Vex, Scalar::Vey, Scalar::Vez}};
+
+        throw std::runtime_error("Error - invalid Vector");
+    }
+    static constexpr std::array<Scalar, 6> componentsQuantities(Tensor qty)
+    {
+        // no condition, for now there's only then momentum tensor M
+        return {{Scalar::Mxx, Scalar::Mxy, Scalar::Mxz, Scalar::Myy, Scalar::Myz, Scalar::Mzz}};
+    }
+
+    NO_DISCARD static constexpr auto B_items()
+    {
+        auto const& [Bx, By, Bz] = B();
+        return std::make_tuple(std::make_pair("Bx", Bx), std::make_pair("By", By),
+                               std::make_pair("Bz", Bz));
+    }
+    NO_DISCARD static constexpr auto E_items()
+    {
+        auto const& [Ex, Ey, Ez] = E();
+        return std::make_tuple(std::make_pair("Ex", Ex), std::make_pair("Ey", Ey),
+                               std::make_pair("Ez", Ez));
+    }
+};
+
+} // namespace PHARE::core
+
+#endif


### PR DESCRIPTION
The pic quantities are probably superfluous but I didn't want to mess with the existing code if it could be avoided, hence the duplicate.

**State**: declares and initializes fermions + sets them as ResourcesUser. Except they're not actually initialized as anything for now because I can't figure how to do that without passing a dictionary to them, and passing a dictionary would mean changing the entire cppdict since we'd need to create a new entry from which ions whould branch out, except that would affect the hybrid state as well, etc. basically would like to avoid opening that can of worms.
OR we could drop the whole idea of a superclass for both particles and just treat ions and electrons separately, and just create new entries for PIC electrons that would just be ignored in hybrid state.
also declares type_list_to_pic_model_t

**Model**: main difference from hybrid model is the way the electrons are treated. MessengerInfo is from hybrid since only the ions are coarsened/refined. If we also want to coarsen the electron data that'll have to change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new physical model (`PICModel`) for Particle-in-Cell (PIC) simulations, enhancing the simulation capabilities.
	- Added new classes (`PICState` and `PICQuantity`) to support advanced PIC simulations, including electromagnetic and fermion quantity management, and defining enums for various physical quantities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->