### PR TITLE
pybind visbility werrors

### DIFF
--- a/src/python3/data_wrangler.hpp
+++ b/src/python3/data_wrangler.hpp
@@ -58,7 +58,7 @@ private:
 
 
 template<std::size_t _dimension, std::size_t _interp_order, std::size_t _nbRefinedPart>
-class DataWrangler
+class __attribute__((visibility("hidden"))) DataWrangler
 {
 public:
     static constexpr std::size_t dimension     = _dimension;
@@ -88,7 +88,7 @@ public:
     auto sort_merge_1d(std::vector<PatchData<std::vector<double>, dimension>> const&& input,
                        bool shared_patch_border = false)
     {
-        std::vector<std::pair<double, const PatchData<std::vector<double>, dimension>*>> sorted;
+        std::vector<std::pair<double, PatchData<std::vector<double>, dimension> const*>> sorted;
         for (auto const& data : input)
             sorted.emplace_back(core::Point<double, 1>::fromString(data.origin)[0], &data);
         std::sort(sorted.begin(), sorted.end(), [](auto& a, auto& b) { return a.first < b.first; });

--- a/src/python3/particles.hpp
+++ b/src/python3/particles.hpp
@@ -1,15 +1,15 @@
 #ifndef PHARE_PYTHON_PARTICLES_HPP
 #define PHARE_PYTHON_PARTICLES_HPP
 
-#include <cassert>
-#include <cstddef>
-#include <tuple>
+
 #include "amr/data/particles/refine/particles_data_split.hpp"
-#include "core/data/particles/particle_packer.hpp"
-#include "core/data/particles/particle.hpp"
-#include "core/utilities/types.hpp"
 
 #include "python3/pybind_def.hpp"
+
+#include <tuple>
+#include <cassert>
+#include <cstddef>
+
 
 namespace PHARE::pydata
 {

--- a/src/python3/patch_data.hpp
+++ b/src/python3/patch_data.hpp
@@ -1,17 +1,17 @@
 #ifndef PHARE_PYTHON_PATCH_DATA_HPP
 #define PHARE_PYTHON_PATCH_DATA_HPP
 
-#include <array>
+#include "pybind_def.hpp"
+
 #include <string>
 #include <cstring>
 #include <utility>
 
-#include "pybind_def.hpp"
 
 namespace PHARE::pydata
 {
 template<typename Data, std::size_t dim>
-struct PatchData
+struct __attribute__((visibility("hidden"))) PatchData
 {
     static auto constexpr dimension = dim;
     std::string patchID;

--- a/src/python3/patch_level.hpp
+++ b/src/python3/patch_level.hpp
@@ -12,7 +12,7 @@
 namespace PHARE::pydata
 {
 template<std::size_t dim, std::size_t interpOrder, std::size_t nbrRefPart>
-class PatchLevel
+class __attribute__((visibility("hidden"))) PatchLevel
 {
 public:
     static constexpr std::size_t dimension     = dim;
@@ -59,8 +59,8 @@ public:
                 if (!pop_data.count(pop.name()))
                     pop_data.emplace(pop.name(), Inner());
 
-                setPatchDataFromField(pop_data.at(pop.name()).emplace_back(), pop.chargeDensity(), grid,
-                                      patchID);
+                setPatchDataFromField(pop_data.at(pop.name()).emplace_back(), pop.chargeDensity(),
+                                      grid, patchID);
             }
         };
 

--- a/src/python3/pybind_def.hpp
+++ b/src/python3/pybind_def.hpp
@@ -36,7 +36,7 @@ std::size_t ndSize(PyArrayInfo const& ar_info)
 
 
 template<typename T>
-class PyArrayWrapper : public core::Span<T>
+class __attribute__((visibility("hidden"))) PyArrayWrapper : public core::Span<T>
 {
 public:
     PyArrayWrapper(PHARE::pydata::py_array_t<T> const& array)


### PR DESCRIPTION
Seeing a werror with a newer compiler for not respecting the visibility settings of pybind classes