### PR TITLE
compute overlap refac

### DIFF
--- a/pyphare/pyphare/pharesee/geometry.py
+++ b/pyphare/pyphare/pharesee/geometry.py
@@ -237,12 +237,13 @@ def compute_overlaps(patches, domain_box):
                             }
                         )
                         if offset != zero_offset:
+                            other_overlap = boxm.shift(gb_ref, -offset) * gb_cmp
                             overlaps.append(
                                 {
                                     "pdatas": (ref_pd, cmp_pd),
                                     "patches": (refPatch, cmpPatch),
-                                    "box": overlap,
-                                    "offset": (zero_offset, offset),
+                                    "box": other_overlap,
+                                    "offset": (-offset, zero_offset),
                                 }
                             )
 

--- a/pyphare/pyphare_tests/test_pharesee/test_geometry.py
+++ b/pyphare/pyphare_tests/test_pharesee/test_geometry.py
@@ -27,7 +27,7 @@ class GeometryTest(unittest.TestCase):
             domain_size=domain_size,
             cell_width=domain_size / nbr_cells,
             refinement_boxes=refinement_boxes,
-            **kwargs
+            **kwargs,
         )
 
     # used for tests without ddt hierarchy overrides
@@ -78,18 +78,20 @@ class GeometryTest(unittest.TestCase):
         }
 
         overlaps = hierarchy_overlaps(hierarchy)
+        tested_overlaps = {
+            ilvl: [
+                {"box": overlap["box"], "offset": overlap["offset"]}
+                for overlap in overlaps[ilvl]
+            ]
+            for ilvl in range(len(hierarchy.patch_levels))
+        }
 
         for ilvl, lvl in enumerate(hierarchy.patch_levels):
             self.assertEqual(len(expected[ilvl]), len(overlaps[ilvl]))
 
-            for exp, actual in zip(expected[ilvl], overlaps[ilvl]):
-                act_box = actual["box"]
-                act_offset = actual["offset"]
-                exp_box = exp["box"]
-                exp_offset = exp["offset"]
-
-                self.assertEqual(act_box, exp_box)
-                self.assertEqual(act_offset, exp_offset)
+            for actual in tested_overlaps[ilvl]:
+                if actual not in expected[ilvl]:
+                    raise AssertionError(f"Unexpected overlap: {actual}")
 
     def test_touch_border(self):
         hierarchy = self.basic_hierarchy()

--- a/pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py
+++ b/pyphare/pyphare_tests/test_pharesee/test_geometry_2d.py
@@ -114,15 +114,19 @@ class GeometryTest(AGeometryTest):
         )
 
         level_overlaps = hierarchy_overlaps(hierarchy)
+        tested_overlaps = {
+            ilvl: [
+                {"box": overlap["box"], "offset": overlap["offset"]}
+                for overlap in level_overlaps[ilvl]
+            ]
+            for ilvl in expected.keys()
+        }
         for ilvl, lvl in enumerate(hierarchy.levels().items()):
             if ilvl not in expected:
                 continue
             self.assertEqual(len(expected[ilvl]), len(level_overlaps[ilvl]))
-            for exp, actual in zip(expected[ilvl], level_overlaps[ilvl]):
-                self.assertEqual(actual["box"], exp["box"])
-                self.assertTrue(
-                    (np.asarray(actual["offset"]) == np.asarray(exp["offset"])).all()
-                )
+            for actual in tested_overlaps[ilvl]:
+                self.assertTrue(actual in expected[ilvl])
 
         if 1 in level_overlaps:
             fig = hierarchy.plot_2d_patches(
@@ -163,14 +167,16 @@ class GeometryTest(AGeometryTest):
         level_overlaps = hierarchy_overlaps(hierarchy)
         ilvl = 0
         overlap_boxes = []
+        tested_overlaps = {
+            0: [
+                {"box": overlap["box"], "offset": overlap["offset"]}
+                for overlap in level_overlaps[ilvl]
+            ]
+        }
 
-        self.assertEqual(len(expected), len(level_overlaps[ilvl]))
-        for exp, actual in zip(expected, level_overlaps[ilvl]):
-            self.assertEqual(actual["box"], exp["box"])
-            self.assertTrue(
-                (np.asarray(actual["offset"]) == np.asarray(exp["offset"])).all()
-            )
-            overlap_boxes += [actual["box"]]
+        self.assertEqual(len(expected), len(tested_overlaps[ilvl]))
+        for actual in tested_overlaps[ilvl]:
+            self.assertTrue(actual in expected)
 
         fig = hierarchy.plot_2d_patches(
             ilvl,


### PR DESCRIPTION
This PR suggests a refac of the computation of overlaps in python hierarchies.
The strategy is less efficient but simpler to understand and maintain. We test the overlap of each patchdata with all others in all their possible periodic shift versions.
probably needed for 3D