### PR TITLE
macos 13 runner is deprecated

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13, macos-14, macos-latest]
+        os: [ macos-14, macos-latest]
 
     steps:
     - name: Build Info


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/13046

even if we remove macos, we can continue to have it working until then
macos latest is macos 15 
https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md