### PR TITLE
minimize save/restore allocations

### DIFF
--- a/src/core/data/particles/particle_array.hpp
+++ b/src/core/data/particles/particle_array.hpp
@@ -41,14 +41,7 @@ public:
 
 
 public:
-    ParticleArray(box_t box)
-        : box_{box}
-        , cellMap_{box_}
-    {
-        assert(box_.size() > 0);
-    }
-
-    ParticleArray(box_t box, std::size_t size)
+    ParticleArray(box_t box = box_t{}, std::size_t size = 0)
         : particles_(size)
         , box_{box}
         , cellMap_{box_}
@@ -79,6 +72,9 @@ public:
     {
         return (this->particles_ == that.particles_);
     }
+
+    NO_DISCARD auto data() const { return particles_.data(); }
+    NO_DISCARD auto data() { return particles_.data(); }
 
     NO_DISCARD auto begin() const { return particles_.begin(); }
     NO_DISCARD auto begin() { return particles_.begin(); }
@@ -235,6 +231,7 @@ public:
     NO_DISCARD auto& vector() const { return particles_; }
 
     auto& box() const { return box_; }
+    auto& map() const { return cellMap_; }
 
 
     auto& replace_from(ParticleArray const& that)
@@ -245,6 +242,14 @@ public:
         std::copy(that.begin(), that.end(), this->begin());
         this->box_     = that.box_;
         this->cellMap_ = that.cellMap_;
+        return *this;
+    }
+    auto& replace_from(Particle_t const* particles, std::size_t size, CellMap_t const& map)
+    {
+        this->resize(size);
+        this->cellMap_ = map;
+        this->box_     = map.box();
+        std::copy(particles, particles + size, particles_.data());
         return *this;
     }
 

--- a/src/core/def.hpp
+++ b/src/core/def.hpp
@@ -44,6 +44,8 @@ NO_DISCARD bool isSettable(auto const&... args)
     return (check(args) && ...);
 }
 
+
+
 } // namespace PHARE::core
 
 #endif // PHARE_CORE_DEF_HPP

--- a/src/core/utilities/cellmap.hpp
+++ b/src/core/utilities/cellmap.hpp
@@ -31,7 +31,7 @@ private:
 
 
 public:
-    CellMap(Box<cell_index_t, dim> box)
+    CellMap(Box<cell_index_t, dim> box = {})
         : box_{box}
         , cellIndexes_{box.shape().template toArray<std::uint32_t>()}
     {

--- a/src/core/vector.hpp
+++ b/src/core/vector.hpp
@@ -1,0 +1,55 @@
+#ifndef PHARE_CORE_VECTOR_HPP
+#define PHARE_CORE_VECTOR_HPP
+
+#include <vector>
+#include <cstdint>
+#include "core/utilities/span.hpp"
+
+namespace PHARE::core
+{
+
+
+template<typename T, bool copy_old_ = true>
+struct MinimizingVector
+{
+    template<bool copy_old = copy_old_>
+    auto& get(std::size_t const& s)
+    {
+        if (s < v.capacity() * percentile)
+            ++_c;
+        else
+            _c = 0;
+
+        if (_c == period)
+        {
+            std::vector<T> r(v.capacity() * realloc_to);
+            if constexpr (copy_old)
+                r = v;
+            v  = std::move(r);
+            _c = 0;
+        }
+
+        v.resize(s);
+        return v;
+    }
+
+    auto size() const { return v.size(); }
+    auto capacity() const { return v.capacity(); }
+    auto& operator()() { return v; }
+    auto& operator()() const { return v; }
+    auto& operator()(std::size_t const& s) { return get(s); }
+
+    double const percentile  = .80;
+    double const realloc_to  = .90;
+    std::size_t const period = 100;
+
+    std::vector<T> v{};
+    std::uint16_t _c = 0;
+};
+
+
+
+
+} // namespace PHARE::core
+
+#endif // PHARE_CORE_VECTOR_HPP


### PR DESCRIPTION
master 800**2 harris for 10 timesteps

`perf stat mpirun -n 8 python3 -Ou harris.py`


```
t =  0.01000  -  3.09741sec  - total   3.097sec
t =  0.02000  -  4.06846sec  - total   7.166sec
t =  0.03000  -  3.59235sec  - total   10.76sec
t =  0.04000  -  3.61215sec  - total   14.37sec
t =  0.05000  -  3.54478sec  - total   17.92sec
t =  0.06000  -  3.65917sec  - total   21.57sec
t =  0.07000  -  3.52980sec  - total    25.1sec
t =  0.08000  -  3.47992sec  - total   28.58sec
t =  0.09000  -  3.50010sec  - total   32.08sec
t =  0.10000  -  3.49883sec  - total   35.58sec
mean advance time = 3.558296871185303
total advance time = 0:00:35.582969

 Performance counter stats for 'mpirun -n 8 python3 -Ou ../master/harris.py':

        306,346.10 msec task-clock                       #    7.727 CPUs utilized             
            16,856      context-switches                 #   55.023 /sec                      
             1,358      cpu-migrations                   #    4.433 /sec                      
        13,233,048      page-faults                      #   43.196 K/sec                     
   477,533,241,846      cycles                           #    1.559 GHz                       
    64,904,175,940      stalled-cycles-frontend          #   13.59% frontend cycles idle      
   947,676,761,783      instructions                     #    1.98  insn per cycle            
                                                  #    0.07  stalled cycles per insn   
    71,270,615,978      branches                         #  232.647 M/sec                     
     2,456,773,652      branch-misses                    #    3.45% of all branches           

      39.645463201 seconds time elapsed

     252.248087000 seconds user
      50.480167000 seconds sys

```

vs this PR 

```
t =  0.01000  -  2.64360sec  - total   2.644sec
t =  0.02000  -  3.08067sec  - total   5.724sec
t =  0.03000  -  3.15369sec  - total   8.878sec
t =  0.04000  -  3.11711sec  - total    12.0sec
t =  0.05000  -  3.12012sec  - total   15.12sec
t =  0.06000  -  3.06334sec  - total   18.18sec
t =  0.07000  -  3.08013sec  - total   21.26sec
t =  0.08000  -  3.48485sec  - total   24.74sec
t =  0.09000  -  3.90359sec  - total   28.65sec
t =  0.10000  -  3.10904sec  - total   31.76sec
mean advance time = 3.17561354637146
total advance time = 0:00:31.756135

 Performance counter stats for 'mpirun -n 8 python3 -Ou harris.py':

        276,932.89 msec task-clock                       #    7.702 CPUs utilized             
            18,070      context-switches                 #   65.250 /sec                      
             1,410      cpu-migrations                   #    5.091 /sec                      
         4,189,838      page-faults                      #   15.129 K/sec                     
   403,919,758,323      cycles                           #    1.459 GHz                       
    33,425,036,082      stalled-cycles-frontend          #    8.28% frontend cycles idle      
   839,432,838,228      instructions                     #    2.08  insn per cycle            
                                                  #    0.04  stalled cycles per insn   
    50,362,453,610      branches                         #  181.858 M/sec                     
     1,155,931,187      branch-misses                    #    2.30% of all branches           

      35.956348966 seconds time elapsed

     258.903196000 seconds user
      14.351512000 seconds sys

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `SaveState` struct for improved state management of particles.
	- Added default parameters to the `ParticleArray` constructor for easier instantiation.
	- New functions `isUsable` and `isSettable` added for enhanced usability checks.
	- Implemented optional parameters in the `CellMap` constructor.
	- Introduced a `MinimizingVector` struct for efficient dynamic vector management.

- **Bug Fixes**
	- Updated method signatures for better const correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->