### PR TITLE
do not use h5py on restarts

### DIFF
--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -70,24 +70,20 @@ def getSimulation():
     return sim
 
 
-def _patch_data_ids(path):
+def _patch_data_ids(restart_file_dir):
     """
     for restarts we save samrai patch data ids to the restart files, which we access from here
     to tell samrai which patch datas to load from the restart file on restart
     """
-    import h5py
     from pyphare.cpp import cpp_etc_lib
 
-    h5File = cpp_etc_lib().samrai_restart_file(path)
-    return h5py.File(h5File, "r")["phare"]["patch"]["ids"][:]
+    return cpp_etc_lib().patch_data_ids(restart_file_dir)
 
 
-def _serialized_simulation_string(path):
-    import h5py
+def _serialized_simulation_string(restart_file_dir):
     from pyphare.cpp import cpp_etc_lib
 
-    h5File = cpp_etc_lib().samrai_restart_file(path)
-    return h5py.File(h5File, "r")["phare"].attrs["serialized_simulation"]
+    return cpp_etc_lib().serialized_simulation_string(restart_file_dir)
 
 
 # converts scalars to array of expected size

--- a/src/hdf5/detail/h5/h5_file.hpp
+++ b/src/hdf5/detail/h5/h5_file.hpp
@@ -69,7 +69,10 @@ public:
 
     ~HighFiveFile() {}
 
-    NO_DISCARD HiFile& file() { return h5file_; }
+    NO_DISCARD HiFile& file()
+    {
+        return h5file_;
+    }
 
 
     template<typename T, std::size_t dim = 1>
@@ -233,6 +236,15 @@ public:
                     doAttribute(h5file_.getGroup(keyPath), key, values[i]);
             }
         }
+    }
+
+    template<typename Attr = std::string>
+    auto read_attribute(std::string const& path, std::string const& key)
+    {
+        auto at = h5file_.getGroup(path).getAttribute(key);
+        Attr attr;
+        at.read(attr);
+        return attr;
     }
 
 

--- a/src/python3/cpp_etc.cpp
+++ b/src/python3/cpp_etc.cpp
@@ -33,6 +33,9 @@ auto samrai_version()
 
 PYBIND11_MODULE(cpp_etc, m)
 {
+    auto samrai_restart_file = [](std::string path) {
+        return PHARE::amr::HierarchyRestarter::getRestartFileFullPath(path);
+    };
     py::class_<core::Span<double>, std::shared_ptr<core::Span<double>>>(m, "Span");
     py::class_<PyArrayWrapper<double>, std::shared_ptr<PyArrayWrapper<double>>, core::Span<double>>(
         m, "PyWrapper");
@@ -46,14 +49,33 @@ PYBIND11_MODULE(cpp_etc, m)
         return versions;
     });
 
-    m.def("samrai_restart_file", [](std::string path) {
-        return PHARE::amr::HierarchyRestarter::getRestartFileFullPath(path);
-    });
+    m.def("samrai_restart_file", samrai_restart_file);
 
     m.def("restart_path_for_time", [](std::string path, double timestamp) {
         return PHARE::amr::Hierarchy::restartFilePathForTime(path, timestamp);
     });
 
     m.def("phare_build_config", []() { return PHARE::build_config(); });
+
+    m.def("patch_data_ids", [&](std::string const& path) -> std::vector<int> {
+        _PHARE_WITH_HIGHFIVE({
+            auto const& restart_file = samrai_restart_file(path);
+            PHARE::hdf5::h5::HighFiveFile h5File{restart_file, HighFive::File::ReadOnly,
+                                                 /*para=*/false};
+            return h5File.read_data_set<int>("/phare/patch/ids");
+        });
+
+        throw std::runtime_error("PHARE not built with highfive support");
+    });
+    m.def("serialized_simulation_string", [&](std::string const& path) -> std::string {
+        _PHARE_WITH_HIGHFIVE({
+            auto const& restart_file = samrai_restart_file(path);
+            PHARE::hdf5::h5::HighFiveFile h5File{restart_file, HighFive::File::ReadOnly,
+                                                 /*para=*/false};
+            return h5File.read_attribute("/phare", "serialized_simulation");
+        });
+
+        throw std::runtime_error("PHARE not built with highfive support");
+    });
 }
 } // namespace PHARE::pydata


### PR DESCRIPTION
prevent hdf5 header/lib mismatch 

eg: https://stackoverflow.com/q/45411700/795574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for retrieving patch data IDs and serialized simulation strings directly from the restart file.
	- Added a new method to read attributes from HDF5 files, enhancing data handling capabilities.

- **Improvements**
	- Enhanced clarity of function parameters, improving readability and understanding of intended use.
	- Streamlined internal logic to reduce dependencies on external libraries, potentially improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->