### PR TITLE
find python with dev embed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(CheckCXXCompilerFlag)
 find_program(Git git)
-find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
 
 set(PHARE_PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/res/cmake/dep/pybind.cmake
+++ b/res/cmake/dep/pybind.cmake
@@ -11,7 +11,7 @@ function(get_pybind)
 
   message("downloading subproject pybind11")
   set(PYBIND11_SRCDIR ${CMAKE_CURRENT_SOURCE_DIR}/subprojects/pybind11)
-  set(PYBIND11_VERSION v2.13.6) # github.com/pybind/pybind11/pull/5553 broke master
+  set(PYBIND11_VERSION "master")
 
   phare_github_get_or_update(pybind11 ${PYBIND11_SRCDIR} pybind/pybind11 ${PYBIND11_VERSION})
 


### PR DESCRIPTION
we probably should have had this the whole time.

`If component Development is specified, it implies sub-components Development.Module and Development.Embed.`

https://cmake.org/cmake/help/latest/module/FindPython.html

closes #983