### PR TITLE
prevent mpi crash from hdf5 open file

### DIFF
--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -117,7 +117,7 @@ class DiagnosticsTest(unittest.TestCase):
             ElectromagDiagnostics(
                 quantity=quantity,
                 write_timestamps=timestamps,
-                flush_every=ElectromagDiagnostics.h5_flush_never,
+                flush_every=10000,  # issues seen at t=46.42300 in mpirun -n 2
             )
 
         Simulator(simulation).run()


### PR DESCRIPTION
diagnostics timestamp test can be seen passing with this here https://hephaistos.lpp.polytechnique.fr/teamcity/buildConfiguration/Phare_Phare_Users_Phil_Build/86538

I expect this nightly build to fail under mpi shortly
https://hephaistos.lpp.polytechnique.fr/teamcity/buildConfiguration/Phare_Phare_GhMasterGccSamraisubNightly/86539