### PR TITLE
particle array impl isolation

### DIFF
--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -481,8 +481,9 @@ namespace amr
                     auto& levelGhostParticlesNew = pop.levelGhostParticlesNew();
                     auto& levelGhostParticles    = pop.levelGhostParticles();
 
-                    levelGhostParticlesOld = std::move(levelGhostParticlesNew);
-                    levelGhostParticles    = levelGhostParticlesOld;
+                    std::swap(levelGhostParticlesNew, levelGhostParticlesOld);
+                    levelGhostParticlesNew.clear();
+                    levelGhostParticles = levelGhostParticlesOld;
                 }
             }
         }

--- a/src/core/data/particles/particle_array.hpp
+++ b/src/core/data/particles/particle_array.hpp
@@ -144,7 +144,7 @@ public:
         cellMap_.add(particles_, particles_.size() - 1);
     }
 
-    void swap(ParticleArray<dim>& that) { std::swap(this->particles_, that.particles_); }
+
 
     void map_particles() const { cellMap_.add(particles_); }
     void empty_map() { cellMap_.empty(); }

--- a/src/core/data/particles/particle_array.hpp
+++ b/src/core/data/particles/particle_array.hpp
@@ -56,33 +56,10 @@ public:
         assert(box_.size() > 0);
     }
 
-    ParticleArray(ParticleArray&& from) = delete; // not used anywhere
-
-    ParticleArray(ParticleArray const& from)
-        : particles_{from.particles_}
-        , box_{from.box_}
-        , cellMap_{from.cellMap_}
-    {
-        remap_particles();
-    }
-
-    ParticleArray& operator=(ParticleArray const& from)
-    {
-        this->particles_ = from.particles_;
-        this->box_       = from.box_;
-        this->cellMap_   = from.cellMap_; // copy for alloc, not alloc on pushback
-        remap_particles();
-        return *this;
-    };
-
-    ParticleArray& operator=(ParticleArray&& from)
-    {
-        this->particles_ = std::move(from.particles_);
-        this->box_       = from.box_;     // not movable
-        this->cellMap_   = from.cellMap_; // std::move == segfault / bug in cellmap?
-        from.cellMap_.clear();
-        return *this;
-    };
+    ParticleArray(ParticleArray const& from)            = default;
+    ParticleArray(ParticleArray&& from)                 = default;
+    ParticleArray& operator=(ParticleArray&& from)      = default;
+    ParticleArray& operator=(ParticleArray const& from) = default;
 
     NO_DISCARD std::size_t size() const { return particles_.size(); }
     NO_DISCARD std::size_t capacity() const { return particles_.capacity(); }
@@ -171,11 +148,6 @@ public:
 
     void map_particles() const { cellMap_.add(particles_); }
     void empty_map() { cellMap_.empty(); }
-    void remap_particles()
-    {
-        empty_map();
-        map_particles();
-    }
 
 
     NO_DISCARD auto nbr_particles_in(box_t const& box) const { return cellMap_.size(box); }

--- a/src/core/data/particles/particle_array.hpp
+++ b/src/core/data/particles/particle_array.hpp
@@ -208,24 +208,15 @@ public:
     }
 
 
-    NO_DISCARD bool is_mapped() const
+    NO_DISCARD bool is_consistent() const
     {
-        bool ok = true;
         if (particles_.size() != cellMap_.size())
-        {
-            throw std::runtime_error("particle array not mapped, map.size() != array.size()");
-        }
+            return false;
+
         for (std::size_t pidx = 0; pidx < particles_.size(); ++pidx)
-        {
-            auto const& p = particles_[pidx];
-            auto& icell   = p.iCell;
-            auto l        = cellMap_.list_at(icell);
-            if (!l)
-                throw std::runtime_error("particle cell not mapped");
-            auto& ll = l->get();
-            if (!ll.is_indexed(pidx))
-                throw std::runtime_error("particle not indexed");
-        }
+            if (!cellMap_(particles_[pidx].iCell).is_indexed(pidx))
+                return false;
+
         return true;
     }
 

--- a/tests/core/data/particles/CMakeLists.txt
+++ b/tests/core/data/particles/CMakeLists.txt
@@ -20,5 +20,5 @@ endfunction(_particles_test)
 
 _particles_test(test_main.cpp test-particles)
 _particles_test(test_interop.cpp test-particles-interop)
-_particles_test(test_particle_array_operators.cpp test-particles-operators)
+_particles_test(test_particle_array_consistency.cpp test-particles-consistency)
 

--- a/tests/core/data/particles/CMakeLists.txt
+++ b/tests/core/data/particles/CMakeLists.txt
@@ -20,3 +20,5 @@ endfunction(_particles_test)
 
 _particles_test(test_main.cpp test-particles)
 _particles_test(test_interop.cpp test-particles-interop)
+_particles_test(test_particle_array_operators.cpp test-particles-operators)
+

--- a/tests/core/data/particles/test_particle_array_consistency.cpp
+++ b/tests/core/data/particles/test_particle_array_consistency.cpp
@@ -34,12 +34,10 @@ void add_particles_in(ParticleArray_t& particles, Box_t const& box)
             particles.emplace_back(particle<ParticleArray_t::dimension>(*bix));
 }
 
-struct AParticleArrayConstructionTest : public ::testing::Test
-{
-};
+
 
 template<typename ParticleArray_>
-struct ParticleArrayConstructionTest : public AParticleArrayConstructionTest
+struct ParticleArrayConsistencyTest : public ::testing::Test
 {
     auto constexpr static dim    = ParticleArray_::dimension;
     auto constexpr static interp = 1;
@@ -55,11 +53,11 @@ struct ParticleArrayConstructionTest : public AParticleArrayConstructionTest
 using Permutations_t = testing::Types<ParticleArray<1>>;
 
 
-TYPED_TEST_SUITE(ParticleArrayConstructionTest, Permutations_t, );
+TYPED_TEST_SUITE(ParticleArrayConsistencyTest, Permutations_t, );
 
 
 
-TYPED_TEST(ParticleArrayConstructionTest, test_move_swap_etc)
+TYPED_TEST(ParticleArrayConsistencyTest, test_is_consistent_after_swap_copy)
 {
     using ParticleArray_t     = TestFixture::ParticleArray_t;
     auto static constexpr dim = ParticleArray_t::dimension;

--- a/tests/core/data/particles/test_particle_array_operators.cpp
+++ b/tests/core/data/particles/test_particle_array_operators.cpp
@@ -57,31 +57,6 @@ using Permutations_t = testing::Types<ParticleArray<1>>;
 
 TYPED_TEST_SUITE(ParticleArrayConstructionTest, Permutations_t, );
 
-TYPED_TEST(ParticleArrayConstructionTest, test_swap_etc)
-{
-    using ParticleArray_t     = TestFixture::ParticleArray_t;
-    auto static constexpr dim = ParticleArray_t::dimension;
-
-    auto levelGhostParticles = ParticleArray<dim>{this->layout.AMRBox()};
-    add_particles_in(levelGhostParticles, this->layout.AMRBox());
-
-    auto levelGhostParticlesNew = ParticleArray<dim>{this->layout.AMRBox()};
-    add_particles_in(levelGhostParticlesNew, this->layout.AMRBox());
-
-    auto levelGhostParticlesOld = ParticleArray<dim>{this->layout.AMRBox()};
-    add_particles_in(levelGhostParticlesOld, this->layout.AMRBox());
-
-    std::swap(levelGhostParticlesNew, levelGhostParticlesOld);
-    levelGhostParticlesNew.clear();
-    levelGhostParticles.clear();
-    std::copy(std::begin(levelGhostParticlesOld), std::end(levelGhostParticlesOld),
-              std::back_inserter(levelGhostParticles));
-
-    EXPECT_EQ(levelGhostParticlesNew.size(), 0);
-    EXPECT_EQ(levelGhostParticlesOld.size(), ppc * std::pow(cells, TestFixture::dim));
-    EXPECT_EQ(levelGhostParticles.size(), ppc * std::pow(cells, TestFixture::dim));
-}
-
 
 
 TYPED_TEST(ParticleArrayConstructionTest, test_move_swap_etc)
@@ -105,6 +80,10 @@ TYPED_TEST(ParticleArrayConstructionTest, test_move_swap_etc)
     EXPECT_EQ(levelGhostParticlesNew.size(), 0);
     EXPECT_EQ(levelGhostParticlesOld.size(), ppc * std::pow(cells, TestFixture::dim));
     EXPECT_EQ(levelGhostParticles.size(), ppc * std::pow(cells, TestFixture::dim));
+
+    EXPECT_TRUE(levelGhostParticlesNew.is_consistent());
+    EXPECT_TRUE(levelGhostParticlesOld.is_consistent());
+    EXPECT_TRUE(levelGhostParticles.is_consistent());
 }
 
 

--- a/tests/core/data/particles/test_particle_array_operators.cpp
+++ b/tests/core/data/particles/test_particle_array_operators.cpp
@@ -1,0 +1,118 @@
+
+
+#include "phare_core.hpp"
+#include "core/utilities/types.hpp"
+#include "core/data/particles/particle_array.hpp"
+
+#include "tests/core/data/gridlayout/test_gridlayout.hpp"
+
+#include "gtest/gtest.h"
+#include <cmath>
+
+
+namespace PHARE::core
+{
+std::size_t static constexpr cells = 3;
+std::size_t static constexpr ppc   = 10;
+
+
+template<std::size_t dim, typename ICell>
+PHARE::core::Particle<dim> particle(ICell const& icell)
+{
+    return {/*.weight = */ 0,
+            /*.charge = */ 1,
+            /*.iCell  = */ icell,
+            /*.delta  = */ PHARE::core::ConstArray<double, dim>(.5),
+            /*.v      = */ {{.00001, .00001, .00001}}};
+}
+
+template<typename ParticleArray_t, typename Box_t>
+void add_particles_in(ParticleArray_t& particles, Box_t const& box)
+{
+    for (auto const& bix : box)
+        for (std::size_t i = 0; i < ppc; ++i)
+            particles.emplace_back(particle<ParticleArray_t::dimension>(*bix));
+}
+
+struct AParticleArrayConstructionTest : public ::testing::Test
+{
+};
+
+template<typename ParticleArray_>
+struct ParticleArrayConstructionTest : public AParticleArrayConstructionTest
+{
+    auto constexpr static dim    = ParticleArray_::dimension;
+    auto constexpr static interp = 1;
+
+    using GridLayout_t    = TestGridLayout<typename PHARE_Types<dim, interp>::GridLayout_t>;
+    using ParticleArray_t = ParticleArray_;
+
+    GridLayout_t layout{cells};
+};
+
+
+
+using Permutations_t = testing::Types<ParticleArray<1>>;
+
+
+TYPED_TEST_SUITE(ParticleArrayConstructionTest, Permutations_t, );
+
+TYPED_TEST(ParticleArrayConstructionTest, test_swap_etc)
+{
+    using ParticleArray_t     = TestFixture::ParticleArray_t;
+    auto static constexpr dim = ParticleArray_t::dimension;
+
+    auto levelGhostParticles = ParticleArray<dim>{this->layout.AMRBox()};
+    add_particles_in(levelGhostParticles, this->layout.AMRBox());
+
+    auto levelGhostParticlesNew = ParticleArray<dim>{this->layout.AMRBox()};
+    add_particles_in(levelGhostParticlesNew, this->layout.AMRBox());
+
+    auto levelGhostParticlesOld = ParticleArray<dim>{this->layout.AMRBox()};
+    add_particles_in(levelGhostParticlesOld, this->layout.AMRBox());
+
+    std::swap(levelGhostParticlesNew, levelGhostParticlesOld);
+    levelGhostParticlesNew.clear();
+    levelGhostParticles.clear();
+    std::copy(std::begin(levelGhostParticlesOld), std::end(levelGhostParticlesOld),
+              std::back_inserter(levelGhostParticles));
+
+    EXPECT_EQ(levelGhostParticlesNew.size(), 0);
+    EXPECT_EQ(levelGhostParticlesOld.size(), ppc * std::pow(cells, TestFixture::dim));
+    EXPECT_EQ(levelGhostParticles.size(), ppc * std::pow(cells, TestFixture::dim));
+}
+
+
+
+TYPED_TEST(ParticleArrayConstructionTest, test_move_swap_etc)
+{
+    using ParticleArray_t     = TestFixture::ParticleArray_t;
+    auto static constexpr dim = ParticleArray_t::dimension;
+
+    auto levelGhostParticles = ParticleArray<dim>{this->layout.AMRBox()};
+    add_particles_in(levelGhostParticles, this->layout.AMRBox());
+
+    auto levelGhostParticlesNew = ParticleArray<dim>{this->layout.AMRBox()};
+    add_particles_in(levelGhostParticlesNew, this->layout.AMRBox());
+
+    auto levelGhostParticlesOld = ParticleArray<dim>{this->layout.AMRBox()};
+    add_particles_in(levelGhostParticlesOld, this->layout.AMRBox());
+
+    std::swap(levelGhostParticlesNew, levelGhostParticlesOld);
+    levelGhostParticlesNew.clear();
+    levelGhostParticles = levelGhostParticlesOld;
+
+    EXPECT_EQ(levelGhostParticlesNew.size(), 0);
+    EXPECT_EQ(levelGhostParticlesOld.size(), ppc * std::pow(cells, TestFixture::dim));
+    EXPECT_EQ(levelGhostParticles.size(), ppc * std::pow(cells, TestFixture::dim));
+}
+
+
+} // namespace PHARE::core
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
closes #967

currently the internal impl of the particle array somewhat leaks out as we have to use the copy with back_inserter in order to use the ParticleArray::push_back function, which in turns updates the cell map internally.

solution is to rely on a custom copy construct which itself keeps the new cellmap consistent