### PR TITLE
unset compiler flag var before/after use cause no worky otherwise :/

### DIFF
--- a/res/cmake/def.cmake
+++ b/res/cmake/def.cmake
@@ -2,11 +2,16 @@
 
 # Per compiler CXXFLAGS
 set (PHARE_FLAGS ${PHARE_FLAGS} )
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set (PHARE_FLAGS ${PHARE_FLAGS} )
-else() # !Clang
-  set (PHARE_FLAGS ${PHARE_FLAGS} --param=min-pagesize=0 )
-endif() # clang
+# mostly for silencing spurious Werrors
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  # --param=min-pagesize=0    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+  unset(CHECK_SUPPORTS_FLAG CACHE)
+  check_cxx_compiler_flag( --param=min-pagesize=0 CHECK_SUPPORTS_FLAG)
+  if (${CHECK_SUPPORTS_FLAG})
+    set (PHARE_FLAGS ${PHARE_FLAGS} --param=min-pagesize=0 )
+  endif()
+  unset(CHECK_SUPPORTS_FLAG CACHE)
+endif() # compiler is GNU
 
 set (PHARE_LINK_FLAGS )
 set (PHARE_BASE_LIBS )

--- a/src/core/hybrid/hybrid_quantities.hpp
+++ b/src/core/hybrid/hybrid_quantities.hpp
@@ -36,7 +36,7 @@ public:
         Mzz,
         count
     };
-    enum class Vector { B, E, J, V, F };
+    enum class Vector { B, E, J, V };
     enum class Tensor { M, count };
 
     template<std::size_t rank, typename = std::enable_if_t<rank == 1 or rank == 2, void>>


### PR DESCRIPTION
https://stackoverflow.com/a/49297190/795574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Adjusted compiler flags to resolve a bug related to `--param=min-pagesize=0` for GNU compilers.
- **Refactor**
  - Removed the `F` member from the `Vector` enum in the `HybridQuantity` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->