### PR TITLE
minimized deps for cpp_etc / etc

### DIFF
--- a/src/initializer/python_data_provider.hpp
+++ b/src/initializer/python_data_provider.hpp
@@ -6,18 +6,8 @@
 
 #include "initializer/data_provider.hpp"
 
-#include "core/def/pragma_disable.hpp"
-
-// clang-format off
-DISABLE_WARNING(shadow, shadow-field-in-constructor-modified, 42)
-
-#undef HAVE_SYS_TIMES_H // included in python again, possibly with different value
-#undef HAVE_UNISTD_H
-
 #include <pybind11/embed.h> // everything needed for embedding
 #include <pybind11/functional.h>
-ENABLE_WARNING(shadow, shadow-field-in-constructor-modified, 42)
-// clang-format on
 
 namespace py = pybind11;
 

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -28,7 +28,7 @@ endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 pybind11_add_module(cpp_etc cpp_etc.cpp)
 target_compile_options(cpp_etc PRIVATE ${PHARE_WERROR_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE})
-target_link_libraries(cpp_dbg PUBLIC phare_amr) # gives us samrai header includes
+target_link_libraries(cpp_etc PUBLIC phare_amr) # gives us samrai header includes
 set_target_properties(cpp_etc
     PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pybindlibs"

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -27,7 +27,6 @@ endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 
 pybind11_add_module(cpp_etc cpp_etc.cpp)
-target_link_libraries(cpp_etc PUBLIC phare_amr)
 target_compile_options(cpp_etc PRIVATE ${PHARE_WERROR_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE})
 set_target_properties(cpp_etc
     PROPERTIES

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -28,6 +28,7 @@ endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 pybind11_add_module(cpp_etc cpp_etc.cpp)
 target_compile_options(cpp_etc PRIVATE ${PHARE_WERROR_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE})
+target_link_libraries(cpp_dbg PUBLIC phare_amr) # gives us samrai header includes
 set_target_properties(cpp_etc
     PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pybindlibs"

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -27,7 +27,7 @@ endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 
 pybind11_add_module(cpp_etc cpp_etc.cpp)
-target_link_libraries(cpp_etc PUBLIC phare_simulator)
+target_link_libraries(cpp_etc PUBLIC phare_amr)
 target_compile_options(cpp_etc PRIVATE ${PHARE_WERROR_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE})
 set_target_properties(cpp_etc
     PROPERTIES

--- a/src/python3/cpp_etc.cpp
+++ b/src/python3/cpp_etc.cpp
@@ -1,9 +1,14 @@
 
-#include "python3/pybind_def.hpp"
-#include "simulator/simulator.hpp"
-
+#include "core/def.hpp"
 #include "core/def/phare_config.hpp"
 
+#include "python3/pybind_def.hpp"
+
+#include "hdf5/phare_hdf5.hpp"
+
+#if PHARE_HAS_HIGHFIVE
+#include "hdf5/detail/h5/h5_file.hpp"
+#endif
 
 #include "amr/wrappers/hierarchy.hpp" // for HierarchyRestarter::getRestartFileFullPath
 

--- a/src/python3/pybind_def.hpp
+++ b/src/python3/pybind_def.hpp
@@ -10,8 +10,7 @@
 
 #include "pybind11/stl.h"
 #include "pybind11/numpy.h"
-#undef HAVE_SYS_TIMES_H // included in python again, possibly with different value
-#undef HAVE_UNISTD_H
+
 
 namespace PHARE::pydata
 {


### PR DESCRIPTION
related to #958

Change cpp_etc target to no longer link to libphare_simulator, which was unnecessary originally as we only need samrai and hdf5 for version info

potential todos: do no build an other libraries for phare except the necessary shared libs

i.e. dictator, initializer, cpp pybind libs

the issue, so we think is that during link time optimization there is some symbol which is expected but is not found, but the symbol, should never be used, so it's understandable that it's not found, just not why it is expected.

It seems like the issue is in diagnostics for cppdict and highfive attributes

and some other general maintenance around pybind and include/pragmas

