### PR TITLE
GetDomainSize in pharsee.run.py was failing if no B field diag

### DIFF
--- a/pyphare/pyphare/pharesee/run/run.py
+++ b/pyphare/pyphare/pharesee/run/run.py
@@ -218,12 +218,9 @@ class Run:
         return list_of_mass[0]
 
     def GetDomainSize(self, **kwargs):
-        h5_filename = "EM_B.h5"  # _____ TODO : could be another file
-
         import h5py
 
-        data_file = h5py.File(os.path.join(self.path, h5_filename), "r")
-
+        data_file = h5py.File(self.available_diags[0], "r")  # That is the first file in th available diags
         root_cell_width = np.asarray(data_file.attrs["cell_width"])
 
         return (data_file.attrs["domain_box"] + 1) * root_cell_width


### PR DESCRIPTION
In the previous version, `GetDomainSize` was using by default the file `EM_B.h`  to get needed attributes. Hence it was failing if this file was missing. Now it looks all the available diags... and take the first one.