### PR TITLE
set hdf5 flush to prevent crash 

### DIFF
--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -161,7 +161,7 @@ class DiagnosticsTest(unittest.TestCase):
                     ElectromagDiagnostics(
                         quantity=quantity,
                         write_timestamps=timestamps,
-                        flush_every=ElectromagDiagnostics.h5_flush_never,
+                        flush_every=10000,  # issues seen at t=46.42300 in mpirun -n 2
                     )
 
                 Simulator(simulation).run()


### PR DESCRIPTION
closes #1007

flush_never seems ok in serial, but I guess in parallel it probably has some upper limit likely associated with the amount of shared memory available
