### PR TITLE
comment on timestamp diag test

### DIFF
--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -102,6 +102,13 @@ class DiagnosticsTest(unittest.TestCase):
         return self._testMethodName.split("_")[-1]
 
     def test_dump_diags_timestamps(self):
+        """
+        This test was made to run for a long time to make sure we do not have rounding
+        errors in the way the time is set in PHARE. Before, time was incrementally increase
+        by dt, leading to rounding errors, leading to key errors while reading diags. Now with the
+        ConstantTimeStamper, we iterate the time INDEX and get the current time increment
+        from start time, which removes the rounding error.
+        """
         print("test_dump_diags dim/interp:{}/{}".format(1, 1))
 
         simulation = ph.Simulation(**simArgs.copy())


### PR DESCRIPTION
add some comment to explain why the test is here and how the issue was solved.
The purpose of the second test is not clear. It's differing by having a refined level which means it could assess the times are OK also at fine level diags, but they are not dumped/checked, but it also only does 100 steps.