### PR TITLE
modify the Getter of run.py to manage merged=True

### DIFF
--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -44,6 +44,10 @@ yee_centering = {
         "Pyz": "primal",
         "Pzz": "primal",
         "tags": "dual",
+        "value": "primal",
+        "x": "primal",
+        "y": "primal",
+        "z": "primal",
     },
     "y": {
         "Bx": "dual",
@@ -79,6 +83,10 @@ yee_centering = {
         "Pyz": "primal",
         "Pzz": "primal",
         "tags": "dual",
+        "value": "primal",
+        "x": "primal",
+        "y": "primal",
+        "z": "primal",
     },
     "z": {
         "Bx": "dual",
@@ -114,6 +122,10 @@ yee_centering = {
         "Pyz": "primal",
         "Pzz": "primal",
         "tags": "dual",
+        "value": "primal",
+        "x": "primal",
+        "y": "primal",
+        "z": "primal",
     },
 }
 yee_centering_lower = {

--- a/pyphare/pyphare/core/operators.py
+++ b/pyphare/pyphare/core/operators.py
@@ -20,12 +20,12 @@ def _compute_dot_product(patch_datas, **kwargs):
 
 
 def _compute_sqrt(patch_datas, **kwargs):
-    ref_name = next(iter(patch_datas.keys()))
+    # ref_name = next(iter(patch_datas.keys())) TODO this is always "value"
 
     dset = np.sqrt(patch_datas["value"][:])
 
     return (
-        {"name": "value", "data": dset, "centering": patch_datas[ref_name].centerings},
+        {"name": "value", "data": dset, "centering": patch_datas["value"].centerings},
     )
 
 

--- a/pyphare/pyphare/core/operators.py
+++ b/pyphare/pyphare/core/operators.py
@@ -20,8 +20,6 @@ def _compute_dot_product(patch_datas, **kwargs):
 
 
 def _compute_sqrt(patch_datas, **kwargs):
-    # ref_name = next(iter(patch_datas.keys())) TODO this is always "value"
-
     dset = np.sqrt(patch_datas["value"][:])
 
     return (

--- a/pyphare/pyphare/pharesee/hierarchy/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy/hierarchy.py
@@ -438,8 +438,9 @@ class PatchHierarchy(object):
                 label = "L{level}P{patch}".format(level=lvl_nbr, patch=ip)
                 marker = kwargs.get("marker", "")
                 ls = kwargs.get("ls", "--")
+                lw = kwargs.get("lw", 1)
                 color = kwargs.get("color", "k")
-                ax.plot(x, val, label=label, marker=marker, ls=ls, color=color)
+                ax.plot(x, val, label=label, marker=marker, ls=ls, lw=lw, color=color)
 
         ax.set_title(kwargs.get("title", ""))
         ax.set_xlabel(kwargs.get("xlabel", "x"))

--- a/pyphare/pyphare/pharesee/run/run.py
+++ b/pyphare/pyphare/pharesee/run/run.py
@@ -7,6 +7,7 @@ from pyphare.pharesee.hierarchy import ScalarField, VectorField
 
 from pyphare.pharesee.hierarchy.hierarchy_utils import compute_hier_from
 from pyphare.pharesee.hierarchy.hierarchy_utils import flat_finest_field
+from pyphare.pharesee.hierarchy.hierarchy_utils import rename
 from pyphare.core.phare_utilities import listify
 
 from pyphare.logger import getLogger
@@ -93,6 +94,7 @@ class Run:
         if merged:
             all_primal = False
         hier = self._get_hierarchy(time, "EM_B.h5", **kwargs)
+
         if not all_primal:
             return self._get(hier, time, merged, interp)
 
@@ -103,30 +105,69 @@ class Run:
         if merged:
             all_primal = False
         hier = self._get_hierarchy(time, "EM_E.h5", **kwargs)
+
         if not all_primal:
             return self._get(hier, time, merged, interp)
 
         h = compute_hier_from(_compute_to_primal, hier, x="Ex", y="Ey", z="Ez")
         return VectorField(h)
 
-    def GetMassDensity(self, time, merged=False, interp="nearest", **kwargs):
+    def GetMassDensity(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
+        if merged:
+            all_primal = False
         hier = self._get_hierarchy(time, "ions_mass_density.h5", **kwargs)
-        return ScalarField(self._get(hier, time, merged, interp))
 
-    def GetNi(self, time, merged=False, interp="nearest", **kwargs):
+        if not all_primal:
+            return self._get(hier, time, merged, interp)
+
+        h = compute_hier_from(_compute_to_primal, hier, value="rho")
+        return ScalarField(h)
+
+    def GetNi(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
+        if merged:
+            all_primal = False
         hier = self._get_hierarchy(time, "ions_charge_density.h5", **kwargs)
-        return ScalarField(self._get(hier, time, merged, interp))
 
-    def GetN(self, time, pop_name, merged=False, interp="nearest", **kwargs):
+        if not all_primal:
+            return self._get(hier, time, merged, interp)
+
+        h = compute_hier_from(_compute_to_primal, hier, value="rho")
+        return ScalarField(h)
+
+    def GetN(self, time, pop_name, merged=False, interp="nearest", all_primal=True, **kwargs):
+        if merged:
+            all_primal = False
         hier = self._get_hierarchy(time, f"ions_pop_{pop_name}_density.h5", **kwargs)
-        return ScalarField(self._get(hier, time, merged, interp))
 
-    def GetVi(self, time, merged=False, interp="nearest", **kwargs):
+        hier_ = rename(hier, ['rho',])
+        if not all_primal:
+            return self._get(hier_, time, merged, interp)
+
+        h = compute_hier_from(_compute_to_primal, hier_, value="rho")
+        return ScalarField(h)
+
+    def GetVi(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
+        if merged:
+            all_primal = False
         hier = self._get_hierarchy(time, "ions_bulkVelocity.h5", **kwargs)
+
+        if not all_primal:
+            return self._get(hier, time, merged, interp)
+
+        h = compute_hier_from(_compute_to_primal, hier, x="Vx", y="Vy", z="Vz")
         return VectorField(self._get(hier, time, merged, interp))
 
-    def GetFlux(self, time, pop_name, merged=False, interp="nearest", **kwargs):
+    def GetFlux(self, time, pop_name, merged=False, interp="nearest", all_primal=True, **kwargs):
+        if merged:
+            all_primal = False
         hier = self._get_hierarchy(time, f"ions_pop_{pop_name}_flux.h5", **kwargs)
+
+        hier_ = rename(hier, ['Fx', 'Fy', 'Fz'])
+        # print(hier.quantities())
+        if not all_primal:
+            return self._get(hier_, time, merged, interp)
+
+        h = compute_hier_from(_compute_to_primal, hier_, x="Fx", y="Fy", z="Fz")
         return VectorField(self._get(hier, time, merged, interp))
 
     def GetPressure(self, time, pop_name, merged=False, interp="nearest", **kwargs):

--- a/pyphare/pyphare/pharesee/run/run.py
+++ b/pyphare/pyphare/pharesee/run/run.py
@@ -155,7 +155,7 @@ class Run:
             return self._get(hier, time, merged, interp)
 
         h = compute_hier_from(_compute_to_primal, hier, x="Vx", y="Vy", z="Vz")
-        return VectorField(self._get(hier, time, merged, interp))
+        return VectorField(h)
 
     def GetFlux(self, time, pop_name, merged=False, interp="nearest", all_primal=True, **kwargs):
         if merged:
@@ -168,7 +168,7 @@ class Run:
             return self._get(hier_, time, merged, interp)
 
         h = compute_hier_from(_compute_to_primal, hier_, x="Fx", y="Fy", z="Fz")
-        return VectorField(self._get(hier, time, merged, interp))
+        return VectorField(h)
 
     def GetPressure(self, time, pop_name, merged=False, interp="nearest", **kwargs):
         M = self._get_hierarchy(

--- a/pyphare/pyphare/pharesee/run/run.py
+++ b/pyphare/pyphare/pharesee/run/run.py
@@ -174,11 +174,11 @@ class Run:
         M = self._get_hierarchy(
             time, f"ions_pop_{pop_name}_momentum_tensor.h5", **kwargs
         )
-        V = self.GetFlux(time, pop_name, **kwargs)
+        F = self.GetFlux(time, pop_name, **kwargs)
         N = self.GetN(time, pop_name, **kwargs)
         P = compute_hier_from(
             _compute_pop_pressure,
-            (M, V, N),
+            (M, F, N),
             popname=pop_name,
             mass=self.GetMass(pop_name, **kwargs),
         )

--- a/pyphare/pyphare/pharesee/run/utils.py
+++ b/pyphare/pyphare/pharesee/run/utils.py
@@ -309,6 +309,7 @@ def _compute_to_primal(patchdatas, patch_id, **kwargs):
 
     pd_attrs = []
     for name, pd_name in kwargs.items():
+        # print(name, pd_name)
         pd = patchdatas[pd_name]
 
         ds = pd.dataset
@@ -328,6 +329,9 @@ def _compute_to_primal(patchdatas, patch_id, **kwargs):
         # chunks is a tupls of all the slices coming from the initial dataset
         # that are needed to calculate the average for the all_primal dataset
         inner, chunks = slices_to_primal(pd_name, nb_ghosts=nb_ghosts, ndim=ndim)
+        # TODO if the pd_name contains the name of a population (like the one coming from GetN)
+        # then, this name has to be removed from "pd_name" as in the "yee_centering" dict
+        # coming from gridlayout, the pop_name is not here...
 
         for chunk in chunks:
             ds_[inner] = np.add(ds_[inner], ds[chunk] / len(chunks))
@@ -488,3 +492,5 @@ def make_interpolator(data, coords, interp, domain, dl, qty, nbrGhosts):
         raise ValueError("make_interpolator is not yet 3d")
 
     return interpolator, finest_coords
+
+

--- a/pyphare/pyphare/pharesee/run/utils.py
+++ b/pyphare/pyphare/pharesee/run/utils.py
@@ -383,9 +383,9 @@ def _compute_pressure(patch_datas, **kwargs):
     Myz = patch_datas["Myz"].dataset[:]
     Mzz = patch_datas["Mzz"].dataset[:]
     massDensity = patch_datas["value"].dataset[:]
-    Vix = patch_datas["Vx"].dataset[:]
-    Viy = patch_datas["Vy"].dataset[:]
-    Viz = patch_datas["Vz"].dataset[:]
+    Vix = patch_datas["x"].dataset[:]
+    Viy = patch_datas["y"].dataset[:]
+    Viz = patch_datas["z"].dataset[:]
 
     Pxx = Mxx - Vix * Vix * massDensity
     Pxy = Mxy - Vix * Viy * massDensity


### PR DESCRIPTION
The getter that we have in `run.py` (`GetB`,  `GetN`, ...) can handle the kwarg `merged` :
* if it is `True`, then we get an interpolator
* if it `False`, we get a hierarchy. But if `all_primal` is `True`, this hierarchy is the now a `ScalarField` or a `VectorField`