### PR TITLE
remove compute_timestamps

### DIFF
--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -28,7 +28,6 @@ def diagnostics_checker(func):
 
         accepted_keywords = [
             "path",
-            "compute_timestamps",
             "population_name",
             "flush_every",
         ]
@@ -117,9 +116,11 @@ class Diagnostics(object):
         self.write_timestamps = validate_timestamps(
             self.__class__.__name__, "write_timestamps", **kwargs
         )
-        self.compute_timestamps = validate_timestamps(
-            self.__class__.__name__, "compute_timestamps", **kwargs
-        )
+        # for now every diagnostics needing computation (like momentum tensor)
+        # is computing at the same time as written.
+        # later this parameter can evolve to allow for different timestamps
+        # that will depend on the type of diagnostics.
+        self.compute_timestamps = self.write_timestamps
 
         self.attributes = kwargs.get("attributes", {})
 

--- a/pyphare/pyphare_tests/test_pharesee/test_hierarchy.py
+++ b/pyphare/pyphare_tests/test_pharesee/test_hierarchy.py
@@ -145,11 +145,7 @@ class PatchHierarchyTest(unittest.TestCase):
                 ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
             for quantity in ["density", "bulkVelocity"]:
-                ph.FluidDiagnostics(
-                    quantity=quantity,
-                    write_timestamps=timestamps,
-                    compute_timestamps=timestamps,
-                )
+                ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
             return sim
 

--- a/src/phare/phare_init.py
+++ b/src/phare/phare_init.py
@@ -98,19 +98,11 @@ timestamps = np.arange(0, sim.final_time + sim.time_step, 100 * sim.time_step)
 
 
 for quantity in ["E", "B"]:
-    ph.ElectromagDiagnostics(
-        quantity=quantity,
-        write_timestamps=timestamps,
-        compute_timestamps=timestamps,
-    )
+    ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
 
 for quantity in ["density", "bulkVelocity"]:
-    ph.FluidDiagnostics(
-        quantity=quantity,
-        write_timestamps=timestamps,
-        compute_timestamps=timestamps,
-    )
+    ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
 pops = [
     "protons",

--- a/src/phare/phare_init_small.py
+++ b/src/phare/phare_init_small.py
@@ -101,19 +101,11 @@ timestamps = np.arange(0, sim.final_time + sim.time_step, 10 * sim.time_step)
 
 
 for quantity in ["E", "B"]:
-    ph.ElectromagDiagnostics(
-        quantity=quantity,
-        write_timestamps=timestamps,
-        compute_timestamps=timestamps,
-    )
+    ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
 
 for quantity in ["density", "bulkVelocity"]:
-    ph.FluidDiagnostics(
-        quantity=quantity,
-        write_timestamps=timestamps,
-        compute_timestamps=timestamps,
-    )
+    ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
 pops = [
     "protons",

--- a/tests/diagnostic/__init__.py
+++ b/tests/diagnostic/__init__.py
@@ -20,24 +20,18 @@ def dump_all_diags(pops=[], flush_every=100, timestamps=None):
     if timestamps is None:
         timestamps = all_timestamps(sim)
 
-    ph.InfoDiagnostics(
-        quantity="particle_count",
-        write_timestamps=timestamps,
-        compute_timestamps=timestamps,
-    )
+    ph.InfoDiagnostics(quantity="particle_count", write_timestamps=timestamps)
     # commented out because not working propertly at the moment
     # but we keep it there for when it does
     # ph.MetaDiagnostics(
     #     quantity="tags",
-    #     write_timestamps=timestamps,
-    #     compute_timestamps=timestamps,
+    #     write_timestamps=timestamps
     # )
 
     for quantity in ["density", "bulkVelocity", "pressure_tensor"]:
         ph.FluidDiagnostics(
             quantity=quantity,
             write_timestamps=timestamps,
-            compute_timestamps=timestamps,
             flush_every=flush_every,
         )
 
@@ -46,7 +40,6 @@ def dump_all_diags(pops=[], flush_every=100, timestamps=None):
             ph.FluidDiagnostics(
                 quantity=quantity,
                 write_timestamps=timestamps,
-                compute_timestamps=timestamps,
                 flush_every=flush_every,
                 population_name=pop,
             )
@@ -54,7 +47,6 @@ def dump_all_diags(pops=[], flush_every=100, timestamps=None):
         for quantity in ["domain", "levelGhost", "patchGhost"]:
             ph.ParticleDiagnostics(
                 quantity=quantity,
-                compute_timestamps=timestamps,
                 write_timestamps=timestamps,
                 flush_every=flush_every,
                 population_name=pop,
@@ -64,6 +56,5 @@ def dump_all_diags(pops=[], flush_every=100, timestamps=None):
         ph.ElectromagDiagnostics(
             quantity=quantity,
             write_timestamps=timestamps,
-            compute_timestamps=timestamps,
             flush_every=flush_every,
         )

--- a/tests/functional/alfven_wave/alfven_wave1d.py
+++ b/tests/functional/alfven_wave/alfven_wave1d.py
@@ -91,18 +91,10 @@ def config():
     timestamps = all_timestamps(sim)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 

--- a/tests/functional/conservation/conserv.py
+++ b/tests/functional/conservation/conserv.py
@@ -83,16 +83,11 @@ def uniform(vth, dl, cells, nbr_steps):
     timestamps = np.arange(0, sim.final_time, 50 * sim.time_step)
 
     for quantity in ["B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for name in ["domain", "levelGhost", "patchGhost"]:
         ph.ParticleDiagnostics(
             quantity=name,
-            compute_timestamps=timestamps,
             write_timestamps=timestamps,
             population_name="protons",
         )

--- a/tests/functional/dispersion/dispersion.py
+++ b/tests/functional/dispersion/dispersion.py
@@ -86,11 +86,7 @@ def fromNoise():
     timestamps = np.arange(0, sim.final_time + sim.time_step, sim.time_step)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 
@@ -172,18 +168,10 @@ def prescribedModes():
     timestamps = np.arange(0, sim.final_time + sim.time_step, sim.time_step)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 

--- a/tests/functional/ionIonBeam/ion_ion_beam1d.py
+++ b/tests/functional/ionIonBeam/ion_ion_beam1d.py
@@ -96,18 +96,11 @@ def config():
     timestamps = np.arange(0, sim.final_time, 0.1)
 
     for quantity in ["B", "E"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for pop_name in ["main", "beam"]:
         ph.ParticleDiagnostics(
-            quantity="domain",
-            population_name=pop_name,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
+            quantity="domain", population_name=pop_name, write_timestamps=timestamps
         )
     return sim
 

--- a/tests/functional/shock/shock.py
+++ b/tests/functional/shock/shock.py
@@ -105,18 +105,10 @@ def config(interp_order):
     timestamps = dt * np.arange(nt)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 

--- a/tests/functional/td/td1d.py
+++ b/tests/functional/td/td1d.py
@@ -98,17 +98,12 @@ def config():
     timestamps = np.linspace(0, sim.final_time, n_dump)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
         ph.FluidDiagnostics(
             quantity=quantity,
             write_timestamps=timestamps,
-            compute_timestamps=timestamps,
         )
     return sim
 

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -116,23 +116,14 @@ def config(**options):
     timestamps = all_timestamps(sim)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for pop in sim.model.populations:
         for quantity in ["domain"]:
             ph.ParticleDiagnostics(
                 quantity=quantity,
-                compute_timestamps=timestamps[: particle_diagnostics["count"] + 1],
                 write_timestamps=timestamps[: particle_diagnostics["count"] + 1],
                 population_name=pop,
             )

--- a/tests/functional/translation/translat1d.py
+++ b/tests/functional/translation/translat1d.py
@@ -85,18 +85,10 @@ def config_uni(**kwargs):
     timestamps = all_timestamps(sim)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 
@@ -188,18 +180,10 @@ def config_td(**kwargs):
     timestamps = all_timestamps(sim)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 

--- a/tests/simulator/refinement/test_2d_10_core.py
+++ b/tests/simulator/refinement/test_2d_10_core.py
@@ -99,18 +99,10 @@ def config(diag_outputs, model_init={}, refinement_boxes=None):
     timestamps = dt * np.arange(nt)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 

--- a/tests/simulator/refinement/test_2d_2_core.py
+++ b/tests/simulator/refinement/test_2d_2_core.py
@@ -99,18 +99,10 @@ def config(diag_outputs, model_init={}, refinement_boxes=None):
     timestamps = dt * np.arange(nt)
 
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     for quantity in ["density", "bulkVelocity"]:
-        ph.FluidDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
     return sim
 

--- a/tests/simulator/test_advance.py
+++ b/tests/simulator/test_advance.py
@@ -150,17 +150,12 @@ class AdvanceTestBase(SimulatorTest):
             timestamps = all_timestamps(global_vars.sim)
 
         for quantity in ["E", "B"]:
-            ElectromagDiagnostics(
-                quantity=quantity,
-                write_timestamps=timestamps,
-                compute_timestamps=timestamps,
-            )
+            ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
         for quantity in ["density", "bulkVelocity"]:
             FluidDiagnostics(
                 quantity=quantity,
                 write_timestamps=timestamps,
-                compute_timestamps=timestamps,
             )
 
         poplist = ["protons"]
@@ -169,14 +164,12 @@ class AdvanceTestBase(SimulatorTest):
                 FluidDiagnostics(
                     quantity=quantity,
                     write_timestamps=timestamps,
-                    compute_timestamps=timestamps,
                     population_name=pop,
                 )
 
             for quantity in ["domain", "levelGhost", "patchGhost"]:
                 ParticleDiagnostics(
                     quantity=quantity,
-                    compute_timestamps=timestamps,
                     write_timestamps=timestamps,
                     population_name=pop,
                 )

--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -117,7 +117,6 @@ class DiagnosticsTest(unittest.TestCase):
             ElectromagDiagnostics(
                 quantity=quantity,
                 write_timestamps=timestamps,
-                compute_timestamps=timestamps,
                 flush_every=ElectromagDiagnostics.h5_flush_never,
             )
 
@@ -162,7 +161,6 @@ class DiagnosticsTest(unittest.TestCase):
                     ElectromagDiagnostics(
                         quantity=quantity,
                         write_timestamps=timestamps,
-                        compute_timestamps=timestamps,
                         flush_every=ElectromagDiagnostics.h5_flush_never,
                     )
 

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -167,16 +167,12 @@ class InitializationTest(SimulatorTest):
 
         for quantity in ["E", "B"]:
             ElectromagDiagnostics(
-                quantity=quantity,
-                write_timestamps=np.zeros(time_step_nbr),
-                compute_timestamps=np.zeros(time_step_nbr),
+                quantity=quantity, write_timestamps=np.zeros(time_step_nbr)
             )
 
         for quantity in ["density", "bulkVelocity"]:
             FluidDiagnostics(
-                quantity=quantity,
-                write_timestamps=np.zeros(time_step_nbr),
-                compute_timestamps=np.zeros(time_step_nbr),
+                quantity=quantity, write_timestamps=np.zeros(time_step_nbr)
             )
 
         poplist = ["protons", "beam"] if beam else ["protons"]
@@ -185,14 +181,12 @@ class InitializationTest(SimulatorTest):
                 FluidDiagnostics(
                     quantity=quantity,
                     write_timestamps=np.zeros(time_step_nbr),
-                    compute_timestamps=np.zeros(time_step_nbr),
                     population_name=pop,
                 )
 
             for quantity in ["domain", "levelGhost", "patchGhost"]:
                 ParticleDiagnostics(
                     quantity=quantity,
-                    compute_timestamps=np.zeros(time_step_nbr),
                     write_timestamps=np.zeros(time_step_nbr),
                     population_name=pop,
                 )

--- a/tools/bench/real/bench_harris.py
+++ b/tools/bench/real/bench_harris.py
@@ -1,85 +1,131 @@
-
-
 import numpy as np
-from pyphare.cpp import cpp_lib # must be first
+from pyphare.cpp import cpp_lib  # must be first
+
 cpp_lib("pybindlibs.cpp_sim_2_1_4")
 import pyphare.pharein as ph
 
 seed = 133333333337
-cells, dl = 100, .2
-patch_sizes = [50,100]
-diag_outputs="tools/bench/real/harris/outputs"
+cells, dl = 100, 0.2
+patch_sizes = [50, 100]
+diag_outputs = "tools/bench/real/harris/outputs"
+
 
 def density(x, y):
     L = ph.global_vars.sim.simulation_domain()[1]
-    return 0.2 + 1./np.cosh((y-L*0.3)/0.5)**2 + 1./np.cosh((y-L*0.7)/0.5)**2
+    return (
+        0.2
+        + 1.0 / np.cosh((y - L * 0.3) / 0.5) ** 2
+        + 1.0 / np.cosh((y - L * 0.7) / 0.5) ** 2
+    )
+
 
 def by(x, y):
     sim = ph.global_vars.sim
     Lx = sim.simulation_domain()[0]
     Ly = sim.simulation_domain()[1]
     w1, w2 = 0.2, 1.0
-    x0 = (x - 0.5 * Lx)
-    y1 = (y - 0.3 * Ly)
-    y2 = (y - 0.7 * Ly)
-    w3 = np.exp(-(x0*x0 + y1*y1) / (w2*w2))
-    w4 = np.exp(-(x0*x0 + y2*y2) / (w2*w2))
-    w5 = 2.0*w1/w2
-    return (w5 * x0 * w3) + ( -w5 * x0 * w4)
+    x0 = x - 0.5 * Lx
+    y1 = y - 0.3 * Ly
+    y2 = y - 0.7 * Ly
+    w3 = np.exp(-(x0 * x0 + y1 * y1) / (w2 * w2))
+    w4 = np.exp(-(x0 * x0 + y2 * y2) / (w2 * w2))
+    w5 = 2.0 * w1 / w2
+    return (w5 * x0 * w3) + (-w5 * x0 * w4)
 
-def S(y, y0, l): return 0.5*(1. + np.tanh((y-y0)/l))
+
+def S(y, y0, l):
+    return 0.5 * (1.0 + np.tanh((y - y0) / l))
+
+
 def bx(x, y):
     sim = ph.global_vars.sim
     Lx = sim.simulation_domain()[0]
     Ly = sim.simulation_domain()[1]
     w1, w2 = 0.2, 1.0
-    x0 = (x - 0.5 * Lx)
-    y1 = (y - 0.3 * Ly)
-    y2 = (y - 0.7 * Ly)
-    w3 = np.exp(-(x0*x0 + y1*y1) / (w2*w2))
-    w4 = np.exp(-(x0*x0 + y2*y2) / (w2*w2))
-    w5 = 2.0*w1/w2
-    v1, v2 = -1, 1.
-    return v1 + (v2-v1)*(S(y,Ly*0.3,0.5) -S(y, Ly*0.7, 0.5)) + (-w5*y1*w3) + (+w5*y2*w4)
+    x0 = x - 0.5 * Lx
+    y1 = y - 0.3 * Ly
+    y2 = y - 0.7 * Ly
+    w3 = np.exp(-(x0 * x0 + y1 * y1) / (w2 * w2))
+    w4 = np.exp(-(x0 * x0 + y2 * y2) / (w2 * w2))
+    w5 = 2.0 * w1 / w2
+    v1, v2 = -1, 1.0
+    return (
+        v1
+        + (v2 - v1) * (S(y, Ly * 0.3, 0.5) - S(y, Ly * 0.7, 0.5))
+        + (-w5 * y1 * w3)
+        + (+w5 * y2 * w4)
+    )
 
-def bz(x, y): return 0.
-def b2(x, y): return bx(x,y)**2 + by(x, y)**2 + bz(x, y)**2
-def T(x, y):  return 1./density(x, y)*(1 - b2(x, y)*0.5)
-def vxyz(x, y): return 0.
-def vthxyz(x, y): return np.sqrt(T(x, y))
+
+def bz(x, y):
+    return 0.0
+
+
+def b2(x, y):
+    return bx(x, y) ** 2 + by(x, y) ** 2 + bz(x, y) ** 2
+
+
+def T(x, y):
+    return 1.0 / density(x, y) * (1 - b2(x, y) * 0.5)
+
+
+def vxyz(x, y):
+    return 0.0
+
+
+def vthxyz(x, y):
+    return np.sqrt(T(x, y))
+
 
 def config():
-    ph.Simulation(# strict=True,
-        smallest_patch_size=patch_sizes[0], largest_patch_size=patch_sizes[1],
-        time_step_nbr=10, time_step=0.001,
-        cells=[cells] * 2, dl=[dl] * 2,
-        resistivity=0.001, hyper_resistivity=0.001,
-        diag_options={"format": "phareh5", "options": {"dir": diag_outputs, "mode":"overwrite"}},
+    ph.Simulation(  # strict=True,
+        smallest_patch_size=patch_sizes[0],
+        largest_patch_size=patch_sizes[1],
+        time_step_nbr=10,
+        time_step=0.001,
+        cells=[cells] * 2,
+        dl=[dl] * 2,
+        resistivity=0.001,
+        hyper_resistivity=0.001,
+        diag_options={
+            "format": "phareh5",
+            "options": {"dir": diag_outputs, "mode": "overwrite"},
+        },
         refinement_boxes={},
     )
-    ph.MaxwellianFluidModel( bx=bx, by=by, bz=bz,
-        protons={"charge": 1, "density": density, "init":{"seed": seed},
-          **{ "nbr_part_per_cell":100,
-            "vbulkx": vxyz, "vbulky": vxyz, "vbulkz": vxyz,
-            "vthx": vthxyz, "vthy": vthxyz, "vthz": vthxyz,
-          }
+    ph.MaxwellianFluidModel(
+        bx=bx,
+        by=by,
+        bz=bz,
+        protons={
+            "charge": 1,
+            "density": density,
+            "init": {"seed": seed},
+            **{
+                "nbr_part_per_cell": 100,
+                "vbulkx": vxyz,
+                "vbulky": vxyz,
+                "vbulkz": vxyz,
+                "vthx": vthxyz,
+                "vthy": vthxyz,
+                "vthz": vthxyz,
+            },
         },
     )
     ph.ElectronModel(closure="isothermal", Te=0.0)
 
     from tests.diagnostic import all_timestamps
+
     timestamps = all_timestamps(ph.global_vars.sim)
     timestamps = np.asarray([timestamps[0], timestamps[-1]])
     for quantity in ["E", "B"]:
-        ph.ElectromagDiagnostics(
-            quantity=quantity,
-            write_timestamps=timestamps,
-            compute_timestamps=timestamps,
-        )
+        ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
-if ph.PHARE_EXE or __name__=="__main__":
+
+if ph.PHARE_EXE or __name__ == "__main__":
     config()
 
-if __name__=="__main__":
+if __name__ == "__main__":
     from pyphare.simulator.simulator import Simulator
+
     Simulator(ph.global_vars.sim).run()


### PR DESCRIPTION
from #773

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified diagnostic functionality by removing the `compute_timestamps` parameter from various diagnostic classes, enhancing overall clarity and performance.
  
- **Bug Fixes**
	- Adjustments made to the handling of timestamps to ensure consistent behavior across diagnostics.

- **Documentation**
	- Improved comments and code readability for better maintainability in diagnostic processes.
  
- **Style**
	- Code formatting enhancements for better readability and consistency across various scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->