### PR TITLE
tagging better

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
         set -ex
         cmake $GITHUB_WORKSPACE
         cd ${{runner.workspace}}/PHARE/subprojects/samrai && mkdir build && cd build
-        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug  -DCMAKE_CXX_FLAGS="-O3"
+        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
         make -j2 && sudo make install && cd ../.. && rm -rf samrai
         cd ${{runner.workspace}}/build && rm -rf *
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --fresh \

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -74,11 +74,11 @@ jobs:
         set -ex
         cmake $GITHUB_WORKSPACE
         cd ${{runner.workspace}}/PHARE/subprojects/samrai && mkdir build && cd build
-        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
+        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug  -DCMAKE_CXX_FLAGS="-O3"
         make -j2 && sudo make install && cd ../.. && rm -rf samrai
         cd ${{runner.workspace}}/build && rm -rf *
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --fresh \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dasan=OFF \
+              -DCMAKE_BUILD_TYPE=Debug -Dasan=OFF \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DlowResourceTests=ON -DdevMode=ON -Dbench=ON \

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
         set -ex
         cmake $GITHUB_WORKSPACE
         cd ${{runner.workspace}}/PHARE/subprojects/samrai && mkdir build && cd build
-        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake .. -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
         make -j2 && sudo make install && cd ../.. && rm -rf samrai
         cd ${{runner.workspace}}/build && rm -rf *
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON --fresh \
@@ -82,7 +82,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DlowResourceTests=ON -DdevMode=ON -Dbench=ON \
-              -DCMAKE_CXX_FLAGS="-DPHARE_DIAG_DOUBLES=1 " -Dphare_configurator=ON
+              -DCMAKE_CXX_FLAGS="-O3 -DPHARE_DIAG_DOUBLES=1 " -Dphare_configurator=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/src/amr/tagging/default_hybrid_tagger_strategy.hpp
+++ b/src/amr/tagging/default_hybrid_tagger_strategy.hpp
@@ -108,10 +108,15 @@ void DefaultHybridTaggerStrategy<HybridModel>::tag(HybridModel& model,
             {
                 auto field_diff = [&](auto const& F) //
                 {
-                    return std::make_tuple(std::abs((F(ix + 2, iy) - F(ix, iy))
-                                                    / (1 + std::abs(F(ix + 1, iy) - F(ix, iy)))),
-                                           std::abs(F(ix, iy + 2) - F(ix, iy))
-                                               / (std::abs(F(ix, iy + 1) - F(ix, iy)) + 1));
+                    auto const delta_2x = std::abs(F(ix + 2, iy) - F(ix, iy));
+                    auto const delta_2y = std::abs(F(ix, iy + 2) - F(ix, iy));
+                    auto const delta_x  = std::abs(F(ix + 1, iy) - F(ix, iy));
+                    auto const delta_y  = std::abs(F(ix, iy + 1) - F(ix, iy));
+
+                    auto const criter_x = delta_2x / (1 + delta_x);
+                    auto const criter_y = delta_2y / (1 + delta_y);
+
+                    return std::make_tuple(criter_x, criter_y);
                 };
 
                 auto const& [Bx_x, Bx_y] = field_diff(Bx);

--- a/src/amr/tagging/default_hybrid_tagger_strategy.hpp
+++ b/src/amr/tagging/default_hybrid_tagger_strategy.hpp
@@ -108,9 +108,10 @@ void DefaultHybridTaggerStrategy<HybridModel>::tag(HybridModel& model,
             {
                 auto field_diff = [&](auto const& F) //
                 {
-                    return std::make_tuple(
-                        std::abs((F(ix + 2, iy) - F(ix, iy)) / (1 + F(ix + 1, iy) - F(ix, iy))),
-                        std::abs((F(ix, iy + 2) - F(ix, iy)) / (F(ix, iy + 1) - F(ix, iy) + 1)));
+                    return std::make_tuple(std::abs((F(ix + 2, iy) - F(ix, iy))
+                                                    / (1 + std::abs(F(ix + 1, iy) - F(ix, iy)))),
+                                           std::abs(F(ix, iy + 2) - F(ix, iy))
+                                               / (std::abs(F(ix, iy + 1) - F(ix, iy)) + 1));
                 };
 
                 auto const& [Bx_x, Bx_y] = field_diff(Bx);


### PR DESCRIPTION
This PR fixes the tagging formula by adding the missing absolute value at the denominator.

Results below were obtained with this diff on top of  #893 

current master formula (also in the paper) leads to this refinement if increasing the threshold

![image](https://github.com/user-attachments/assets/ddb01fbd-db3b-437e-9d42-c3b11a64f219)


clearly the two current layers being similar in terms of scales and magnetic jump they should be refined the same way.
This comes from the absolute value missing in the denominator that makes the positive and negative derivatives of B leading to different values of tagging formula hence difference response to the thresholding.

adding the absolute value and testing it for different tagging thresholds leads to 


![image](https://github.com/user-attachments/assets/bb8cbddd-039d-45ac-901c-fe2bc77e57a9)


Which behaves better, see the pic above that tested the same configuration as above for different thresholds:

- at 0.8 there is no refinement
- at 0.6 there is L1 but no L2
- at 0.4 there is an L2 mapping the 2 current layers
- at 0.1, things are a bit similar to 0.4
- at 0.05 L1 remains about the same, but L2 grows a bit, there are more patches
- at 0.01, L1 becomes wider, there is almost no space in between the two current sheets that is not refined
- at 0.001 L2 is larger and L1 occupies all space in between the current layers.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability of magnetic field calculations in the tagging process, reducing the risk of division by zero.

- **New Features**
	- Enhanced logic for tagging in 2D scenarios, ensuring more accurate results based on field differences.
	- Updated build configuration for improved optimization in the SAMRAI project, including changes to build type and compiler flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->