### PR TITLE
absolute tagging

### DIFF
--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -236,8 +236,10 @@ def populateDict():
         )  # integrator.h might want some looking at
 
     add_string("simulation/algo/ion_updater/pusher/name", simulation.particle_pusher)
+
     add_double("simulation/algo/ohm/resistivity", simulation.resistivity)
     add_double("simulation/algo/ohm/hyper_resistivity", simulation.hyper_resistivity)
+    add_double("simulation/algo/ohm/hyper_mode", simulation.hyper_mode)
 
     # load balancer block start
     lb = simulation.load_balancer or LoadBalancer(active=False, _register=False)

--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -239,7 +239,7 @@ def populateDict():
 
     add_double("simulation/algo/ohm/resistivity", simulation.resistivity)
     add_double("simulation/algo/ohm/hyper_resistivity", simulation.hyper_resistivity)
-    add_double("simulation/algo/ohm/hyper_mode", simulation.hyper_mode)
+    add_string("simulation/algo/ohm/hyper_mode", simulation.hyper_mode)
 
     # load balancer block start
     lb = simulation.load_balancer or LoadBalancer(active=False, _register=False)

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -719,6 +719,7 @@ def checker(func):
         kwargs["resistivity"] = check_resistivity(**kwargs)
 
         kwargs["hyper_resistivity"] = check_hyper_resistivity(**kwargs)
+        kwargs["hyper_mode"] = kwargs.get("hyper_mode", "constant")
 
         kwargs["dry_run"] = kwargs.get(
             "dry_run", os.environ.get("PHARE_DRY_RUN", "0") == "1"

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -647,6 +647,7 @@ def checker(func):
             "diag_options",
             "resistivity",
             "hyper_resistivity",
+            "hyper_mode",
             "strict",
             "restart_options",
             "tag_buffer",

--- a/src/amr/resources_manager/amr_utils.hpp
+++ b/src/amr/resources_manager/amr_utils.hpp
@@ -182,7 +182,8 @@ namespace amr
             nbrCell[iDim] = static_cast<std::uint32_t>(domain.numberCells(iDim));
         }
 
-        return GridLayoutT{dl, nbrCell, origin, amr::Box<int, dimension>{domain}};
+        auto lvlNbr = patch.getPatchLevelNumber();
+        return GridLayoutT{dl, nbrCell, origin, amr::Box<int, dimension>{domain}, lvlNbr};
     }
 
     inline auto to_string(SAMRAI::hier::GlobalId const& id)

--- a/src/amr/tagging/default_hybrid_tagger_strategy.hpp
+++ b/src/amr/tagging/default_hybrid_tagger_strategy.hpp
@@ -108,9 +108,10 @@ void DefaultHybridTaggerStrategy<HybridModel>::tag(HybridModel& model,
             {
                 auto field_diff = [&](auto const& F) //
                 {
-                    return std::make_tuple(
-                        std::abs((F(ix + 2, iy) - F(ix, iy)) / (1 + F(ix + 1, iy) - F(ix, iy))),
-                        std::abs((F(ix, iy + 2) - F(ix, iy)) / (F(ix, iy + 1) - F(ix, iy) + 1)));
+                    return std::make_tuple(std::abs((F(ix + 2, iy) - F(ix, iy))
+                                                    / (1 + std::abs(F(ix + 1, iy) - F(ix, iy)))),
+                                           std::abs(F(ix, iy + 2) - F(ix, iy))
+                                               / (std::abs(F(ix, iy + 1) - F(ix, iy)) + 1));
                 };
 
                 auto const& [Bx_x, Bx_y] = field_diff(Bx);

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -112,7 +112,7 @@ namespace core
         GridLayout(std::array<double, dimension> const& meshSize,
                    std::array<std::uint32_t, dimension> const& nbrCells,
                    Point<double, dimension> const& origin,
-                   Box<int, dimension> AMRBox = Box<int, dimension>{})
+                   Box<int, dimension> AMRBox = Box<int, dimension>{}, int level_number = 0)
             : meshSize_{meshSize}
             , origin_{origin}
             , nbrPhysicalCells_{nbrCells}
@@ -120,6 +120,7 @@ namespace core
             , physicalEndIndexTable_{initPhysicalEnd_()}
             , ghostEndIndexTable_{initGhostEnd_()}
             , AMRBox_{AMRBox}
+            , levelNumber_{level_number}
         {
             if (AMRBox_.isEmpty())
             {
@@ -1170,6 +1171,7 @@ namespace core
             evalOnBox_(field, fn, indices);
         }
 
+        auto levelNumber() const { return levelNumber_; }
 
     private:
         template<typename Field, typename IndicesFn, typename Fn>
@@ -1513,6 +1515,8 @@ namespace core
         // arrays will be accessed with [primal] and [dual] indexes.
         constexpr static std::array<int, 2> nextIndexTable_{{nextPrimal_(), nextDual_()}};
         constexpr static std::array<int, 2> prevIndexTable_{{prevPrimal_(), prevDual_()}};
+
+        int levelNumber_ = 0;
     };
 
 

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -1073,6 +1073,7 @@ namespace core
          */
         NO_DISCARD auto static constexpr JzToMoments() { return GridLayoutImpl::JzToMoments(); }
 
+        NO_DISCARD auto static constexpr BxToEx() { return GridLayoutImpl::BxToEx(); }
 
         /**
          * @brief ByToEx return the indexes and associated coef to compute the linear
@@ -1088,6 +1089,7 @@ namespace core
         NO_DISCARD auto static constexpr BzToEx() { return GridLayoutImpl::BzToEx(); }
 
 
+
         /**
          * @brief BxToEy return the indexes and associated coef to compute the linear
          * interpolation necessary to project Bx onto Ey.
@@ -1095,6 +1097,7 @@ namespace core
         NO_DISCARD auto static constexpr BxToEy() { return GridLayoutImpl::BxToEy(); }
 
 
+        NO_DISCARD auto static constexpr ByToEy() { return GridLayoutImpl::ByToEy(); }
 
         /**
          * @brief BzToEy return the indexes and associated coef to compute the linear
@@ -1117,6 +1120,8 @@ namespace core
          * interpolation necessary to project By onto Ez.
          */
         NO_DISCARD auto static constexpr ByToEz() { return GridLayoutImpl::ByToEz(); }
+
+        NO_DISCARD auto static constexpr BzToEz() { return GridLayoutImpl::BzToEz(); }
 
 
 

--- a/src/core/data/grid/gridlayoutimplyee.hpp
+++ b/src/core/data/grid/gridlayoutimplyee.hpp
@@ -685,6 +685,47 @@ namespace core
             }
         }
 
+        NO_DISCARD auto static constexpr BxToEx()
+        {
+            // Bx is primal dual dual
+            // Ex is dual primal primal
+            // operation is pdd to dpp
+            [[maybe_unused]] auto constexpr p2dShift = primalToDual();
+            [[maybe_unused]] auto constexpr d2pShift = dualToPrimal();
+
+            if constexpr (dimension == 1)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0}, 0.5};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{p2dShift}, 0.5};
+                return std::array<WeightPoint<dimension>, 2>{P1, P2};
+            }
+            else if constexpr (dimension == 2)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{0, d2pShift}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{p2dShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{p2dShift, d2pShift},
+                                                    0.25};
+                return std::array<WeightPoint<dimension>, 4>{P1, P2, P3, P4};
+            }
+            else if constexpr (dimension == 3)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0, 0}, 0.125};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{0, d2pShift, 0}, 0.125};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{p2dShift, 0, 0}, 0.125};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{p2dShift, d2pShift, 0},
+                                                    0.125};
+
+                constexpr WeightPoint<dimension> P5{Point<int, dimension>{0, 0, d2pShift}, 0.125};
+                constexpr WeightPoint<dimension> P6{Point<int, dimension>{0, d2pShift, d2pShift},
+                                                    0.125};
+                constexpr WeightPoint<dimension> P7{Point<int, dimension>{p2dShift, 0, d2pShift},
+                                                    0.125};
+                constexpr WeightPoint<dimension> P8{
+                    Point<int, dimension>{p2dShift, d2pShift, d2pShift}, 0.125};
+                return std::array<WeightPoint<dimension>, 8>{P1, P2, P3, P4, P5, P6, P7, P8};
+            }
+        }
 
 
         NO_DISCARD auto static constexpr ByToEx()
@@ -744,6 +785,47 @@ namespace core
         }
 
 
+        NO_DISCARD auto static constexpr BzToEz()
+        {
+            // Bz is dual dual primal
+            // Ez is primal primal dual
+            // operation is thus ddp to ppd
+            auto constexpr p2dShift = primalToDual();
+            auto constexpr d2pShift = dualToPrimal();
+
+            if constexpr (dimension == 1)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0}, 0.5};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift}, 0.5};
+                return std::array<WeightPoint<dimension>, 2>{P1, P2};
+            }
+
+            else if constexpr (dimension == 2)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, d2pShift}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, d2pShift},
+                                                    0.25};
+                return std::array<WeightPoint<dimension>, 4>{P1, P2, P3, P4};
+            }
+            else if constexpr (dimension == 3)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, d2pShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, d2pShift, 0},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P5{Point<int, dimension>{0, 0, p2dShift}, 0.25};
+                constexpr WeightPoint<dimension> P6{Point<int, dimension>{d2pShift, 0, p2dShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P7{Point<int, dimension>{0, d2pShift, p2dShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P8{
+                    Point<int, dimension>{d2pShift, d2pShift, p2dShift}, 0.25};
+                return std::array<WeightPoint<dimension>, 8>{P1, P2, P3, P4, P5, P6, P7, P8};
+            }
+        }
 
 
         NO_DISCARD auto static constexpr ByToEz()
@@ -838,6 +920,46 @@ namespace core
         }
 
 
+        NO_DISCARD auto static constexpr ByToEy()
+        {
+            // By is dual primal dual
+            // Ey is primal dual primal
+            // the operation is thus dpd to pdp
+            auto constexpr p2dShift = primalToDual();
+            auto constexpr d2pShift = dualToPrimal();
+
+            if constexpr (dimension == 1)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0}, 0.5};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift}, 0.5};
+                return std::array<WeightPoint<dimension>, 2>{P1, P2};
+            }
+            else if constexpr (dimension == 2)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, p2dShift}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, p2dShift},
+                                                    0.25};
+                return std::array<WeightPoint<dimension>, 4>{P1, P2, P3, P4};
+            }
+            else if constexpr (dimension == 3)
+            {
+                constexpr WeightPoint<dimension> P1{Point<int, dimension>{0, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P2{Point<int, dimension>{d2pShift, 0, 0}, 0.25};
+                constexpr WeightPoint<dimension> P3{Point<int, dimension>{0, p2dShift, 0}, 0.25};
+                constexpr WeightPoint<dimension> P4{Point<int, dimension>{d2pShift, p2dShift, 0},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P5{Point<int, dimension>{0, 0, d2pShift}, 0.25};
+                constexpr WeightPoint<dimension> P6{Point<int, dimension>{d2pShift, 0, d2pShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P7{Point<int, dimension>{0, p2dShift, d2pShift},
+                                                    0.25};
+                constexpr WeightPoint<dimension> P8{
+                    Point<int, dimension>{d2pShift, p2dShift, d2pShift}, 0.25};
+                return std::array<WeightPoint<dimension>, 8>{P1, P2, P3, P4, P5, P6, P7, P8};
+            }
+        }
 
 
         NO_DISCARD auto static constexpr BzToEy()

--- a/src/core/data/tensorfield/tensorfield.hpp
+++ b/src/core/data/tensorfield/tensorfield.hpp
@@ -82,15 +82,13 @@ public:
 
     NO_DISCARD auto getCompileTimeResourcesViewList()
     {
-        return for_N<N, for_N_R_mode::forward_tuple>([&](auto i) -> auto& {
-            return components_[i];
-        });
+        return for_N<N, for_N_R_mode::forward_tuple>(
+            [&](auto i) -> auto& { return components_[i]; });
     }
     NO_DISCARD auto getCompileTimeResourcesViewList() const
     {
-        return for_N<N, for_N_R_mode::forward_tuple>([&](auto i) -> auto& {
-            return components_[i];
-        });
+        return for_N<N, for_N_R_mode::forward_tuple>(
+            [&](auto i) -> auto& { return components_[i]; });
     }
 
 

--- a/src/core/data/vecfield/vecfield.hpp
+++ b/src/core/data/vecfield/vecfield.hpp
@@ -31,11 +31,16 @@ namespace core
                 Vavg.getComponent(Component::Z));
     }
 
-    // template<std::size_t... Index>
-    // NO_DISCARD auto norm(std::index_sequence<Index...>) const
+    // template<typename VecField, typename... Index>
+    // NO_DISCARD auto norm(VecField const& vf, Index... index)
     // {
-    //     std::sqrt(std::accumulate(std::begin(components_), std::end(components_), Type{0},
-    //                               [](auto acc, auto const& c) { return acc + c * c; }));
+    //     using Type = typename VecField::value_type;
+    //     std::sqrt(std::accumulate(std::begin(vf.components()), std::end(vf.components()),
+    //     Type{0},
+    //                               [&](auto acc, auto const& c) {
+    //                                   auto const v = c(index...);
+    //                                   return acc(index...) + v * v;
+    //                               }));
     // }
 
     struct VecFieldNames

--- a/src/core/data/vecfield/vecfield.hpp
+++ b/src/core/data/vecfield/vecfield.hpp
@@ -31,6 +31,12 @@ namespace core
                 Vavg.getComponent(Component::Z));
     }
 
+    // template<std::size_t... Index>
+    // NO_DISCARD auto norm(std::index_sequence<Index...>) const
+    // {
+    //     std::sqrt(std::accumulate(std::begin(components_), std::end(components_), Type{0},
+    //                               [](auto acc, auto const& c) { return acc + c * c; }));
+    // }
 
     struct VecFieldNames
     {

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -76,7 +76,7 @@ private:
         Exyz(ijk...) = ideal_<Tag>(Ve, B, {ijk...})      //
                        + pressure_<Tag>(n, Pe, {ijk...}) //
                        + resistive_<Tag>(J, {ijk...})    //
-                       + hyperresistive_<Tag>(J, {ijk...});
+                       + hyperresistive_<Tag>(J, B, n, {ijk...});
     }
 
 
@@ -335,7 +335,8 @@ private:
 
 
     template<auto component, typename VecField>
-    auto hyperresistive_(VecField const& J, MeshIndex<VecField::dimension> index) const
+    auto hyperresistive_(VecField const& J, VecField const& B, VecField const& n,
+                         MeshIndex<VecField::dimension> index) const
     { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
         return -nu_ * layout_->laplacian(J(component), index);
     }

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -365,9 +365,7 @@ private:
     auto spatial_hyperresistive_(VecField const& J, VecField const& B, Field const& n,
                                  MeshIndex<VecField::dimension> index) const
     { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
-        double const dl2{std::accumulate(std::begin(layout_->meshSize()),
-                                         std::end(layout_->meshSize()), 0.,
-                                         [](double acc, double d) { return acc + d * d; })};
+        auto const lvlCoeff = std::pow(4, layout_->levelNumber());
 
         auto computeHR = [&](auto BxProj, auto ByProj, auto BzProj, auto nProj) {
             auto const BxOnE = GridLayout::project(B(Component::X), index, BxProj);
@@ -375,7 +373,7 @@ private:
             auto const BzOnE = GridLayout::project(B(Component::Z), index, BzProj);
             auto const nOnE  = GridLayout::project(n, index, nProj);
             auto b           = std::sqrt(BxOnE * BxOnE + ByOnE * ByOnE + BzOnE * BzOnE);
-            return -nu_ * b / nOnE * dl2 * layout_->laplacian(J(component), index);
+            return -nu_ * b / nOnE * lvlCoeff * layout_->laplacian(J(component), index);
         };
 
         if constexpr (component == Component::X)

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -349,6 +349,8 @@ private:
             return constant_hyperresistive_<component>(J, index);
         else if (hyper_mode == HyperMode::spatial)
             return spatial_hyperresistive_<component>(J, B, n, index);
+        else // should not happen but otherwise -Wreturn-type fails with Werror
+            return 0.;
     }
 
 

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -369,32 +369,29 @@ private:
                                          std::end(layout_->meshSize()), 0.,
                                          [](double acc, double d) { return acc + d * d; })};
 
-        if constexpr (component == Component::X)
-        {
-            auto const BxOnE = GridLayout::project(B(Component::X), index, GridLayout::BxToEx());
-            auto const ByOnE = GridLayout::project(B(Component::Y), index, GridLayout::ByToEx());
-            auto const BzOnE = GridLayout::project(B(Component::Z), index, GridLayout::BzToEx());
-            auto const nOnE  = GridLayout::project(n, index, GridLayout::momentsToEx());
+        auto computeHR = [&](auto BxProj, auto ByProj, auto BzProj, auto nProj) {
+            auto const BxOnE = GridLayout::project(B(Component::X), index, BxProj);
+            auto const ByOnE = GridLayout::project(B(Component::Y), index, ByProj);
+            auto const BzOnE = GridLayout::project(B(Component::Z), index, BzProj);
+            auto const nOnE  = GridLayout::project(n, index, nProj);
             auto b           = std::sqrt(BxOnE * BxOnE + ByOnE * ByOnE + BzOnE * BzOnE);
             return -nu_ * b / nOnE * dl2 * layout_->laplacian(J(component), index);
+        };
+
+        if constexpr (component == Component::X)
+        {
+            return computeHR(GridLayout::BxToEx(), GridLayout::ByToEx(), GridLayout::BzToEx(),
+                             GridLayout::momentsToEx());
         }
         if constexpr (component == Component::Y)
         {
-            auto const BxOnE = GridLayout::project(B(Component::X), index, GridLayout::BxToEy());
-            auto const ByOnE = GridLayout::project(B(Component::Y), index, GridLayout::ByToEy());
-            auto const BzOnE = GridLayout::project(B(Component::Z), index, GridLayout::BzToEy());
-            auto const nOnE  = GridLayout::project(n, index, GridLayout::momentsToEy());
-            auto b           = std::sqrt(BxOnE * BxOnE + ByOnE * ByOnE + BzOnE * BzOnE);
-            return -nu_ * b / nOnE * dl2 * layout_->laplacian(J(component), index);
+            return computeHR(GridLayout::BxToEy(), GridLayout::ByToEy(), GridLayout::BzToEy(),
+                             GridLayout::momentsToEy());
         }
         if constexpr (component == Component::Z)
         {
-            auto const BxOnE = GridLayout::project(B(Component::X), index, GridLayout::BxToEz());
-            auto const ByOnE = GridLayout::project(B(Component::Y), index, GridLayout::ByToEz());
-            auto const BzOnE = GridLayout::project(B(Component::Z), index, GridLayout::BzToEz());
-            auto const nOnE  = GridLayout::project(n, index, GridLayout::momentsToEz());
-            auto b           = std::sqrt(BxOnE * BxOnE + ByOnE * ByOnE + BzOnE * BzOnE);
-            return -nu_ * b / nOnE * dl2 * layout_->laplacian(J(component), index);
+            return computeHR(GridLayout::BxToEz(), GridLayout::ByToEz(), GridLayout::BzToEz(),
+                             GridLayout::momentsToEz());
         }
     }
 };

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -365,7 +365,7 @@ private:
     auto spatial_hyperresistive_(VecField const& J, VecField const& B, Field const& n,
                                  MeshIndex<VecField::dimension> index) const
     { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
-        auto const lvlCoeff = std::pow(4, layout_->levelNumber());
+        auto const lvlCoeff = 1. / std::pow(4, layout_->levelNumber());
 
         auto computeHR = [&](auto BxProj, auto ByProj, auto BzProj, auto nProj) {
             auto const BxOnE = GridLayout::project(B(Component::X), index, BxProj);


### PR DESCRIPTION
is on top of #893 
the PR only concerns the diff in default hybrid tagging and adds absolute values to the tagging formula.
Or alternatively, only the last commit ("tagging better")
current master formula (also in the paper) leads to this refinement if increasing the threshold

![image](https://github.com/user-attachments/assets/ddb01fbd-db3b-437e-9d42-c3b11a64f219)


clearly the two current layers being similar in terms of scales and magnetic jump they should be refined the same way.
This comes from the absolute value missing in the denominator that makes the positive and negative derivatives of B leading to different values of tagging formula hence difference response to the thresholding.

adding the absolute value and testing it for different tagging thresholds leads to 


![image](https://github.com/user-attachments/assets/bb8cbddd-039d-45ac-901c-fe2bc77e57a9)


Which behaves better, see the pic above that tested the same configuration as above for different thresholds:

- at 0.8 there is no refinement
- at 0.6 there is L1 but no L2
- at 0.4 there is an L2 mapping the 2 current layers
- at 0.1, things are a bit similar to 0.4
- at 0.05 L1 remains about the same, but L2 grows a bit, there are more patches
- at 0.01, L1 becomes wider, there is almost no space in between the two current sheets that is not refined
- at 0.001 L2 is larger and L1 occupies all space in between the current layers.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced simulation configurability with new parameters for load balancing and Ohm's law.
	- Introduced `hyper_mode` for improved validation of simulation parameters.
	- Added methods for better handling of magnetic and electric field relationships in Yee grid layouts.

- **Bug Fixes**
	- Improved error handling for unregistered simulation electrons.

- **Refactor**
	- Updated constructors and method signatures to accommodate new features and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->