### PR TITLE
macos-12 github action deprecated

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12, macos-13, macos-latest]
+        os: [ macos-13, macos-14, macos-latest]
         include:
-        - os: macos-12
-          dylib_path: /usr/local/lib/gcc/current
         - os: macos-13
+          dylib_path: /usr/local/lib/gcc/current
+        - os: macos-14
           dylib_path: /usr/local/lib/gcc/current
         - os: macos-latest # https://github.com/actions/runner/issues/3337
           dylib_path: /opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/current

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  dylib_path: Monday
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,14 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-13, macos-14, macos-latest]
-        include:
-        - os: macos-13
-          dylib_path: /usr/local/lib/gcc/current
-        - os: macos-14
-          dylib_path: /usr/local/lib/gcc/current
-        - os: macos-latest # https://github.com/actions/runner/issues/3337
-          dylib_path: /opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/current
-
 
     steps:
     - name: Build Info
@@ -79,10 +74,10 @@ jobs:
     - name: Configure CMake
       working-directory: ${{runner.workspace}}/build
       env:
-        LIBRARY_PATH: ${{ matrix.dylib_path }} # used by clang, needed to find libquadmath - else link error
+        LIBRARY_PATH: ${{ env.dylib_path }} # used by clang, needed to find libquadmath - else link error
       run: |
         [ -d /opt/homebrew/Cellar/gcc ] && ls -l /opt/homebrew/Cellar/gcc
-        [ ! -d "${{matrix.dylib_path}}" ] && echo dylib_path not found && find / -name "libquadmath.0.dylib" && exit 1
+        [ ! -d "${{env.dylib_path}}" ] && echo dylib_path not found && find / -name "libquadmath.0.dylib" && exit 1
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -92,7 +87,7 @@ jobs:
     - name: Build
       working-directory: ${{runner.workspace}}/build
       env:
-        LIBRARY_PATH: ${{ matrix.dylib_path }} # used by clang, needed to find libquadmath - else link error
+        LIBRARY_PATH: ${{ env.dylib_path }} # used by clang, needed to find libquadmath - else link error
       run: cmake --build . -j 2
 
     - name: Test

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -1,5 +1,8 @@
 name: CMake MacOS
 
+# if issues with libquadmath appear again, see previous version:
+#  https://github.com/PHAREHUB/PHARE/blob/61ad57b285e875b396ecf8957e0579427ad6be30/.github/workflows/cmake_macos.yml
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -7,9 +10,6 @@ concurrency:
 on:
   pull_request:
   workflow_dispatch:
-
-env:
-  dylib_path: Monday
 
 jobs:
   build:
@@ -73,11 +73,7 @@ jobs:
 
     - name: Configure CMake
       working-directory: ${{runner.workspace}}/build
-      env:
-        LIBRARY_PATH: ${{ env.dylib_path }} # used by clang, needed to find libquadmath - else link error
       run: |
-        [ -d /opt/homebrew/Cellar/gcc ] && ls -l /opt/homebrew/Cellar/gcc
-        [ ! -d "${{env.dylib_path}}" ] && echo dylib_path not found && find / -name "libquadmath.0.dylib" && exit 1
         cmake $GITHUB_WORKSPACE -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DENABLE_SAMRAI_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -86,8 +82,6 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      env:
-        LIBRARY_PATH: ${{ env.dylib_path }} # used by clang, needed to find libquadmath - else link error
       run: cmake --build . -j 2
 
     - name: Test


### PR DESCRIPTION
`The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the macOS versions in the build workflow to include `macos-14` and remove `macos-12`.
	- Simplified the setup by removing `dylib_path` references from the workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->