### PR TITLE
default tile clustering

### DIFF
--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -906,7 +906,7 @@ class Simulation(object):
 
         * **max_nbr_levels** (``int``), default=1, max number of levels in the hierarchy. Used if no `refinement_boxes` are set
         * **tag_buffer** (``int``), default=1, value representing the number of cells by which tagged cells are buffered before clustering into boxes. The larger `tag_buffer`, the wider refined regions will be around tagged cells.
-        * **clustering** (``str``), {"berger" (default), "tile"}, type of clustering to use for AMR. `tile` results in wider patches, less artifacts and better scalability
+        * **clustering** (``str``), {"berger", "tile" (default)}, type of clustering to use for AMR. `tile` results in wider patches, less artifacts and better scalability
 
         **Expert parameters:**
 

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -613,7 +613,7 @@ def check_hyper_resistivity(**kwargs):
 
 def check_clustering(**kwargs):
     valid_keys = ["berger", "tile"]
-    clustering = kwargs.get("clustering", "berger")
+    clustering = kwargs.get("clustering", "tile")
     if clustering not in valid_keys:
         raise ValueError(
             f"Error: clustering type is not supported, supported types are {valid_keys}"


### PR DESCRIPTION
Berger Rigoutsos box clustering has been seen to generate very inhomogeneous sets of patch sizes and sometimes leading to artifacts. Replacing by tile clustering as a default is a safer option and also more scalable