### PR TITLE
git hash in build/runtime logs

### DIFF
--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -154,19 +154,6 @@ def run_cli_cmd(cmd, shell=True, capture_output=True, check=False, print_cmd=Fal
         raise RuntimeError(decode_bytes(e.stderr))
 
 
-def git_hashes(N=1):
-    return decode_bytes(
-        run_cli_cmd(f"git log -{N} --pretty=format:%h").stdout
-    ).splitlines()
-
-
-def top_git_hash():
-    hashes = git_hashes(1)
-    if len(hashes) > 0:
-        return hashes[0]
-    return "master"  # github actions fails?
-
-
 def print_trace():
     import sys, traceback
 

--- a/pyphare/pyphare/cpp/validate.py
+++ b/pyphare/pyphare/cpp/validate.py
@@ -67,10 +67,19 @@ def check_build_config_is_runtime_compatible(strict=True):
             raise e
 
 
+def get_git_hash():
+    build_config: dict = cpp.build_config()
+
+    if "PHARE_CONFIG_ERROR" in build_config:
+        return "git hash not available"
+    return build_config["GIT_HASH"]
+
+
 @dataclasses.dataclass
 class RuntimeSettings:
     python_version: str
     python_binary: str
+    git_hash: str
 
 
 def try_system_binary(cli, log_to):
@@ -93,7 +102,9 @@ def log_runtime_config():
     cpp_lib = cpp.cpp_lib()
 
     settings = RuntimeSettings(
-        python_binary=sys.executable, python_version=python_version_from(sys.executable)
+        python_binary=sys.executable,
+        python_version=python_version_from(sys.executable),
+        git_hash=get_git_hash(),
     )
 
     if cpp_lib.mpi_rank() == 0:

--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -93,6 +93,15 @@ def try_cpp_dep_vers():
         return {}
 
 
+def try_cpp_build_config():
+    try:
+        from pyphare import cpp
+
+        return cpp.build_config()
+    except ImportError:
+        return {}
+
+
 class Diagnostics(object):
     h5_flush_never = 0
     cpp_dep_vers = try_cpp_dep_vers()
@@ -113,7 +122,11 @@ class Diagnostics(object):
         )
 
         self.attributes = kwargs.get("attributes", {})
-        self.attributes["git_hash"] = phare_utilities.top_git_hash()
+
+        build_config = try_cpp_build_config()
+        self.attributes["git_hash"] = build_config.get(
+            "GIT_HASH", "git hash not available"
+        )
 
         for dep, dep_ver in Diagnostics.cpp_dep_vers.items():
             self.attributes[f"{dep}_version"] = dep_ver

--- a/tools/config/config.py
+++ b/tools/config/config.py
@@ -28,6 +28,8 @@ class SystemSettings:
     python_binary: str
     python_version: str
     uname: str
+    git_hash: str
+    git_message: str
 
 
 SYSTEM_CPP_ = """
@@ -47,6 +49,8 @@ struct SystemConfig {{
     constexpr static std::string_view PYTHON_BINARY = R"({})";
     constexpr static std::string_view PYTHON_VERSION = R"({})";
     constexpr static std::string_view UNAME = R"({})";
+    constexpr static std::string_view GIT_HASH = R"({})";
+    constexpr static std::string_view GIT_MESSAGE = R"({})";
 
 }};
 
@@ -61,7 +65,9 @@ std::unordered_map<std::string, std::string> build_config(){{
       {{"MPI_VERSION", std::string{{SystemConfig::_MPI_VERSION_}}}},
       {{"PYTHON_BINARY", std::string{{SystemConfig::PYTHON_BINARY}}}},
       {{"PYTHON_VERSION", std::string{{SystemConfig::PYTHON_VERSION}}}},
-      {{"UNAME", std::string{{SystemConfig::UNAME}}}}
+      {{"UNAME", std::string{{SystemConfig::UNAME}}}},
+      {{"GIT_HASH", std::string{{SystemConfig::GIT_HASH}}}},
+      {{"GIT_MESSAGE", std::string{{SystemConfig::GIT_MESSAGE}}}}
   }};
 }}
 
@@ -196,6 +202,8 @@ def gen_system_file():
         python_binary=os.environ["PYTHON_EXECUTABLE"],
         python_version=get_python_version(os.environ["PYTHON_EXECUTABLE"]),
         uname=subprocess_run("uname -a"),
+        git_hash=subprocess_run("git log -1 --pretty=format:%H", "git log failed"),
+        git_message=subprocess_run("git log -1"),
     )
     with open(DOT_PHARE_DIR / "build_config.json", "w") as f:
         json.dump(dataclasses.asdict(settings), f)
@@ -203,16 +211,7 @@ def gen_system_file():
     with open(out_file, "w") as f:
         f.write(
             SYSTEM_CPP_.format(
-                settings.cmake_binary,
-                settings.cmake_version,
-                settings.cxx_compiler,
-                settings.cxx_compiler_version,
-                settings.hdf5_version,
-                settings.hdf5_is_parallel,
-                settings.mpi_version,
-                settings.python_binary,
-                settings.python_version,
-                settings.uname,
+                *[getattr(settings, v.name) for v in dataclasses.fields(settings)]
             )
         )
 

--- a/tools/config/config.py
+++ b/tools/config/config.py
@@ -203,7 +203,7 @@ def gen_system_file():
         python_version=get_python_version(os.environ["PYTHON_EXECUTABLE"]),
         uname=subprocess_run("uname -a"),
         git_hash=subprocess_run("git log -1 --pretty=format:%H", "git log failed"),
-        git_message=subprocess_run("git log -1"),
+        git_message=subprocess_run("git log -1", "git log failed"),
     )
     with open(DOT_PHARE_DIR / "build_config.json", "w") as f:
         json.dump(dataclasses.asdict(settings), f)


### PR DESCRIPTION
diagnostics git hash is still reading from disk at runtime, should probably use build config version instead if available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added functionality to retrieve Git hash from build configuration.
  - Introduced `git_hash` field to `RuntimeSettings` data class.
  - Enhanced `log_runtime_config()` function to include Git hash in settings.
  - Added `try_cpp_build_config()` function in `pyphare/pyphare/pharein/diagnostics.py`.
  - Modified `Diagnostics` class in `pyphare/pyphare/pharein/diagnostics.py` to use build configuration for Git hash retrieval.
  - Updated `SystemSettings` class in `tools/config/config.py` to include `git_hash` and `git_message` attributes.
  - Reflected changes in class definition, initialization, and usage within `gen_system_file` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->