### PR TITLE
safer nu

### DIFF
--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -360,7 +360,8 @@ private:
     auto spatial_hyperresistive_(VecField const& J, VecField const& B, Field const& n,
                                  MeshIndex<VecField::dimension> index) const
     { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
-        auto const lvlCoeff = 1. / std::pow(4, layout_->levelNumber());
+        auto const lvlCoeff        = 1. / std::pow(4, layout_->levelNumber());
+        auto constexpr min_density = 0.1;
 
         auto computeHR = [&](auto BxProj, auto ByProj, auto BzProj, auto nProj) {
             auto const BxOnE = GridLayout::project(B(Component::X), index, BxProj);
@@ -368,7 +369,8 @@ private:
             auto const BzOnE = GridLayout::project(B(Component::Z), index, BzProj);
             auto const nOnE  = GridLayout::project(n, index, nProj);
             auto b           = std::sqrt(BxOnE * BxOnE + ByOnE * ByOnE + BzOnE * BzOnE);
-            return -nu_ * b / nOnE * lvlCoeff * layout_->laplacian(J(component), index);
+            return -nu_ * (b / (nOnE + min_density) + 1) * lvlCoeff
+                   * layout_->laplacian(J(component), index);
         };
 
         if constexpr (component == Component::X)


### PR DESCRIPTION
replaces 

$$
-\nu_0 \frac{B}{n} L\nabla^2\mathbf{j}
$$

which becomes too small when $B\to 0$, typically around reconnection X points.


<img width="741" alt="Capture d’écran 2024-10-19 à 16 06 24" src="https://github.com/user-attachments/assets/2a06b51f-6b8f-4492-8e16-63cc9e3852c7">


There, increasing $\nu_0$ is not solving the problem, it only increases dissipation in regions where B is non-zero and cannot prevent the dissipation to go to zero with B.


The proposed formula is:

$$
-\nu_0 (\frac{B}{n+n_\epsilon}+1) L\nabla^2\mathbf{j}
$$

which tends to:

with

$$
-\nu_0  L\nabla^2\mathbf{j}
$$

when $B\to 0$


and 

$$
-\nu_0 (\frac{B}{n_\epsilon}+1) L\nabla^2\mathbf{j}
$$


when $n\to 0$


For reference, here is what we get un run055 with constant hyper-resistivity $\nu=0.002$:

<img width="762" alt="image" src="https://github.com/user-attachments/assets/d9b2a1bb-09ab-4ecf-bd5b-5f60320dea5d">

