### PR TITLE
werror particle may be uninitialized

### DIFF
--- a/src/core/data/particles/particle_packer.hpp
+++ b/src/core/data/particles/particle_packer.hpp
@@ -14,6 +14,8 @@ namespace PHARE::core
 template<std::size_t dim>
 class ParticlePacker
 {
+    constexpr static Particle<dim> default_particle{};
+
 public:
     static constexpr std::size_t n_keys = 5;
 
@@ -28,11 +30,7 @@ public:
                                      particle.delta, particle.v);
     }
 
-    static auto empty()
-    {
-        Particle<dim> particle{};
-        return get(particle);
-    }
+    static constexpr auto empty() { return get(default_particle); }
 
     // sometimes we use this to infer the size of an ParticleArray
     // could be "charge" either
@@ -65,7 +63,7 @@ public:
 private:
     ParticleArray<dim> const& particles_;
     std::size_t it_ = 0;
-    static inline const std::array<std::string, n_keys> keys_{"weight", "charge", "iCell", "delta",
+    static inline std::array<std::string, n_keys> const keys_{"weight", "charge", "iCell", "delta",
                                                               "v"};
 };
 


### PR DESCRIPTION
extract from #953 that fixes 

```
/home/runner/work/PHARE/PHARE/src/core/utilities/types.hpp:102:46: error: ‘particle’ may be used uninitialized [-Werror=maybe-uninitialized]
  102 |         std::apply([&](auto&... args) { (func(args), ...); }, tuple);

[...]
declared here
  139 |         core::apply(Packer::empty(), [&](auto const& arg) {
      |                                      ^
/home/runner/work/PHARE/PHARE/src/core/data/particles/particle_packer.hpp:33:23: note: ‘particle’ declared here
   33 |         Particle<dim> particle{};
      |                       ^~~~~~~~
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized default instance handling to simplify empty state processing.
	- Enhanced internal configuration clarity for more consistent behavior.

This update refines how default data scenarios are managed. While the user experience remains unchanged, these improvements strengthen consistency and maintainability behind the scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->