### PR TITLE
convert numpy arrays to lists on serialization of simulation

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -20,8 +20,8 @@ jobs:
           dylib_path: /usr/local/lib/gcc/current
         - os: macos-13
           dylib_path: /usr/local/lib/gcc/current
-        - os: macos-latest # https://github.com/actions/runner/issues/3337
-          dylib_path: /opt/homebrew/Cellar/gcc/14.1.0_2/lib/gcc/current
+        - os: macos-latest
+          dylib_path: /usr/local/lib/gcc/current
 
 
     steps:

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -20,8 +20,8 @@ jobs:
           dylib_path: /usr/local/lib/gcc/current
         - os: macos-13
           dylib_path: /usr/local/lib/gcc/current
-        - os: macos-latest
-          dylib_path: /usr/local/lib/gcc/current
+        - os: macos-latest # https://github.com/actions/runner/issues/3337
+          dylib_path: /opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/current
 
 
     steps:

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -28,13 +28,13 @@ def de_numpify_recursive(owner, key):
     if isinstance(obj, np.ndarray):
         object.__setattr__(owner, key, obj.tolist())
     elif hasattr(obj, "__dict__"):
-        for k in obj.__dict__.keys():
+        for k in obj.__dict__:
             de_numpify_recursive(obj, k)
 
 
 def de_numpify_simulation(sim):
     assert isinstance(sim, Simulation)
-    for k in sim.__dict__.keys():
+    for k in sim.__dict__:
         de_numpify_recursive(sim, k)
     return sim
 
@@ -46,13 +46,13 @@ def re_numpify_recursive(owner, key):
     if isinstance(obj, list) and len(obj) and not isinstance(obj[0], str):
         object.__setattr__(owner, key, np.array(obj))
     elif hasattr(obj, "__dict__"):
-        for k in obj.__dict__.keys():
+        for k in obj.__dict__:
             re_numpify_recursive(obj, k)
 
 
 def re_numpify_simulation(sim):
     assert isinstance(sim, Simulation)
-    for k in sim.__dict__.keys():
+    for k in sim.__dict__:
         re_numpify_recursive(sim, k)
     return sim
 

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -5,7 +5,7 @@ from ..core import phare_utilities
 from . import global_vars
 from ..core import box as boxm
 from ..core.box import Box
-
+from copy import deepcopy
 
 # ------------------------------------------------------------------------------
 
@@ -19,6 +19,42 @@ def compute_dimension(cells):
 
 
 # ------------------------------------------------------------------------------
+
+
+def de_numpify_recursive(owner, key):
+    obj = getattr(owner, key)
+    if obj is None:
+        return
+    if isinstance(obj, np.ndarray):
+        object.__setattr__(owner, key, obj.tolist())
+    elif hasattr(obj, "__dict__"):
+        for k in obj.__dict__.keys():
+            de_numpify_recursive(obj, k)
+
+
+def de_numpify_simulation(sim):
+    assert isinstance(sim, Simulation)
+    for k in sim.__dict__.keys():
+        de_numpify_recursive(sim, k)
+    return sim
+
+
+def re_numpify_recursive(owner, key):
+    obj = getattr(owner, key)
+    if obj is None:
+        return
+    if isinstance(obj, list) and len(obj) and not isinstance(obj[0], str):
+        object.__setattr__(owner, key, np.array(obj))
+    elif hasattr(obj, "__dict__"):
+        for k in obj.__dict__.keys():
+            re_numpify_recursive(obj, k)
+
+
+def re_numpify_simulation(sim):
+    assert isinstance(sim, Simulation)
+    for k in sim.__dict__.keys():
+        re_numpify_recursive(sim, k)
+    return sim
 
 
 def check_domain(**kwargs):
@@ -944,11 +980,11 @@ def serialize(sim):
     import dill
     import codecs
 
-    return codecs.encode(dill.dumps(sim), "hex")
+    return codecs.encode(dill.dumps(de_numpify_simulation(deepcopy(sim))), "hex")
 
 
 def deserialize(hex):
     import dill
     import codecs
 
-    return dill.loads(codecs.decode(hex, "hex"))
+    return re_numpify_simulation(dill.loads(codecs.decode(hex, "hex")))

--- a/tests/simulator/test_simulation.py
+++ b/tests/simulator/test_simulation.py
@@ -1,0 +1,64 @@
+#
+#
+
+import unittest
+import numpy as np
+import pyphare.pharein as ph
+
+from pyphare.simulator.simulator import Simulator
+
+from copy import deepcopy
+from tests.simulator import SimulatorTest
+
+simArgs = dict(
+    time_step_nbr=1,  # avoid regrid for refinement boxes https://github.com/LLNL/SAMRAI/issues/199
+    time_step=0.001,
+    boundary_types="periodic",
+    cells=np.array([20]),
+    dl=0.3,
+)
+
+
+class SimulatorValidation(SimulatorTest):
+    def __init__(self, *args, **kwargs):
+        super(SimulatorValidation, self).__init__(*args, **kwargs)
+        self.simulator = None
+
+    def tearDown(self):
+        super(SimulatorValidation, self).tearDown()
+        if self.simulator is not None:
+            self.simulator.reset()
+        ph.global_vars.sim = None
+
+    def test_no_numpy_on_serialization(self):
+        import dill
+        import codecs
+
+        simput = deepcopy(simArgs)
+        sim = ph.Simulation(**deepcopy(simArgs))
+
+        # check is np array before serialization
+        assert isinstance(sim.cells, np.ndarray)
+        hex = ph.simulation.serialize(sim)
+
+        def check_numpify_recursive(owner, key):
+            obj = getattr(owner, key)
+            if obj is None:
+                return 0
+            if hasattr(obj, "__dict__"):
+                for k in obj.__dict__:
+                    check_numpify_recursive(obj, k)
+            else:
+                assert not isinstance(obj, np.ndarray)
+                return 1
+            return 0
+
+        desim = dill.loads(codecs.decode(hex, "hex"))
+        checks = 0
+        for k in desim.__dict__:
+            checks += check_numpify_recursive(desim, k)
+        assert checks > 1  # we asserted something
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
closes #871 (intends to at least) 

includes #883 - will be rebased out later

not sure what kind of test is suitable here, that wouldn't just be a copy paste of the conversion code mostly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced functions for converting between NumPy arrays and Python lists, enhancing data handling in simulations.
	- Added a unit test suite to validate serialization behavior of the Simulator class, ensuring no NumPy arrays are present in serialized data.

- **Refactor**
	- Updated GitHub Actions workflow for improved compatibility in macOS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->