### PR TITLE
make sure the ref patch used in finest_part_data is not empty

### DIFF
--- a/pyphare/pyphare/pharesee/hierarchy/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy/hierarchy.py
@@ -629,7 +629,7 @@ def finest_part_data(hierarchy, time=None):
     for i_ref, p in enumerate(hierarchy.level(0, time=time).patches):
         if len(p.patch_datas):
             break
-    if i_ref == None:
+    if i_ref is None:
         raise ValueError("This particle hierarchy seems empty !")
 
     # we are going to return a dict {popname : Particles}


### PR DESCRIPTION
When using `finest_part_data` of a particle hierarchy (for example in a `dist_plot` with `finest=True`) we need to iterate through the patches, hence know their names. Then, these names was taken from the first `patch_data`, of index 0. But this one could eventually be empty, hence not able to provide these names.

In this version, we hence iterate on all the patches of level 0, and then get the index of the first one that is not empty. This index is then used to get the keys of the patch_data dict, as it is then the first one to know them.

With this fix, we should then be able to make the `dist_plot` of a set of particles containing empty patch(es).