### PR TITLE
skip maxwellian fn validation if from restart

### DIFF
--- a/pyphare/pyphare/pharein/maxwellian_fluid_model.py
+++ b/pyphare/pyphare/pharein/maxwellian_fluid_model.py
@@ -43,7 +43,10 @@ class MaxwellianFluidModel(object):
         for population in self.populations:
             self.add_population(population, **kwargs[population])
 
-        if not global_vars.sim.dry_run:
+        should_validate = not any(
+            [global_vars.sim.dry_run, global_vars.sim.is_from_restart()]
+        )
+        if should_validate:
             self.validate(global_vars.sim)
 
         global_vars.sim.set_model(self)

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -870,9 +870,14 @@ class Simulation(object):
         return self.restart_options.get("dir", "phare_outputs")
 
     def start_time(self):
-        if self.restart_options is not None:
-            return self.restart_options.get("restart_time", 0)
+        if self.is_from_restart():
+            return self.restart_options["restart_time"]
         return 0
+
+    def is_from_restart(self):
+        return (
+            self.restart_options is not None and "restart_time" in self.restart_options
+        )
 
     def __getattr__(
         self, name


### PR DESCRIPTION
kinda redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to determine if the simulation is a restart, improving clarity when managing restart scenarios.
- **Bug Fixes**
	- Enhanced validation logic during simulation initialization, ensuring proper handling of dry runs versus restarts.
- **Refactor**
	- Streamlined control flow in the `start_time` method for better separation of concerns and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->