### PR TITLE
spatially variable hyperresistivity

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
         set -ex
         cmake $GITHUB_WORKSPACE
         cd ${{runner.workspace}}/PHARE/subprojects/samrai && mkdir build && cd build
-        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug  -DCMAKE_CXX_FLAGS="-O3"
+        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
         make -j2 && sudo make install && cd ../.. && rm -rf samrai
         cd ${{runner.workspace}}/build && rm -rf *
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --fresh \

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -74,11 +74,11 @@ jobs:
         set -ex
         cmake $GITHUB_WORKSPACE
         cd ${{runner.workspace}}/PHARE/subprojects/samrai && mkdir build && cd build
-        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
+        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug  -DCMAKE_CXX_FLAGS="-O3"
         make -j2 && sudo make install && cd ../.. && rm -rf samrai
         cd ${{runner.workspace}}/build && rm -rf *
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --fresh \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dasan=OFF \
+              -DCMAKE_BUILD_TYPE=Debug -Dasan=OFF \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DlowResourceTests=ON -DdevMode=ON -Dbench=ON \

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
         set -ex
         cmake $GITHUB_WORKSPACE
         cd ${{runner.workspace}}/PHARE/subprojects/samrai && mkdir build && cd build
-        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
         make -j2 && sudo make install && cd ../.. && rm -rf samrai
         cd ${{runner.workspace}}/build && rm -rf *
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --fresh \
@@ -82,7 +82,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DlowResourceTests=ON -DdevMode=ON -Dbench=ON \
-              -DCMAKE_CXX_FLAGS="-DPHARE_DIAG_DOUBLES=1 " -Dphare_configurator=ON
+              -DCMAKE_CXX_FLAGS="-O3 -DPHARE_DIAG_DOUBLES=1 " -Dphare_configurator=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -236,8 +236,10 @@ def populateDict():
         )  # integrator.h might want some looking at
 
     add_string("simulation/algo/ion_updater/pusher/name", simulation.particle_pusher)
+
     add_double("simulation/algo/ohm/resistivity", simulation.resistivity)
     add_double("simulation/algo/ohm/hyper_resistivity", simulation.hyper_resistivity)
+    add_string("simulation/algo/ohm/hyper_mode", simulation.hyper_mode)
 
     # load balancer block start
     lb = simulation.load_balancer or LoadBalancer(active=False, _register=False)

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -604,7 +604,11 @@ def check_hyper_resistivity(**kwargs):
     if hyper_resistivity < 0.0:
         raise ValueError("Error: hyper_resistivity should not be negative")
 
-    return hyper_resistivity
+    hyper_mode = kwargs.get("hyper_mode", "constant")
+    if hyper_mode not in ["constant", "spatial"]:
+        raise ValueError("Error: hyper_mode should be 'constant' or 'spatial'")
+
+    return hyper_resistivity, hyper_mode
 
 
 def check_clustering(**kwargs):
@@ -719,8 +723,9 @@ def checker(func):
 
         kwargs["resistivity"] = check_resistivity(**kwargs)
 
-        kwargs["hyper_resistivity"] = check_hyper_resistivity(**kwargs)
-        kwargs["hyper_mode"] = kwargs.get("hyper_mode", "constant")
+        nu, hyper_mode = check_hyper_resistivity(**kwargs)
+        kwargs["hyper_resistivity"] = nu
+        kwargs["hyper_mode"] = hyper_mode
 
         kwargs["dry_run"] = kwargs.get(
             "dry_run", os.environ.get("PHARE_DRY_RUN", "0") == "1"

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -647,6 +647,7 @@ def checker(func):
             "diag_options",
             "resistivity",
             "hyper_resistivity",
+            "hyper_mode",
             "strict",
             "restart_options",
             "tag_buffer",
@@ -719,6 +720,7 @@ def checker(func):
         kwargs["resistivity"] = check_resistivity(**kwargs)
 
         kwargs["hyper_resistivity"] = check_hyper_resistivity(**kwargs)
+        kwargs["hyper_mode"] = kwargs.get("hyper_mode", "constant")
 
         kwargs["dry_run"] = kwargs.get(
             "dry_run", os.environ.get("PHARE_DRY_RUN", "0") == "1"

--- a/src/amr/resources_manager/amr_utils.hpp
+++ b/src/amr/resources_manager/amr_utils.hpp
@@ -182,7 +182,8 @@ namespace amr
             nbrCell[iDim] = static_cast<std::uint32_t>(domain.numberCells(iDim));
         }
 
-        return GridLayoutT{dl, nbrCell, origin, amr::Box<int, dimension>{domain}};
+        auto lvlNbr = patch.getPatchLevelNumber();
+        return GridLayoutT{dl, nbrCell, origin, amr::Box<int, dimension>{domain}, lvlNbr};
     }
 
     inline auto to_string(SAMRAI::hier::GlobalId const& id)

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -112,7 +112,7 @@ namespace core
         GridLayout(std::array<double, dimension> const& meshSize,
                    std::array<std::uint32_t, dimension> const& nbrCells,
                    Point<double, dimension> const& origin,
-                   Box<int, dimension> AMRBox = Box<int, dimension>{})
+                   Box<int, dimension> AMRBox = Box<int, dimension>{}, int level_number = 0)
             : meshSize_{meshSize}
             , origin_{origin}
             , nbrPhysicalCells_{nbrCells}
@@ -120,6 +120,7 @@ namespace core
             , physicalEndIndexTable_{initPhysicalEnd_()}
             , ghostEndIndexTable_{initGhostEnd_()}
             , AMRBox_{AMRBox}
+            , levelNumber_{level_number}
         {
             if (AMRBox_.isEmpty())
             {
@@ -1073,6 +1074,7 @@ namespace core
          */
         NO_DISCARD auto static constexpr JzToMoments() { return GridLayoutImpl::JzToMoments(); }
 
+        NO_DISCARD auto static constexpr BxToEx() { return GridLayoutImpl::BxToEx(); }
 
         /**
          * @brief ByToEx return the indexes and associated coef to compute the linear
@@ -1088,6 +1090,7 @@ namespace core
         NO_DISCARD auto static constexpr BzToEx() { return GridLayoutImpl::BzToEx(); }
 
 
+
         /**
          * @brief BxToEy return the indexes and associated coef to compute the linear
          * interpolation necessary to project Bx onto Ey.
@@ -1095,6 +1098,7 @@ namespace core
         NO_DISCARD auto static constexpr BxToEy() { return GridLayoutImpl::BxToEy(); }
 
 
+        NO_DISCARD auto static constexpr ByToEy() { return GridLayoutImpl::ByToEy(); }
 
         /**
          * @brief BzToEy return the indexes and associated coef to compute the linear
@@ -1117,6 +1121,8 @@ namespace core
          * interpolation necessary to project By onto Ez.
          */
         NO_DISCARD auto static constexpr ByToEz() { return GridLayoutImpl::ByToEz(); }
+
+        NO_DISCARD auto static constexpr BzToEz() { return GridLayoutImpl::BzToEz(); }
 
 
 
@@ -1165,6 +1171,7 @@ namespace core
             evalOnBox_(field, fn, indices);
         }
 
+        auto levelNumber() const { return levelNumber_; }
 
     private:
         template<typename Field, typename IndicesFn, typename Fn>
@@ -1508,6 +1515,8 @@ namespace core
         // arrays will be accessed with [primal] and [dual] indexes.
         constexpr static std::array<int, 2> nextIndexTable_{{nextPrimal_(), nextDual_()}};
         constexpr static std::array<int, 2> prevIndexTable_{{prevPrimal_(), prevDual_()}};
+
+        int levelNumber_ = 0;
     };
 
 

--- a/src/core/data/grid/gridlayoutimplyee.hpp
+++ b/src/core/data/grid/gridlayoutimplyee.hpp
@@ -685,6 +685,47 @@ namespace core
             }
         }
 
+        NO_DISCARD auto static constexpr BxToEx()
+        {
+            // Bx is primal dual dual
+            // Ex is dual primal primal
+            // operation is pdd to dpp
+            [[maybe_unused]] auto constexpr p2dShift = primalToDual();
+            [[maybe_unused]] auto constexpr d2pShift = dualToPrimal();
+
+            if constexpr (dimension == 1)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0}, 0.5};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{p2dShift}, 0.5};
+                return std::array<WeightPoint<dimension>, 2>{P1, P2};
+            }
+            else if constexpr (dimension == 2)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{0, d2pShift}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{p2dShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{p2dShift, d2pShift},
+                                                    0.25};
+                return std::array<WeightPoint<dimension>, 4>{P1, P2, P3, P4};
+            }
+            else if constexpr (dimension == 3)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0, 0}, 0.125};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{0, d2pShift, 0}, 0.125};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{p2dShift, 0, 0}, 0.125};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{p2dShift, d2pShift, 0},
+                                                    0.125};
+
+                constexpr WeightPoint<dimension> P5{Point<int, dimension>{0, 0, d2pShift}, 0.125};
+                constexpr WeightPoint<dimension> P6{Point<int, dimension>{0, d2pShift, d2pShift},
+                                                    0.125};
+                constexpr WeightPoint<dimension> P7{Point<int, dimension>{p2dShift, 0, d2pShift},
+                                                    0.125};
+                constexpr WeightPoint<dimension> P8{
+                    Point<int, dimension>{p2dShift, d2pShift, d2pShift}, 0.125};
+                return std::array<WeightPoint<dimension>, 8>{P1, P2, P3, P4, P5, P6, P7, P8};
+            }
+        }
 
 
         NO_DISCARD auto static constexpr ByToEx()
@@ -744,6 +785,47 @@ namespace core
         }
 
 
+        NO_DISCARD auto static constexpr BzToEz()
+        {
+            // Bz is dual dual primal
+            // Ez is primal primal dual
+            // operation is thus ddp to ppd
+            auto constexpr p2dShift = primalToDual();
+            auto constexpr d2pShift = dualToPrimal();
+
+            if constexpr (dimension == 1)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0}, 0.5};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift}, 0.5};
+                return std::array<WeightPoint<dimension>, 2>{P1, P2};
+            }
+
+            else if constexpr (dimension == 2)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, d2pShift}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, d2pShift},
+                                                    0.25};
+                return std::array<WeightPoint<dimension>, 4>{P1, P2, P3, P4};
+            }
+            else if constexpr (dimension == 3)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, d2pShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, d2pShift, 0},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P5{Point<int, dimension>{0, 0, p2dShift}, 0.25};
+                constexpr WeightPoint<dimension> P6{Point<int, dimension>{d2pShift, 0, p2dShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P7{Point<int, dimension>{0, d2pShift, p2dShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P8{
+                    Point<int, dimension>{d2pShift, d2pShift, p2dShift}, 0.25};
+                return std::array<WeightPoint<dimension>, 8>{P1, P2, P3, P4, P5, P6, P7, P8};
+            }
+        }
 
 
         NO_DISCARD auto static constexpr ByToEz()
@@ -838,6 +920,46 @@ namespace core
         }
 
 
+        NO_DISCARD auto static constexpr ByToEy()
+        {
+            // By is dual primal dual
+            // Ey is primal dual primal
+            // the operation is thus dpd to pdp
+            auto constexpr p2dShift = primalToDual();
+            auto constexpr d2pShift = dualToPrimal();
+
+            if constexpr (dimension == 1)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0}, 0.5};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift}, 0.5};
+                return std::array<WeightPoint<dimension>, 2>{P1, P2};
+            }
+            else if constexpr (dimension == 2)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, p2dShift}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, p2dShift},
+                                                    0.25};
+                return std::array<WeightPoint<dimension>, 4>{P1, P2, P3, P4};
+            }
+            else if constexpr (dimension == 3)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, p2dShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, p2dShift, 0},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P5{Point<int, dimension>{0, 0, d2pShift}, 0.25};
+                constexpr WeightPoint<dimension> P6{Point<int, dimension>{d2pShift, 0, d2pShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P7{Point<int, dimension>{0, p2dShift, d2pShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P8{
+                    Point<int, dimension>{d2pShift, p2dShift, d2pShift}, 0.25};
+                return std::array<WeightPoint<dimension>, 8>{P1, P2, P3, P4, P5, P6, P7, P8};
+            }
+        }
 
 
         NO_DISCARD auto static constexpr BzToEy()

--- a/src/core/data/tensorfield/tensorfield.hpp
+++ b/src/core/data/tensorfield/tensorfield.hpp
@@ -82,15 +82,13 @@ public:
 
     NO_DISCARD auto getCompileTimeResourcesViewList()
     {
-        return for_N<N, for_N_R_mode::forward_tuple>([&](auto i) -> auto& {
-            return components_[i];
-        });
+        return for_N<N, for_N_R_mode::forward_tuple>(
+            [&](auto i) -> auto& { return components_[i]; });
     }
     NO_DISCARD auto getCompileTimeResourcesViewList() const
     {
-        return for_N<N, for_N_R_mode::forward_tuple>([&](auto i) -> auto& {
-            return components_[i];
-        });
+        return for_N<N, for_N_R_mode::forward_tuple>(
+            [&](auto i) -> auto& { return components_[i]; });
     }
 
 

--- a/src/core/data/vecfield/vecfield.hpp
+++ b/src/core/data/vecfield/vecfield.hpp
@@ -32,6 +32,7 @@ namespace core
     }
 
 
+
     struct VecFieldNames
     {
         std::string vecName;

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -1,19 +1,19 @@
 #ifndef PHARE_OHM_HPP
 #define PHARE_OHM_HPP
 
-#include <cstddef>
-#include <iostream>
 
 #include "core/data/grid/gridlayoutdefs.hpp"
-#include "core/data/grid/gridlayout.hpp"
 #include "core/data/grid/gridlayout_utils.hpp"
 #include "core/data/vecfield/vecfield_component.hpp"
 
 #include "initializer/data_provider.hpp"
 
 
+
 namespace PHARE::core
 {
+enum class HyperMode { constant, spatial };
+
 template<typename GridLayout>
 class Ohm : public LayoutHolder<GridLayout>
 {
@@ -24,6 +24,9 @@ public:
     explicit Ohm(PHARE::initializer::PHAREDict const& dict)
         : eta_{dict["resistivity"].template to<double>()}
         , nu_{dict["hyper_resistivity"].template to<double>()}
+        , hyper_mode{cppdict::get_value(dict, "hyper_mode", std::string{"constant"}) == "constant"
+                         ? HyperMode::constant
+                         : HyperMode::spatial}
     {
     }
 
@@ -52,10 +55,12 @@ public:
 
 
 
-    double const eta_;
-    double const nu_;
 
 private:
+    double const eta_;
+    double const nu_;
+    HyperMode const hyper_mode;
+
     template<typename VecField, typename Field>
     struct OhmPack
     {
@@ -76,7 +81,7 @@ private:
         Exyz(ijk...) = ideal_<Tag>(Ve, B, {ijk...})      //
                        + pressure_<Tag>(n, Pe, {ijk...}) //
                        + resistive_<Tag>(J, {ijk...})    //
-                       + hyperresistive_<Tag>(J, {ijk...});
+                       + hyperresistive_<Tag>(J, B, n, {ijk...});
     }
 
 
@@ -281,6 +286,7 @@ private:
                 return -gradPOnEy / nOnEy;
             }
             else
+#include <cmath>
             {
                 return 0.;
             }
@@ -331,13 +337,56 @@ private:
         }
     }
 
-
+    template<auto component, typename VecField, typename Field>
+    auto hyperresistive_(VecField const& J, VecField const& B, Field const& n,
+                         MeshIndex<VecField::dimension> index) const
+    {
+        if (hyper_mode == HyperMode::constant)
+            return constant_hyperresistive_<component>(J, index);
+        else if (hyper_mode == HyperMode::spatial)
+            return spatial_hyperresistive_<component>(J, B, n, index);
+        else // should not happen but otherwise -Wreturn-type fails with Werror
+            throw std::runtime_error("Error - Ohm - unknown hyper_mode");
+    }
 
 
     template<auto component, typename VecField>
-    auto hyperresistive_(VecField const& J, MeshIndex<VecField::dimension> index) const
+    auto constant_hyperresistive_(VecField const& J, MeshIndex<VecField::dimension> index) const
     { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
         return -nu_ * layout_->laplacian(J(component), index);
+    }
+
+
+    template<auto component, typename VecField, typename Field>
+    auto spatial_hyperresistive_(VecField const& J, VecField const& B, Field const& n,
+                                 MeshIndex<VecField::dimension> index) const
+    { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
+        auto const lvlCoeff = 1. / std::pow(4, layout_->levelNumber());
+
+        auto computeHR = [&](auto BxProj, auto ByProj, auto BzProj, auto nProj) {
+            auto const BxOnE = GridLayout::project(B(Component::X), index, BxProj);
+            auto const ByOnE = GridLayout::project(B(Component::Y), index, ByProj);
+            auto const BzOnE = GridLayout::project(B(Component::Z), index, BzProj);
+            auto const nOnE  = GridLayout::project(n, index, nProj);
+            auto b           = std::sqrt(BxOnE * BxOnE + ByOnE * ByOnE + BzOnE * BzOnE);
+            return -nu_ * b / nOnE * lvlCoeff * layout_->laplacian(J(component), index);
+        };
+
+        if constexpr (component == Component::X)
+        {
+            return computeHR(GridLayout::BxToEx(), GridLayout::ByToEx(), GridLayout::BzToEx(),
+                             GridLayout::momentsToEx());
+        }
+        if constexpr (component == Component::Y)
+        {
+            return computeHR(GridLayout::BxToEy(), GridLayout::ByToEy(), GridLayout::BzToEy(),
+                             GridLayout::momentsToEy());
+        }
+        if constexpr (component == Component::Z)
+        {
+            return computeHR(GridLayout::BxToEz(), GridLayout::ByToEz(), GridLayout::BzToEz(),
+                             GridLayout::momentsToEz());
+        }
     }
 };
 

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -286,7 +286,6 @@ private:
                 return -gradPOnEy / nOnEy;
             }
             else
-#include <cmath>
             {
                 return 0.;
             }


### PR DESCRIPTION
implements #880 

- implements new projections of B on E needed to compute the norm of the magnetic field on E locations




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for converting magnetic field components to electric field components, enhancing electromagnetic field simulations.
	- Added capabilities for transforming weight points between different dimensional representations in the grid layout system.
	- Enhanced the `hyperresistive_` method in the `Ohm` class for improved physical modeling of electric and magnetic field interactions.
	- Added a new `hyper_mode` configuration option for simulations, allowing for more nuanced resistivity calculations.
	- Expanded `GridLayout` functionality by including a level number parameter for improved grid management.
	- Updated simulation configuration to include new parameters for enhanced configurability.

- **Bug Fixes**
	- Improved readability of lambda functions in the `TensorField` class without altering functionality.

- **Chores**
	- Updated CMake configuration parameters for the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->