### PR TITLE
less costly  box iteration

### DIFF
--- a/res/cmake/bench.cmake
+++ b/res/cmake/bench.cmake
@@ -49,6 +49,7 @@ if (bench)
   add_subdirectory(tools/bench/core/data/particles)
   add_subdirectory(tools/bench/core/numerics/pusher)
 
+  add_subdirectory(tools/bench/amr/data/field/refinement)
   add_subdirectory(tools/bench/amr/data/particles)
   add_subdirectory(tools/bench/core/numerics/ion_updater)
   add_subdirectory(tools/bench/core/numerics/interpolator)

--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -9,6 +9,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
   add_subdirectory(tests/core/data/minimizing_vector)
   add_subdirectory(tests/core/data/ndarray)
+  add_subdirectory(tests/core/data/field)
   add_subdirectory(tests/core/data/grid)
   add_subdirectory(tests/core/data/gridlayout)
   add_subdirectory(tests/core/data/vecfield)

--- a/src/amr/data/field/refine/electric_field_refiner.hpp
+++ b/src/amr/data/field/refine/electric_field_refiner.hpp
@@ -37,22 +37,23 @@ public:
 
     // electric field refinement strategy follows
     // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-    template<typename FieldT>
-    void operator()(FieldT const& coarseField, FieldT& fineField,
-                    core::Point<int, dimension> fineIndex)
+    void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                    auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                    auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
 
-        auto const locFineIdx   = AMRToLocal(fineIndex, fineBox_);
-        auto const coarseIdx    = toCoarseIndex(fineIndex);
-        auto const locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
+        if (not std::isnan(fineVal))
+            return; // KEEP!
 
         if constexpr (dimension == 1)
-            refine1D_(coarseField, fineField, locFineIdx, locCoarseIdx);
+            fineVal = coarseVal;
         else if constexpr (dimension == 2)
-            refine2D_(coarseField, fineField, fineIndex, locFineIdx, locCoarseIdx);
+            refine2D_(coarseField, fineField, fineIndex, coarseIndex, locFineIdx, locCoarseIdx,
+                      fineVal, coarseVal);
         else if constexpr (dimension == 3)
-            refine3D_(coarseField, fineField, fineIndex, locFineIdx, locCoarseIdx);
+            refine3D_(coarseField, fineField, fineIndex, coarseIndex, locFineIdx, locCoarseIdx,
+                      fineVal, coarseVal);
     }
 
 private:
@@ -73,44 +74,13 @@ private:
     }
 
 
-    template<typename FieldT>
-    void refine1D_(FieldT const& coarseField, FieldT& fineField,
-                   core::Point<int, dimension> const& locFineIdx,
-                   core::Point<int, dimension> const& locCoarseIdx)
-    {
-        // if dual, then Ex
-        // if even fine index, we're on top of coarse, we take 100% coarse overlapped fieldValue
-        // e.g. fineIndex==100, we take coarse[100/2]
-        // e.g. fineIndex==101  we take coarse[101/2] = coarse[50] as well
-        //
-        //          49           50             51
-        //    o     x     o      x       o      x      o        Ex on coarse
-        //    o  x  o  x  o   x  o   x   o   x  o   x  o        Ex on fine
-        //       98    99   100     101     102    103
-        //
-        //
-        // if primal, then Ey,Ez we just copy the coarse value
-        // since they are on top of the fine one.
-        //
-        // therefore in all cases in 1D we just copy the coarse value
-        //
-        if (std::isnan(fineField(locFineIdx[dirX])))
-            fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
-    }
-
-    template<typename FieldT>
-    void refine2D_(FieldT const& coarseField, FieldT& fineField,
-                   core::Point<int, dimension> const& fineIndex,
-                   core::Point<int, dimension> const& locFineIdx,
-                   core::Point<int, dimension> const& locCoarseIdx)
+    void refine2D_(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                   auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                   auto& fineVal, auto const& coarseVal)
     {
         // ilc: index local coarse
-        // ilf: index local fine
         auto const ilcx = locCoarseIdx[dirX];
         auto const ilcy = locCoarseIdx[dirY];
-        auto const ilfx = locFineIdx[dirX];
-        auto const ilfy = locFineIdx[dirY];
-
 
         // this is Ex
         if (centerings_[dirX] == core::QtyCentering::dual
@@ -120,16 +90,14 @@ private:
             {
                 // we're on a fine edge shared with coarse mesh
                 // take the coarse face value
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+                fineVal = coarseVal;
             }
             else
             {
                 // we're on a fine edge in between two coarse edges
                 // we take the average
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy)
-                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx, ilcy + 1));
+
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx, ilcy + 1));
             }
         }
         // Ey
@@ -143,16 +111,15 @@ private:
                 // both fine Ey e.g. at j=100 and 101 will take j=50 on coarse
                 // so no need to look at whether jfine is even or odd
                 // just take the value at the local coarse index
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+
+                fineVal = coarseVal;
             }
             else
             {
                 // we're on a fine edge in between two coarse ones
                 // we take the average
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy)
-                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy));
+
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx + 1, ilcy));
             }
         }
         // and this is now Ez
@@ -161,47 +128,34 @@ private:
         {
             if (onCoarseXFace_(fineIndex) and onCoarseYFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy) = coarseField(ilcx, ilcy);
+                fineVal = coarseVal;
             }
             else if (onCoarseXFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy)
-                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx, ilcy + 1));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx, ilcy + 1));
             }
             else if (onCoarseYFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy)
-                        = 0.5 * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx + 1, ilcy));
             }
             else
             {
-                if (std::isnan(fineField(ilfx, ilfy)))
-                    fineField(ilfx, ilfy)
-                        = 0.25
-                          * (coarseField(ilcx, ilcy) + coarseField(ilcx + 1, ilcy)
-                             + coarseField(ilcx, ilcy + 1) + coarseField(ilcx + 1, ilcy + 1));
+                fineVal = 0.25
+                          * (coarseVal + coarseField(ilcx + 1, ilcy) + coarseField(ilcx, ilcy + 1)
+                             + coarseField(ilcx + 1, ilcy + 1));
             }
         }
     }
 
 
-    template<typename FieldT>
-    void refine3D_(FieldT const& coarseField, FieldT& fineField,
-                   core::Point<int, dimension> const& fineIndex,
-                   core::Point<int, dimension> const& locFineIdx,
-                   core::Point<int, dimension> const& locCoarseIdx)
+    void refine3D_(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                   auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                   auto& fineVal, auto const& coarseVal)
     {
         // ilc: index local coarse
-        // ilf: index local fine
         auto const ilcx = locCoarseIdx[dirX];
         auto const ilcy = locCoarseIdx[dirY];
         auto const ilcz = locCoarseIdx[dirZ];
-        auto const ilfx = locFineIdx[dirX];
-        auto const ilfy = locFineIdx[dirY];
-        auto const ilfz = locFineIdx[dirZ];
 
         // Ex
         if (centerings_[dirX] == core::QtyCentering::dual
@@ -212,34 +166,28 @@ private:
             // just copy the coarse value
             if (onCoarseYFace_(fineIndex) and onCoarseZFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+                fineVal = coarseVal;
             }
             // we share the Y face but not the Z face
             // we must be one of the 2 X fine edges on a Y face
             // thus we take the average of the two surrounding edges at Z and Z+DZ
             else if (onCoarseYFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy, ilcz + 1));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx, ilcy, ilcz + 1));
             }
             // we share a Z face but not the Y face
             // we must be one of the 2 X fine edges on a Z face
             // we thus take the average of the two X edges at y and y+dy
             else if (onCoarseZFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx, ilcy + 1, ilcz));
             }
             else
             {
                 // we don't share any face thus we're on one of the 2 middle X edges
                 // we take the average of the 4 surrounding X averages
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.25 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz))
+
+                fineVal = 0.25 * (coarseVal + coarseField(ilcx, ilcy + 1, ilcz))
                           + 0.25
                                 * (coarseField(ilcx, ilcy, ilcz + 1)
                                    + coarseField(ilcx, ilcy + 1, ilcz + 1));
@@ -254,8 +202,8 @@ private:
             if (onCoarseXFace_(fineIndex) and onCoarseZFace_(fineIndex))
             {
                 // we thus just copy the coarse value
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+
+                fineVal = coarseVal;
             }
             // now we only have same X face, but not (else) the Z face
             // so we're a new fine Y edge in between two coarse Y edges
@@ -267,28 +215,23 @@ private:
                 // this means we are on a Y edge that lies in between 2 coarse edges
                 // at z and z+dz
                 // take the average of these 2 coarse value
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy, ilcz + 1));
+
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx, ilcy, ilcz + 1));
             }
             // we're on a Z coarse face, but not on a X coarse face
             // we thus must be one of the 2 Y edges on a Z face
             // and thus we take the average of the 2 Y edges at X and X+dX
             else if (onCoarseZFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx + 1, ilcy, ilcz));
             }
             // now we're not on any of the coarse faces
             // so we must be one of the two Y edge in the middle of the cell
             // we thus average over the 4 Y edges of the coarse cell
             else
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.25
-                          * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz)
+                fineVal = 0.25
+                          * (coarseVal + coarseField(ilcx + 1, ilcy, ilcz)
                              + coarseField(ilcx, ilcy, ilcz + 1)
                              + coarseField(ilcx + 1, ilcy, ilcz + 1));
             }
@@ -302,36 +245,29 @@ private:
             // we thus copy the coarse value
             if (onCoarseXFace_(fineIndex) and onCoarseYFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz) = coarseField(ilcx, ilcy, ilcz);
+                fineVal = coarseVal;
             }
             // here we're on a coarse X face, but not a Y face
             // we must be 1 of the 2 Z edges on a X face
             // thus we average the 2 surrounding Z coarse edges at Y and Y+dY
             else if (onCoarseXFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx, ilcy + 1, ilcz));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx, ilcy + 1, ilcz));
             }
             // here we're on a coarse Y face, but not a X face
             // we must be 1 of the 2 Z edges on a Y face
             // thus we average the 2 surrounding Z coarse edges at X and X+dX
             else if (onCoarseYFace_(fineIndex))
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.5 * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz));
+                fineVal = 0.5 * (coarseVal + coarseField(ilcx + 1, ilcy, ilcz));
             }
             // we're not on any coarse face thus must be one of the 2 Z edges
             // in the middle of the coarse cell
             // we therefore take the average of the 4 surrounding Z edges
             else
             {
-                if (std::isnan(fineField(ilfx, ilfy, ilfz)))
-                    fineField(ilfx, ilfy, ilfz)
-                        = 0.25
-                          * (coarseField(ilcx, ilcy, ilcz) + coarseField(ilcx + 1, ilcy, ilcz)
+                fineVal = 0.25
+                          * (coarseVal + coarseField(ilcx + 1, ilcy, ilcz)
                              + coarseField(ilcx, ilcy + 1, ilcz)
                              + coarseField(ilcx + 1, ilcy + 1, ilcz));
             }

--- a/src/amr/data/field/refine/electric_field_refiner.hpp
+++ b/src/amr/data/field/refine/electric_field_refiner.hpp
@@ -37,14 +37,19 @@ public:
 
     // electric field refinement strategy follows
     // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    //
+    // operator() parameters follow the FieldRefinerPolicy contract documented on
+    // DefaultFieldRefiner::operator() in field_refiner.hpp
     void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
                     auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
                     auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
 
+        // KEEP: don't overwrite a fine cell a previous pass (or a boundary
+        // condition) already filled in; NaN means "not yet set"
         if (not std::isnan(fineVal))
-            return; // KEEP!
+            return;
 
         if constexpr (dimension == 1)
             fineVal = coarseVal;

--- a/src/amr/data/field/refine/field_refine_operator.hpp
+++ b/src/amr/data/field/refine/field_refine_operator.hpp
@@ -5,6 +5,7 @@
 #include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 #include "core/utilities/box/box_span.hpp"
 
+#include "amr/amr_constants.hpp"
 #include "amr/data/field/field_data.hpp"
 #include "amr/resources_manager/amr_utils.hpp"
 #include "amr/data/tensorfield/tensor_field_data.hpp"
@@ -85,7 +86,7 @@ void refine_field(core::FieldBox<Field_t>& dst, core::FieldBox<Field_t const>& s
                 refiner(src.field, dst.field, d_amr_point, s_amr_point, d_lcl_point, s_lcl_point,
                         d_span[dst_idx], s_span[src_idx]);
 
-                if (d_amr_point[IDX] % 2 != 0)
+                if (d_amr_point[IDX] % refinementRatio != 0)
                 {
                     ++src_idx;
                     ++s_lcl_point[IDX];
@@ -96,14 +97,14 @@ void refine_field(core::FieldBox<Field_t>& dst, core::FieldBox<Field_t const>& s
                 ++d_lcl_point[IDX];
             }
 
-            if (span_idx % 2 != 0)
+            if (span_idx % refinementRatio != 0)
             {
                 ++s_f_spans;
                 ++s_b_spans;
             }
         }
 
-        if (slab_idx % 2 != 0)
+        if (slab_idx % refinementRatio != 0)
         {
             ++s_f_slabs;
             ++s_b_slabs;

--- a/src/amr/data/field/refine/field_refine_operator.hpp
+++ b/src/amr/data/field/refine/field_refine_operator.hpp
@@ -1,18 +1,14 @@
 #ifndef PHARE_FIELD_REFINE_OPERATOR_HPP
 #define PHARE_FIELD_REFINE_OPERATOR_HPP
 
-
-
-#include "core/def/phare_mpi.hpp" // IWYU pragma: keep
-
 #include "core/def.hpp"
+#include "core/def/phare_mpi.hpp" // IWYU pragma: keep
+#include "core/utilities/box/box_span.hpp"
 
 #include "amr/data/field/field_data.hpp"
+#include "amr/resources_manager/amr_utils.hpp"
 #include "amr/data/tensorfield/tensor_field_data.hpp"
 #include "amr/resources_manager/tensor_field_resource.hpp"
-
-#include "field_linear_refine.hpp"
-#include "field_refiner.hpp"
 
 #include <SAMRAI/tbox/Dimension.h>
 #include <SAMRAI/hier/RefineOperator.h>
@@ -28,13 +24,91 @@ using core::dirX;
 using core::dirY;
 using core::dirZ;
 
-
-
-template<typename Dst>
-void refine_field(Dst& destinationField, auto& sourceField, auto& intersectionBox, auto& refiner)
+template<typename Field_t>
+struct CrossLevelIndices
 {
-    for (auto const bix : phare_box_from<Dst::dimension>(intersectionBox))
-        refiner(sourceField, destinationField, bix);
+    auto constexpr static dim = Field_t::dimension;
+    using FieldRow_t          = core::FieldBoxPointSpans<Field_t>;
+    using FieldRow_ct         = core::FieldBoxPointSpans<Field_t const>;
+
+    core::FieldBox<Field_t>& dst;
+    core::FieldBox<Field_t const> const& src;
+
+    core::FieldBoxSpan<Field_t, FieldRow_t> dst_lcl_span
+        = core::make_field_box_point_span(dst.lcl_box, dst.field);
+    core::FieldBoxSpan<Field_t const, FieldRow_ct> src_lcl_span
+        = core::make_field_box_point_span(src.lcl_box, src.field);
+
+    core::BoxSpan<int, dim> dst_amr_span = core::make_box_span(dst.amr_box);
+    core::BoxSpan<int, dim> src_amr_span = core::make_box_span(src.amr_box);
+};
+
+
+
+
+template<typename Field_t>
+void refine_field(core::FieldBox<Field_t>& dst, core::FieldBox<Field_t const>& src, auto& refiner)
+{
+    auto constexpr static IDX = Field_t::dimension - 1;
+
+    CrossLevelIndices<Field_t> indices{dst, src};
+
+    auto d_f_slabs = indices.dst_lcl_span.begin();
+    auto d_b_slabs = indices.dst_amr_span.begin();
+    auto s_f_slabs = indices.src_lcl_span.begin();
+    auto s_b_slabs = indices.src_amr_span.begin();
+
+    auto slab_idx = indices.dst_amr_span.slab_begin();
+
+    for (; d_f_slabs != indices.dst_lcl_span.end(); ++d_f_slabs, ++d_b_slabs, ++slab_idx)
+    {
+        auto d_f_spans = d_f_slabs.begin();
+        auto s_f_spans = s_f_slabs.begin();
+        auto d_b_spans = d_b_slabs.begin();
+        auto s_b_spans = s_b_slabs.begin();
+
+        auto span_idx = d_b_slabs.span_begin();
+        for (; d_f_spans != d_f_slabs.end(); ++d_f_spans, ++d_b_spans, ++span_idx)
+        {
+            auto&& [d_amr_point, d_size] = *d_b_spans;
+            auto&& [s_amr_point, s_size] = *s_b_spans;
+
+            auto&& [d_span, d_lcl_point] = *d_f_spans;
+            auto&& [s_span, s_lcl_point] = *s_f_spans;
+
+            std::size_t dst_idx = 0;
+            std::size_t src_idx = 0;
+            for (; dst_idx < d_span.size(); ++dst_idx)
+            {
+                assert(s_amr_point == toCoarseIndex(d_amr_point));
+
+                refiner(src.field, dst.field, d_amr_point, s_amr_point, d_lcl_point, s_lcl_point,
+                        d_span[dst_idx], s_span[src_idx]);
+
+                if (d_amr_point[IDX] % 2 != 0)
+                {
+                    ++src_idx;
+                    ++s_lcl_point[IDX];
+                    ++s_amr_point[IDX];
+                }
+
+                ++d_amr_point[IDX];
+                ++d_lcl_point[IDX];
+            }
+
+            if (span_idx % 2 != 0)
+            {
+                ++s_f_spans;
+                ++s_b_spans;
+            }
+        }
+
+        if (slab_idx % 2 != 0)
+        {
+            ++s_f_slabs;
+            ++s_b_slabs;
+        }
+    }
 }
 
 
@@ -113,8 +187,10 @@ public:
         {
             // we compute the intersection with the destination,
             // and then we apply the refine operation on each fine index.
-            auto intersectionBox = destFieldBox * box;
-            refine_field(destinationField, sourceField, intersectionBox, refiner);
+            auto const dst_overlap = phare_box_from<dimension>(destFieldBox * box);
+            core::FieldBox dst{destinationField, destLayout, dst_overlap};
+            core::FieldBox src{sourceField, srcLayout, coarsen_box(dst_overlap)};
+            refine_field(dst, src, refiner);
         }
     }
 };
@@ -180,6 +256,8 @@ public:
         auto const& sourceFields = TensorFieldDataT::getFields(source, sourceId);
         auto const& srcLayout    = TensorFieldDataT::getLayout(source, sourceId);
 
+        PHARE_LOG_SCOPE(2, "TensorFieldRefineOperator::refine::" + sourceFields[0].name());
+
         // We assume that quantity are all the same.
         // Note that an assertion will be raised in refineIt operator
         for (std::uint16_t c = 0; c < N; ++c)
@@ -201,8 +279,13 @@ public:
             {
                 // we compute the intersection with the destination,
                 // and then we apply the refine operation on each fine index.
-                auto const intersectionBox = destFieldBox * box;
-                refine_field(destinationFields[c], sourceFields[c], intersectionBox, refiner);
+                auto const dst_overlap = phare_box_from<dimension>(destFieldBox * box);
+                core::FieldBox dst{destinationFields[c], destLayout, dst_overlap};
+
+                auto const src_overlap
+                    = *(coarsen_box(dst_overlap) * srcLayout.AMRGhostBoxFor(sourceFields[c]));
+                core::FieldBox src{sourceFields[c], srcLayout, src_overlap};
+                refine_field(dst, src, refiner);
             }
         }
     }

--- a/src/amr/data/field/refine/field_refine_operator.hpp
+++ b/src/amr/data/field/refine/field_refine_operator.hpp
@@ -3,7 +3,7 @@
 
 #include "core/def.hpp"
 #include "core/def/phare_mpi.hpp" // IWYU pragma: keep
-#include "core/utilities/box/box_span.hpp"
+#include "core/data/field/field_box.hpp"
 
 #include "amr/amr_constants.hpp"
 #include "amr/data/field/field_data.hpp"
@@ -24,94 +24,6 @@ namespace PHARE::amr
 using core::dirX;
 using core::dirY;
 using core::dirZ;
-
-template<typename Field_t>
-struct CrossLevelIndices
-{
-    auto constexpr static dim = Field_t::dimension;
-    using FieldRow_t          = core::FieldBoxPointSpans<Field_t>;
-    using FieldRow_ct         = core::FieldBoxPointSpans<Field_t const>;
-
-    core::FieldBox<Field_t>& dst;
-    core::FieldBox<Field_t const> const& src;
-
-    core::FieldBoxSpan<Field_t, FieldRow_t> dst_lcl_span
-        = core::make_field_box_point_span(dst.lcl_box, dst.field);
-    core::FieldBoxSpan<Field_t const, FieldRow_ct> src_lcl_span
-        = core::make_field_box_point_span(src.lcl_box, src.field);
-
-    core::BoxSpan<int, dim> dst_amr_span = core::make_box_span(dst.amr_box);
-    core::BoxSpan<int, dim> src_amr_span = core::make_box_span(src.amr_box);
-};
-
-
-
-
-template<typename Field_t>
-void refine_field(core::FieldBox<Field_t>& dst, core::FieldBox<Field_t const>& src, auto& refiner)
-{
-    auto constexpr static IDX = Field_t::dimension - 1;
-
-    CrossLevelIndices<Field_t> indices{dst, src};
-
-    auto d_f_slabs = indices.dst_lcl_span.begin();
-    auto d_b_slabs = indices.dst_amr_span.begin();
-    auto s_f_slabs = indices.src_lcl_span.begin();
-    auto s_b_slabs = indices.src_amr_span.begin();
-
-    auto slab_idx = indices.dst_amr_span.slab_begin();
-
-    for (; d_f_slabs != indices.dst_lcl_span.end(); ++d_f_slabs, ++d_b_slabs, ++slab_idx)
-    {
-        auto d_f_spans = d_f_slabs.begin();
-        auto s_f_spans = s_f_slabs.begin();
-        auto d_b_spans = d_b_slabs.begin();
-        auto s_b_spans = s_b_slabs.begin();
-
-        auto span_idx = d_b_slabs.span_begin();
-        for (; d_f_spans != d_f_slabs.end(); ++d_f_spans, ++d_b_spans, ++span_idx)
-        {
-            auto&& [d_amr_point, d_size] = *d_b_spans;
-            auto&& [s_amr_point, s_size] = *s_b_spans;
-
-            auto&& [d_span, d_lcl_point] = *d_f_spans;
-            auto&& [s_span, s_lcl_point] = *s_f_spans;
-
-            std::size_t dst_idx = 0;
-            std::size_t src_idx = 0;
-            for (; dst_idx < d_span.size(); ++dst_idx)
-            {
-                assert(s_amr_point == toCoarseIndex(d_amr_point));
-
-                refiner(src.field, dst.field, d_amr_point, s_amr_point, d_lcl_point, s_lcl_point,
-                        d_span[dst_idx], s_span[src_idx]);
-
-                if (d_amr_point[IDX] % refinementRatio != 0)
-                {
-                    ++src_idx;
-                    ++s_lcl_point[IDX];
-                    ++s_amr_point[IDX];
-                }
-
-                ++d_amr_point[IDX];
-                ++d_lcl_point[IDX];
-            }
-
-            if (span_idx % refinementRatio != 0)
-            {
-                ++s_f_spans;
-                ++s_b_spans;
-            }
-        }
-
-        if (slab_idx % refinementRatio != 0)
-        {
-            ++s_f_slabs;
-            ++s_b_slabs;
-        }
-    }
-}
-
 
 template<typename GridLayoutT, typename FieldT, typename FieldRefinerPolicy>
 class FieldRefineOperator : public SAMRAI::hier::RefineOperator
@@ -188,10 +100,10 @@ public:
         {
             // we compute the intersection with the destination,
             // and then we apply the refine operation on each fine index.
-            auto const dst_overlap = phare_box_from<dimension>(destFieldBox * box);
-            core::FieldBox dst{destinationField, destLayout, dst_overlap};
-            core::FieldBox src{sourceField, srcLayout, coarsen_box(dst_overlap)};
-            refine_field(dst, src, refiner);
+            auto const fine_overlap = phare_box_from<dimension>(destFieldBox * box);
+            core::FieldBox fine{destinationField, destLayout, fine_overlap};
+            core::FieldBox coarse{sourceField, srcLayout, coarsen_box(fine_overlap)};
+            core::operator_across_adjacent_levels(coarse, fine, refinementRatio, refiner);
         }
     }
 };
@@ -280,13 +192,13 @@ public:
             {
                 // we compute the intersection with the destination,
                 // and then we apply the refine operation on each fine index.
-                auto const dst_overlap = phare_box_from<dimension>(destFieldBox * box);
-                core::FieldBox dst{destinationFields[c], destLayout, dst_overlap};
+                auto const fine_overlap = phare_box_from<dimension>(destFieldBox * box);
+                core::FieldBox fine{destinationFields[c], destLayout, fine_overlap};
 
-                auto const src_overlap
-                    = *(coarsen_box(dst_overlap) * srcLayout.AMRGhostBoxFor(sourceFields[c]));
-                core::FieldBox src{sourceFields[c], srcLayout, src_overlap};
-                refine_field(dst, src, refiner);
+                auto const coarse_overlap
+                    = *(coarsen_box(fine_overlap) * srcLayout.AMRGhostBoxFor(sourceFields[c]));
+                core::FieldBox coarse{sourceFields[c], srcLayout, coarse_overlap};
+                core::operator_across_adjacent_levels(coarse, fine, refinementRatio, refiner);
             }
         }
     }

--- a/src/amr/data/field/refine/field_refiner.hpp
+++ b/src/amr/data/field/refine/field_refiner.hpp
@@ -54,6 +54,26 @@ namespace amr
          * - the weights are pre-computed by the FieldRefineIndexesAndWeights object
          * - we just have to know which one to use, depending on where the fineIndex is in the
          * coarse cell
+         *
+         * This is the FieldRefinerPolicy contract shared by every refiner class in this
+         * directory (ElectricFieldRefiner, MagneticFieldRefiner, ...):
+         * core::operator_across_adjacent_levels() (in core/data/field/field_box.hpp)
+         * calls operator() once per fine cell it visits with:
+         *  - coarseField, fineField   : the whole coarse/fine arrays, for policies that
+         *                               need to read neighboring cells (e.g. averaging)
+         *  - fineIndex, coarseIndex   : that cell's AMR index on the fine grid, and its
+         *                               coarse counterpart (fineIndex divided by the
+         *                               refinement ratio)
+         *  - locFineIdx, locCoarseIdx : the same two indices, translated to each field's
+         *                               local (ghost-box-relative) storage index
+         *  - fineVal, coarseVal       : references to fineField(locFineIdx) and
+         *                               coarseField(locCoarseIdx) themselves, passed
+         *                               through so a policy can read/write the cell
+         *                               value directly instead of re-indexing the field
+         *
+         * A policy must not overwrite a fine cell that was already set (by a boundary
+         * condition or an earlier pass): guard with `if (not std::isnan(fineVal)) return;`
+         * before writing, since NaN is the sentinel for "not yet set".
          */
         void operator()(auto const& coarseField, auto& fineField, auto fineIndex,
                         auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,

--- a/src/amr/data/field/refine/magnetic_field_init_refiner.hpp
+++ b/src/amr/data/field/refine/magnetic_field_init_refiner.hpp
@@ -48,15 +48,12 @@ public:
     // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
     // these fine faces equals that on the overlaped coarse face.
     // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-    template<typename FieldT>
-    void operator()(FieldT const& coarseField, FieldT& fineField,
-                    core::Point<int, dimension> fineIndex)
+
+    void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                    auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                    auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
-
-        auto locFineIdx   = AMRToLocal(fineIndex, fineBox_);
-        auto coarseIdx    = toCoarseIndex(fineIndex);
-        auto locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
 
 
         if constexpr (dimension == 1)
@@ -76,10 +73,9 @@ public:
             if (centerings_[0] == core::QtyCentering::primal)
             {
                 if (fineIndex[0] % 2 == 0)
-                {
-                    fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
-                }
+                    fineVal = coarseVal;
             }
+
             // dual case, By, Bz
             //          49           50             51
             //    o     +     o      +       o      +       o      Byz on coarse : +
@@ -89,9 +85,7 @@ public:
             // 100 takes 50 = 100/2
             // 101 takes 50 = 101/2
             else
-            {
-                fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
-            }
+                fineVal = coarseVal;
         }
 
 
@@ -107,8 +101,7 @@ public:
                 {
                     // we're on a coarse X face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY])
-                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -119,8 +112,7 @@ public:
                 {
                     // we're on a coarse Y face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY])
-                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -129,18 +121,13 @@ public:
                 // Bz
                 // we're always on a coarse Z face since there is no dual in z
                 // all 4 fine Bz take the coarse Z value
-                fineField(locFineIdx[dirX], locFineIdx[dirY])
-                    = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                fineVal = coarseVal;
             }
         }
 
 
         else if constexpr (dimension == 3)
         {
-            auto ix = locCoarseIdx[dirX];
-            auto iy = locCoarseIdx[dirY];
-            auto iz = locCoarseIdx[dirZ];
-
             if (centerings_[dirX] == core::QtyCentering::primal
                 and centerings_[dirY] == core::QtyCentering::dual
                 and centerings_[dirZ] == core::QtyCentering::dual)
@@ -150,8 +137,7 @@ public:
                 {
                     // we're on a coarse X face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = coarseField(ix, iy, iz);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -163,8 +149,7 @@ public:
                 {
                     // we're on a coarse Y face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = coarseField(ix, iy, iz);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -176,8 +161,7 @@ public:
                 {
                     // we're on a coarse X face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = coarseField(ix, iy, iz);
+                    fineVal = coarseVal;
                 }
             }
         }

--- a/src/amr/data/field/refine/magnetic_field_init_refiner.hpp
+++ b/src/amr/data/field/refine/magnetic_field_init_refiner.hpp
@@ -48,7 +48,9 @@ public:
     // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
     // these fine faces equals that on the overlaped coarse face.
     // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-
+    //
+    // operator() parameters follow the FieldRefinerPolicy contract documented on
+    // DefaultFieldRefiner::operator() in field_refiner.hpp
     void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
                     auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
                     auto& fineVal, auto const& coarseVal)

--- a/src/amr/data/field/refine/magnetic_field_refiner.hpp
+++ b/src/amr/data/field/refine/magnetic_field_refiner.hpp
@@ -2,9 +2,8 @@
 #define PHARE_MAGNETIC_FIELD_REFINER_HPP
 
 
-#include "core/def/phare_mpi.hpp"
-#include "core/utilities/constants.hpp"
-#include "core/utilities/point/point.hpp"
+
+#include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 #include "core/data/grid/gridlayoutdefs.hpp"
 
 #include "amr/resources_manager/amr_utils.hpp"
@@ -45,20 +44,14 @@ public:
     // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
     // these fine faces equals that on the overlaped coarse face.
     // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-    template<typename FieldT>
-    void operator()(FieldT const& coarseField, FieldT& fineField,
-                    core::Point<int, dimension> fineIndex)
+    void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                    auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                    auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
 
-        using core::dirX;
-        using core::dirY;
-        using core::dirZ;
-
-        auto const locFineIdx   = AMRToLocal(fineIndex, fineBox_);
-        auto const coarseIdx    = toCoarseIndex(fineIndex);
-        auto const locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
-
+        if (not std::isnan(fineVal)) // KEEP
+            return;
 
         if constexpr (dimension == 1)
         {
@@ -76,10 +69,8 @@ public:
             //
             if (centerings_[0] == core::QtyCentering::primal)
             {
-                if (fineIndex[0] % 2 == 0 && std::isnan(fineField(locFineIdx[dirX])))
-                {
-                    fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
-                }
+                if (fineIndex[0] % 2 == 0)
+                    fineVal = coarseVal;
             }
             // dual case, By, Bz
             //          49           50             51
@@ -90,12 +81,8 @@ public:
             // 100 takes 50 = 100/2
             // 101 takes 50 = 101/2
             else
-            {
-                if (std::isnan(fineField(locFineIdx[dirX])))
-                    fineField(locFineIdx[dirX]) = coarseField(locCoarseIdx[dirX]);
-            }
+                fineVal = coarseVal;
         }
-
 
 
 
@@ -105,26 +92,22 @@ public:
                 and centerings_[dirY] == core::QtyCentering::dual)
             {
                 // Bx
-                if (fineIndex[dirX] % 2 == 0
-                    && std::isnan(fineField(locFineIdx[dirX], locFineIdx[dirY])))
+                if (fineIndex[dirX] % 2 == 0)
                 {
                     // we're on a coarse X face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY])
-                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
                      and centerings_[dirY] == core::QtyCentering::primal)
             {
                 // By
-                if (fineIndex[dirY] % 2 == 0
-                    && std::isnan(fineField(locFineIdx[dirX], locFineIdx[dirY])))
+                if (fineIndex[dirY] % 2 == 0)
                 {
                     // we're on a coarse Y face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY])
-                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -133,31 +116,23 @@ public:
                 // Bz
                 // we're always on a coarse Z face since there is no dual in z
                 // all 4 fine Bz take the coarse Z value
-                if (std::isnan(fineField(locFineIdx[dirX], locFineIdx[dirY])))
-                    fineField(locFineIdx[dirX], locFineIdx[dirY])
-                        = coarseField(locCoarseIdx[dirX], locCoarseIdx[dirY]);
+                fineVal = coarseVal;
             }
         }
 
 
         else if constexpr (dimension == 3)
         {
-            auto ix = locCoarseIdx[dirX];
-            auto iy = locCoarseIdx[dirY];
-            auto iz = locCoarseIdx[dirZ];
-
             if (centerings_[dirX] == core::QtyCentering::primal
                 and centerings_[dirY] == core::QtyCentering::dual
                 and centerings_[dirZ] == core::QtyCentering::dual)
             {
                 // Bx
-                if (fineIndex[dirX] % 2 == 0
-                    && std::isnan(fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])))
+                if (fineIndex[dirX] % 2 == 0)
                 {
                     // we're on a coarse X face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = coarseField(ix, iy, iz);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -165,13 +140,11 @@ public:
                      and centerings_[dirZ] == core::QtyCentering::dual)
             {
                 // By
-                if (fineIndex[dirY] % 2 == 0
-                    && std::isnan(fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])))
+                if (fineIndex[dirY] % 2 == 0)
                 {
                     // we're on a coarse Y face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = coarseField(ix, iy, iz);
+                    fineVal = coarseVal;
                 }
             }
             else if (centerings_[dirX] == core::QtyCentering::dual
@@ -179,13 +152,11 @@ public:
                      and centerings_[dirZ] == core::QtyCentering::primal)
             {
                 // Bz
-                if (fineIndex[dirZ] % 2 == 0
-                    && std::isnan(fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])))
+                if (fineIndex[dirZ] % 2 == 0)
                 {
                     // we're on a coarse Z face
                     // take the coarse face value
-                    fineField(locFineIdx[dirX], locFineIdx[dirY], locFineIdx[dirZ])
-                        = coarseField(ix, iy, iz);
+                    fineVal = coarseVal;
                 }
             }
         }

--- a/src/amr/data/field/refine/magnetic_field_refiner.hpp
+++ b/src/amr/data/field/refine/magnetic_field_refiner.hpp
@@ -44,13 +44,18 @@ public:
     // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
     // these fine faces equals that on the overlaped coarse face.
     // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    //
+    // operator() parameters follow the FieldRefinerPolicy contract documented on
+    // DefaultFieldRefiner::operator() in field_refiner.hpp
     void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
                     auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
                     auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
 
-        if (not std::isnan(fineVal)) // KEEP
+        // KEEP: don't overwrite a fine cell a previous pass (or a boundary
+        // condition) already filled in; NaN means "not yet set"
+        if (not std::isnan(fineVal))
             return;
 
         if constexpr (dimension == 1)

--- a/src/amr/data/field/refine/magnetic_field_regrider.hpp
+++ b/src/amr/data/field/refine/magnetic_field_regrider.hpp
@@ -2,7 +2,7 @@
 #define PHARE_MAGNETIC_FIELD_REGRIDER_HPP
 
 
-#include "core/def/phare_mpi.hpp"
+#include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 #include "core/utilities/constants.hpp"
 #include "core/utilities/point/point.hpp"
 #include "core/data/grid/gridlayoutdefs.hpp"
@@ -45,19 +45,15 @@ public:
     // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
     // these fine faces equals that on the overlaped coarse face.
     // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-    template<typename FieldT>
-    void operator()(FieldT const& coarseField, FieldT& fineField,
-                    core::Point<int, dimension> fineIndex)
+    void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                    auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                    auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
 
         using core::dirX;
         using core::dirY;
         using core::dirZ;
-
-        auto const locFineIdx   = AMRToLocal(fineIndex, fineBox_);
-        auto const coarseIdx    = toCoarseIndex(fineIndex);
-        auto const locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
 
 
         if constexpr (dimension == 1)

--- a/src/amr/data/field/refine/magnetic_field_regrider.hpp
+++ b/src/amr/data/field/refine/magnetic_field_regrider.hpp
@@ -45,6 +45,9 @@ public:
     // onto the 2 (1D), 4 (2/3D) colocated fine faces. This way the total flux on
     // these fine faces equals that on the overlaped coarse face.
     // see fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    //
+    // operator() parameters follow the FieldRefinerPolicy contract documented on
+    // DefaultFieldRefiner::operator() in field_refiner.hpp
     void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
                     auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
                     auto& fineVal, auto const& coarseVal)

--- a/src/amr/data/field/refine/magnetic_refine_patch_strategy.hpp
+++ b/src/amr/data/field/refine/magnetic_refine_patch_strategy.hpp
@@ -1,6 +1,7 @@
 #ifndef PHARE_AMR_MAGNETIC_REFINE_PATCH_STRATEGY_HPP
 #define PHARE_AMR_MAGNETIC_REFINE_PATCH_STRATEGY_HPP
 
+#include "core/logger.hpp"
 #include "core/utilities/types.hpp"
 #include "core/utilities/constants.hpp"
 
@@ -12,14 +13,17 @@
 #include "SAMRAI/xfer/RefinePatchStrategy.h"
 
 #include <array>
-#include <cmath>
 #include <cassert>
+#include <type_traits>
 
 namespace PHARE::amr
 {
 using core::dirX;
 using core::dirY;
 using core::dirZ;
+
+
+
 
 template<typename ResMan, typename TensorFieldDataT>
 class MagneticRefinePatchStrategy : public SAMRAI::xfer::RefinePatchStrategy
@@ -56,18 +60,20 @@ public:
     }
 
 
-    void preprocessRefine(SAMRAI::hier::Patch& fine, SAMRAI::hier::Patch const& coarse,
-                          SAMRAI::hier::Box const& fine_box,
-                          SAMRAI::hier::IntVector const& ratio) override
+    void preprocessRefine(SAMRAI::hier::Patch& /*fine*/, SAMRAI::hier::Patch const& /*coarse*/,
+                          SAMRAI::hier::Box const& /*fine_box*/,
+                          SAMRAI::hier::IntVector const& /*ratio*/) override
     {
     }
 
     // We compute the values of the new fine magnetic faces using what was already refined, ie
     // the values on the old coarse faces.
-    void postprocessRefine(SAMRAI::hier::Patch& fine, SAMRAI::hier::Patch const& coarse,
+    void postprocessRefine(SAMRAI::hier::Patch& fine, SAMRAI::hier::Patch const& /*coarse*/,
                            SAMRAI::hier::Box const& fine_box,
-                           SAMRAI::hier::IntVector const& ratio) override
+                           SAMRAI::hier::IntVector const& /*ratio*/) override
     {
+        PHARE_LOG_SCOPE(2, "MagneticRefinePatchStrategy::postprocessRefine");
+
         assertIDsSet();
 
         auto& fields       = TensorFieldDataT::getFields(fine, b_id_);
@@ -79,8 +85,9 @@ public:
         auto const fine_field_box = core::for_N_make_array<N>([&](auto i) {
             using PhysicalQuantity = std::decay_t<decltype(fields[i].physicalQuantity())>;
 
-            return FieldGeometry<gridlayout_type, PhysicalQuantity>::toFieldBox(
-                fine_box, fields[i].physicalQuantity(), fineBoxLayout);
+            return phare_box_from<dimension>(
+                FieldGeometry<gridlayout_type, PhysicalQuantity>::toFieldBox(
+                    fine_box, fields[i].physicalQuantity(), fineBoxLayout));
         });
 
         if constexpr (dimension == 1)
@@ -88,7 +95,7 @@ public:
             // if we ever go to c++23 we could use std::views::zip to iterate both on the local and
             // global indices instead of passing the box to do an amr to local inside the function,
             // which is not obvious at call site
-            for (auto const& i : phare_box_from<dimension>(fine_field_box[dirX]))
+            for (auto const& i : fine_field_box[dirX])
             {
                 postprocessBx1d(bx, layout, i);
             }
@@ -96,12 +103,12 @@ public:
 
         else if constexpr (dimension == 2)
         {
-            for (auto const& i : phare_box_from<dimension>(fine_field_box[dirX]))
+            for (auto const& i : fine_field_box[dirX])
             {
                 postprocessBx2d(bx, by, layout, i);
             }
 
-            for (auto const& i : phare_box_from<dimension>(fine_field_box[dirY]))
+            for (auto const& i : fine_field_box[dirY])
             {
                 postprocessBy2d(bx, by, layout, i);
             }
@@ -111,20 +118,20 @@ public:
         {
             auto meshSize = layout.meshSize();
 
-            for (auto const& i : phare_box_from<dimension>(fine_field_box[dirX]))
-            {
-                postprocessBx3d(bx, by, bz, meshSize, layout, i);
-            }
+            for (auto const& slab : core::make_box_span(fine_field_box[dirX]))
+                for (auto const& [point, size] : slab)
+                    for (std::size_t i = 0; i < size; ++i, ++point[dimension - 1])
+                        postprocessBx3d(bx, by, bz, meshSize, layout, point);
 
-            for (auto const& i : phare_box_from<dimension>(fine_field_box[dirY]))
-            {
-                postprocessBy3d(bx, by, bz, meshSize, layout, i);
-            }
+            for (auto const& slab : core::make_box_span(fine_field_box[dirY]))
+                for (auto const& [point, size] : slab)
+                    for (std::size_t i = 0; i < size; ++i, ++point[dimension - 1])
+                        postprocessBy3d(bx, by, bz, meshSize, layout, point);
 
-            for (auto const& i : phare_box_from<dimension>(fine_field_box[dirZ]))
-            {
-                postprocessBz3d(bx, by, bz, meshSize, layout, i);
-            }
+            for (auto const& slab : core::make_box_span(fine_field_box[dirZ]))
+                for (auto const& [point, size] : slab)
+                    for (std::size_t i = 0; i < size; ++i, ++point[dimension - 1])
+                        postprocessBz3d(bx, by, bz, meshSize, layout, point);
         }
     }
 
@@ -136,7 +143,7 @@ public:
         return amrIdx[dir] % 2 != 0;
     }
 
-    static void postprocessBx1d(auto& bx, auto const& layout, core::Point<int, dimension> idx)
+    static void postprocessBx1d(auto& bx, auto const& layout, auto const& idx)
     {
         auto const locIdx = layout.AMRToLocal(idx);
         auto const ix     = locIdx[dirX];
@@ -144,8 +151,7 @@ public:
             bx(ix) = 0.5 * (bx(ix - 1) + bx(ix + 1));
     }
 
-    static void postprocessBx2d(auto& bx, auto& by, auto const& layout,
-                                core::Point<int, dimension> idx)
+    static void postprocessBx2d(auto& bx, auto& by, auto const& layout, auto const& idx)
     {
         auto const locIdx = layout.AMRToLocal(idx);
         auto const ix     = locIdx[dirX];
@@ -171,8 +177,7 @@ public:
         }
     }
 
-    static void postprocessBy2d(auto& bx, auto& by, auto const& layout,
-                                core::Point<int, dimension> idx)
+    static void postprocessBy2d(auto& bx, auto& by, auto const& layout, auto const& idx)
     {
         auto const locIdx = layout.AMRToLocal(idx);
         auto const ix     = locIdx[dirX];
@@ -195,7 +200,7 @@ public:
     }
 
     static void postprocessBx3d(auto& bx, auto& by, auto& bz, auto const& meshSize,
-                                auto const& layout, core::Point<int, dimension> idx)
+                                auto const& layout, auto const& idx)
     {
         auto const Dx = meshSize[dirX];
         auto const Dy = meshSize[dirY];
@@ -254,7 +259,7 @@ public:
     };
 
     static void postprocessBy3d(auto& bx, auto& by, auto& bz, auto const& meshSize,
-                                auto const& layout, core::Point<int, dimension> idx)
+                                auto const& layout, auto const& idx)
     {
         auto const Dx = meshSize[dirX];
         auto const Dy = meshSize[dirY];
@@ -313,7 +318,7 @@ public:
     };
 
     static void postprocessBz3d(auto& bx, auto& by, auto& bz, auto const& meshSize,
-                                auto const& layout, core::Point<int, dimension> idx)
+                                auto const& layout, auto const& idx)
     {
         auto const Dx = meshSize[dirX];
         auto const Dy = meshSize[dirY];

--- a/src/amr/data/field/refine/magnetic_refine_patch_strategy.hpp
+++ b/src/amr/data/field/refine/magnetic_refine_patch_strategy.hpp
@@ -118,18 +118,20 @@ public:
         {
             auto meshSize = layout.meshSize();
 
+            // `point` is a reference to the span's starting point, incremented in
+            // place to walk the span rather than recomputed for each of its cells
             for (auto const& slab : core::make_box_span(fine_field_box[dirX]))
-                for (auto const& [point, size] : slab)
+                for (auto&& [point, size] : slab)
                     for (std::size_t i = 0; i < size; ++i, ++point[dimension - 1])
                         postprocessBx3d(bx, by, bz, meshSize, layout, point);
 
             for (auto const& slab : core::make_box_span(fine_field_box[dirY]))
-                for (auto const& [point, size] : slab)
+                for (auto&& [point, size] : slab)
                     for (std::size_t i = 0; i < size; ++i, ++point[dimension - 1])
                         postprocessBy3d(bx, by, bz, meshSize, layout, point);
 
             for (auto const& slab : core::make_box_span(fine_field_box[dirZ]))
-                for (auto const& [point, size] : slab)
+                for (auto&& [point, size] : slab)
                     for (std::size_t i = 0; i < size; ++i, ++point[dimension - 1])
                         postprocessBz3d(bx, by, bz, meshSize, layout, point);
         }

--- a/src/amr/data/field/refine/mhd_field_refiner.hpp
+++ b/src/amr/data/field/refine/mhd_field_refiner.hpp
@@ -36,15 +36,11 @@ public:
 
     // electric field refinement strategy follows
     // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-    template<typename FieldT>
-    void operator()(FieldT const& coarseField, FieldT& fineField,
-                    core::Point<int, dimension> fineIndex)
+    void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                    auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                    auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
-
-        auto const locFineIdx   = AMRToLocal(fineIndex, fineBox_);
-        auto const coarseIdx    = toCoarseIndex(fineIndex);
-        auto const locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
 
         if constexpr (dimension == 1)
             refine1D_(coarseField, fineField, locFineIdx, locCoarseIdx);

--- a/src/amr/data/field/refine/mhd_field_refiner.hpp
+++ b/src/amr/data/field/refine/mhd_field_refiner.hpp
@@ -36,6 +36,9 @@ public:
 
     // electric field refinement strategy follows
     // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    //
+    // operator() parameters follow the FieldRefinerPolicy contract documented on
+    // DefaultFieldRefiner::operator() in field_refiner.hpp
     void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
                     auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
                     auto& fineVal, auto const& coarseVal)

--- a/src/amr/data/field/refine/mhd_flux_refiner.hpp
+++ b/src/amr/data/field/refine/mhd_flux_refiner.hpp
@@ -37,15 +37,11 @@ public:
 
     // electric field refinement strategy follows
     // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
-    template<typename FieldT>
-    void operator()(FieldT const& coarseField, FieldT& fineField,
-                    core::Point<int, dimension> fineIndex)
+    void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
+                    auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
+                    auto& fineVal, auto const& coarseVal)
     {
         TBOX_ASSERT(coarseField.physicalQuantity() == fineField.physicalQuantity());
-
-        auto const locFineIdx   = AMRToLocal(fineIndex, fineBox_);
-        auto const coarseIdx    = toCoarseIndex(fineIndex);
-        auto const locCoarseIdx = AMRToLocal(coarseIdx, coarseBox_);
 
         if constexpr (dimension == 1)
             refine1D_(coarseField, fineField, locFineIdx, locCoarseIdx);

--- a/src/amr/data/field/refine/mhd_flux_refiner.hpp
+++ b/src/amr/data/field/refine/mhd_flux_refiner.hpp
@@ -37,6 +37,9 @@ public:
 
     // electric field refinement strategy follows
     // fujimoto et al. 2011 :  doi:10.1016/j.jcp.2011.08.002
+    //
+    // operator() parameters follow the FieldRefinerPolicy contract documented on
+    // DefaultFieldRefiner::operator() in field_refiner.hpp
     void operator()(auto const& coarseField, auto& fineField, auto const& fineIndex,
                     auto const& coarseIndex, auto const& locFineIdx, auto const& locCoarseIdx,
                     auto& fineVal, auto const& coarseVal)

--- a/src/amr/messengers/mhd_messenger.hpp
+++ b/src/amr/messengers/mhd_messenger.hpp
@@ -5,6 +5,7 @@
 #include "core/mhd/mhd_quantities.hpp"
 #include "core/data/vecfield/vecfield.hpp"
 
+#include "amr/data/field/refine/field_refiner.hpp"
 #include "amr/data/field/coarsening/electric_field_coarsener.hpp"
 #include "amr/data/field/coarsening/field_coarsen_operator.hpp"
 #include "amr/data/field/coarsening/mhd_flux_coarsener.hpp"

--- a/src/amr/resources_manager/amr_utils.hpp
+++ b/src/amr/resources_manager/amr_utils.hpp
@@ -345,4 +345,16 @@ namespace amr
 } // namespace amr
 } // namespace PHARE
 
+namespace PHARE::amr
+{
+
+template<typename Box_t>
+NO_DISCARD Box_t coarsen_box(Box_t const& box)
+{
+    return Box_t{toCoarseIndex(box.lower), toCoarseIndex(box.upper)};
+}
+
+} // namespace PHARE::amr
+
+
 #endif // UTILS_HPP

--- a/src/amr/resources_manager/amr_utils.hpp
+++ b/src/amr/resources_manager/amr_utils.hpp
@@ -348,6 +348,9 @@ namespace amr
 namespace PHARE::amr
 {
 
+/** @brief Projects a box expressed on the fine AMR grid down onto the coarse grid
+ * underneath it, by coarsening its lower and upper corners (see toCoarseIndex()).
+ */
 template<typename Box_t>
 NO_DISCARD Box_t coarsen_box(Box_t const& box)
 {

--- a/src/core/data/electrons/electrons.hpp
+++ b/src/core/data/electrons/electrons.hpp
@@ -114,9 +114,7 @@ public:
         auto& Vez = Ve_(Component::Z);
 
         // from Ni because all components defined on primal
-        layout.evalOnBox(Ne, [&](auto const&... args) {
-            auto arr = std::array{args...};
-
+        layout.evalOnBox(Ne, [&](auto const& arr) {
             auto const JxOnVx = GridLayout::template project<GridLayout::JxToMoments>(Jx, arr);
             auto const JyOnVy = GridLayout::template project<GridLayout::JyToMoments>(Jy, arr);
             auto const JzOnVz = GridLayout::template project<GridLayout::JzToMoments>(Jz, arr);

--- a/src/core/data/field/field_box.hpp
+++ b/src/core/data/field/field_box.hpp
@@ -1,34 +1,38 @@
 #ifndef PHARE_CORE_DATA_FIELD_FIELD_BOX_HPP
 #define PHARE_CORE_DATA_FIELD_FIELD_BOX_HPP
 
-#include "core/def.hpp"
-#include "core/logger.hpp"
 #include "core/utilities/types.hpp"
 #include "core/utilities/box/box.hpp"
+#include "core/data/field/field_box_span.hpp"
+#include "core/data/ndarray/ndarray_vector.hpp"
+
 
 #include <vector>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <type_traits>
 
 namespace PHARE::core
 {
 
-template<typename Field_t>
+template<typename Field_t_>
 class FieldBox
 {
+public:
+    using Field_t    = Field_t_;
     using value_type = std::decay_t<typename Field_t::value_type>;
 
-public:
     auto constexpr static dimension = Field_t::dimension;
 
     Field_t& field;
-    Box<int, dimension> amr_ghost_box;
+    Box<int, dimension> amr_box;
     Box<std::uint32_t, dimension> lcl_box;
 
     template<typename GridLayout_t>
     FieldBox(Field_t& field_, GridLayout_t const& layout)
         : field{field_}
-        , amr_ghost_box{layout.AMRGhostBoxFor(field.physicalQuantity())}
+        , amr_box{layout.AMRGhostBoxFor(field.physicalQuantity())}
         , lcl_box{layout.ghostBoxFor(field)}
     {
     }
@@ -37,7 +41,7 @@ public:
     FieldBox(Field_t& field_, GridLayout_t const& layout,
              Box<std::uint32_t, dimension> const& selection)
         : field{field_}
-        , amr_ghost_box{layout.AMRGhostBoxFor(field.physicalQuantity())}
+        , amr_box{layout.localToAMR(selection)}
         , lcl_box{selection}
     {
     }
@@ -45,7 +49,7 @@ public:
     template<typename GridLayout_t>
     FieldBox(Field_t& field_, GridLayout_t const& layout, Box<int, dimension> const& selection)
         : field{field_}
-        , amr_ghost_box{layout.AMRGhostBoxFor(field.physicalQuantity())}
+        , amr_box{selection}
         , lcl_box{layout.AMRToLocal(selection)}
     {
     }
@@ -58,15 +62,41 @@ public:
 };
 
 
+
+template<typename Operator, typename T>
+void operate_on_span(auto& dst, T const* src_data)
+    requires(std::is_same_v<Operator, SetEqual<T>>)
+{
+    std::memcpy(dst.data(), src_data, dst.size() * sizeof(T));
+}
+
+template<typename Operator, typename T>
+void operate_on_span(auto& dst, T const* src_data)
+{
+    for (std::size_t i = 0; i < dst.size(); ++i, ++src_data)
+        Operator{dst[i]}(*src_data);
+}
+
+
+
 template<typename Operator>
 void operate_on_fields(auto& dst, auto const& src)
 {
     assert(dst.lcl_box.size() == src.lcl_box.size());
-    auto src_it = src.lcl_box.begin();
-    auto dst_it = dst.lcl_box.begin();
-    for (; dst_it != dst.lcl_box.end(); ++src_it, ++dst_it)
-        Operator{dst.field(*dst_it)}(src.field(*src_it));
+    auto d_span       = make_field_box_span(dst.lcl_box, dst.field);
+    auto const s_span = make_field_box_span(src.lcl_box, src.field);
+
+    auto d_slabs = d_span.begin();
+    auto s_slabs = s_span.begin();
+    for (; s_slabs != s_span.end(); ++s_slabs, ++d_slabs)
+    {
+        auto d_spans = d_slabs.begin();
+        auto s_spans = s_slabs.begin();
+        for (; s_spans != s_slabs.end(); ++s_spans, ++d_spans)
+            operate_on_span<Operator>(*d_spans, (*s_spans).data());
+    }
 }
+
 
 
 
@@ -74,19 +104,31 @@ template<typename Field_t>
 template<typename Operator>
 void FieldBox<Field_t>::set_from(std::vector<value_type> const& vec, std::size_t seek)
 {
-    auto dst_it = lcl_box.begin();
-    for (; dst_it != lcl_box.end(); ++seek, ++dst_it)
-        Operator{field(*dst_it)}(vec[seek]);
+    for (auto& slab : make_field_box_span(lcl_box, field))
+        for (auto& span : slab)
+        {
+            operate_on_span<Operator>(span, vec.data() + seek);
+            seek += span.size();
+        }
 }
+
 
 template<typename Field_t>
 void FieldBox<Field_t>::append_to(std::vector<value_type>& vec)
 {
     // reserve vec before use!
-    auto src_it = lcl_box.begin();
-    for (; src_it != lcl_box.end(); ++src_it)
-        vec.push_back(field(*src_it));
+    std::size_t seek = vec.size();
+    vec.resize(vec.size() + lcl_box.size());
+
+    for (auto const& slab : make_field_box_span(lcl_box, field))
+        for (auto const& span : slab)
+        {
+            std::memcpy(vec.data() + seek, span.data(), span.size() * sizeof(value_type));
+            seek += span.size();
+        }
 }
+
+
 
 } // namespace PHARE::core
 

--- a/src/core/data/field/field_box.hpp
+++ b/src/core/data/field/field_box.hpp
@@ -16,6 +16,16 @@
 namespace PHARE::core
 {
 
+/** @brief Pairs a field with the same region of interest expressed in both index
+ * spaces: amr_box (global AMR indices) and lcl_box (local, ghost-box-relative
+ * storage indices), so code that needs to walk the field data while also
+ * knowing where each cell sits on the AMR grid doesn't have to convert back
+ * and forth (see operator_across_adjacent_levels() below for such a use).
+ *
+ * With only a field and layout, the region defaults to the field's whole ghost
+ * box; passing a local or AMR box restricts it to that sub-region instead (the
+ * other box is then derived from it via the layout).
+ */
 template<typename Field_t_>
 class FieldBox
 {
@@ -37,6 +47,7 @@ public:
     {
     }
 
+    // selection given in local (ghost-box-relative) indices
     template<typename GridLayout_t>
     FieldBox(Field_t& field_, GridLayout_t const& layout,
              Box<std::uint32_t, dimension> const& selection)
@@ -46,6 +57,7 @@ public:
     {
     }
 
+    // selection given in AMR (global) indices
     template<typename GridLayout_t>
     FieldBox(Field_t& field_, GridLayout_t const& layout, Box<int, dimension> const& selection)
         : field{field_}
@@ -63,6 +75,116 @@ public:
 
 
 
+/** @brief Bundles, for a coarse/fine FieldBox pair, the two kinds of span iteration
+ * operator_across_adjacent_levels() needs to walk in lockstep:
+ *  - the "field" spans, which walk local field storage and yield (data span, local point)
+ *  - the "amr" spans, which walk the same box in AMR (global) index space and yield
+ *    (amr point, span size), used only to know where each span sits on the AMR grid
+ *    (so operator_across_adjacent_levels can tell, via modulo ratio, which fine cells
+ *    sit on top of a coarse one and which fall in between).
+ */
+template<typename Field_t>
+struct CrossLevelIndices
+{
+    auto constexpr static dim = Field_t::dimension;
+    using FieldPointSpans_t   = FieldBoxPointSpans<Field_t>;
+    using FieldPointSpans_ct  = FieldBoxPointSpans<Field_t const>;
+
+    FieldBox<Field_t>& fine;
+    FieldBox<Field_t const> const& coarse;
+
+    FieldBoxSpan<Field_t, FieldPointSpans_t> fine_field_span
+        = make_field_box_point_span(fine.lcl_box, fine.field);
+    FieldBoxSpan<Field_t const, FieldPointSpans_ct> coarse_field_span
+        = make_field_box_point_span(coarse.lcl_box, coarse.field);
+
+    BoxSpan<int, dim> fine_amr_span   = make_box_span(fine.amr_box);
+    BoxSpan<int, dim> coarse_amr_span = make_box_span(coarse.amr_box);
+};
+
+
+
+/** @brief Applies fn to every fine cell of `fine` overlapping `coarse`, walking both
+ * fields span-by-span (see core/utilities/box/box_span.hpp) instead of point-by-point.
+ *
+ * `fine` and `coarse` are iterated in lockstep on the fine grid; `coarse`'s iterators
+ * only advance every ratio-th fine step (skipped via the two "% ratio" checks below),
+ * since a single coarse cell/span underlies `ratio` fine ones (ratio is 2 for the usual
+ * AMR refinement ratio, see amr::refinementRatio at call sites).
+ *
+ * Assumes `coarse` is exactly the box `fine` coarsens to (callers build both FieldBoxes
+ * from the same overlap, one coarsened, so this isn't re-checked here).
+ */
+template<typename Field_t>
+void operator_across_adjacent_levels(FieldBox<Field_t const>& coarse, FieldBox<Field_t>& fine,
+                                     std::size_t ratio, auto& fn)
+{
+    auto constexpr static FASTEST_DIR = Field_t::dimension - 1;
+
+    CrossLevelIndices<Field_t> indices{fine, coarse};
+
+    auto fine_field_slabs   = indices.fine_field_span.begin();
+    auto fine_amr_slabs     = indices.fine_amr_span.begin();
+    auto coarse_field_slabs = indices.coarse_field_span.begin();
+    auto coarse_amr_slabs   = indices.coarse_amr_span.begin();
+
+    auto slab_idx = indices.fine_amr_span.slab_begin();
+
+    for (; fine_field_slabs != indices.fine_field_span.end();
+         ++fine_field_slabs, ++fine_amr_slabs, ++slab_idx)
+    {
+        auto fine_field_spans   = fine_field_slabs.begin();
+        auto coarse_field_spans = coarse_field_slabs.begin();
+        auto fine_amr_spans     = fine_amr_slabs.begin();
+        auto coarse_amr_spans   = coarse_amr_slabs.begin();
+
+        auto span_idx = fine_amr_slabs.span_begin();
+        for (; fine_field_spans != fine_field_slabs.end();
+             ++fine_field_spans, ++fine_amr_spans, ++span_idx)
+        {
+            auto&& [fine_amr_point, fine_amr_span_size]     = *fine_amr_spans;
+            auto&& [coarse_amr_point, coarse_amr_span_size] = *coarse_amr_spans;
+
+            auto&& [fine_span, fine_lcl_point]     = *fine_field_spans;
+            auto&& [coarse_span, coarse_lcl_point] = *coarse_field_spans;
+
+            std::size_t fine_idx   = 0;
+            std::size_t coarse_idx = 0;
+            for (; fine_idx < fine_span.size(); ++fine_idx)
+            {
+                fn(coarse.field, fine.field, fine_amr_point, coarse_amr_point, fine_lcl_point,
+                   coarse_lcl_point, fine_span[fine_idx], coarse_span[coarse_idx]);
+
+                if (fine_amr_point[FASTEST_DIR] % ratio != 0)
+                {
+                    ++coarse_idx;
+                    ++coarse_lcl_point[FASTEST_DIR];
+                    ++coarse_amr_point[FASTEST_DIR];
+                }
+
+                ++fine_amr_point[FASTEST_DIR];
+                ++fine_lcl_point[FASTEST_DIR];
+            }
+
+            if (span_idx % ratio != 0)
+            {
+                ++coarse_field_spans;
+                ++coarse_amr_spans;
+            }
+        }
+
+        if (slab_idx % ratio != 0)
+        {
+            ++coarse_field_slabs;
+            ++coarse_amr_slabs;
+        }
+    }
+}
+
+
+
+// plain assignment (Operator == SetEqual<T>) is just a bulk copy, so it can
+// skip the element-by-element loop below and memcpy the whole span instead
 template<typename Operator, typename T>
 void operate_on_span(auto& dst, T const* src_data)
     requires(std::is_same_v<Operator, SetEqual<T>>)
@@ -70,6 +192,7 @@ void operate_on_span(auto& dst, T const* src_data)
     std::memcpy(dst.data(), src_data, dst.size() * sizeof(T));
 }
 
+// generic per-element path for any other Operator (e.g. PlusEquals, SetMax, see types.hpp)
 template<typename Operator, typename T>
 void operate_on_span(auto& dst, T const* src_data)
 {
@@ -79,6 +202,9 @@ void operate_on_span(auto& dst, T const* src_data)
 
 
 
+// applies Operator span-by-span between two same-shaped FieldBoxes (see
+// core/utilities/box/box_span.hpp); used to add/copy/max one field's local
+// region into another's, e.g. periodic boundary data exchange
 template<typename Operator>
 void operate_on_fields(auto& dst, auto const& src)
 {

--- a/src/core/data/field/field_box_span.hpp
+++ b/src/core/data/field/field_box_span.hpp
@@ -1,0 +1,179 @@
+#ifndef PHARE_CORE_DATA_FIELD_FIELD_BOX_SPAN_HPP
+#define PHARE_CORE_DATA_FIELD_FIELD_BOX_SPAN_HPP
+
+
+#include "core/utilities/span.hpp"
+#include "core/utilities/box/box.hpp"
+#include "core/utilities/box/box_span.hpp"
+
+#include <cstddef>
+
+
+namespace PHARE::core
+{
+
+template<typename Array_t>
+class FieldBoxSpans : public BoxSpans<std::uint32_t, Array_t::dimension>
+{
+    constexpr auto static dim = Array_t::dimension;
+    using Super               = BoxSpans<std::uint32_t, dim>;
+    using raw_value_type      = Array_t::value_type;
+    using Super::span_size;
+
+protected:
+    using Super::point;
+
+public:
+    using value_type
+        = std::conditional_t<std::is_const_v<Array_t>, raw_value_type const, raw_value_type>;
+
+    FieldBoxSpans(Array_t& arr, auto&&... args)
+        : Super{args...}
+        , arr{arr}
+    {
+    }
+
+
+    auto& operator*() { return (span = Span<value_type>{&arr(point()), span_size}); }
+
+private:
+    Array_t& arr;
+    Span<value_type> span{0, 0};
+};
+
+
+template<typename Array_t>
+class FieldBoxPointSpans : public FieldBoxSpans<Array_t>
+{
+    auto constexpr static dim = Array_t::dimension;
+    using Super               = FieldBoxSpans<Array_t>;
+
+public:
+    using value_type = Super::value_type;
+
+    FieldBoxPointSpans(auto&&... args)
+        : Super{args...}
+        , tup{std::forward_as_tuple(*super(), Super::_point)}
+    {
+    }
+
+    Super& super() { return *this; }
+    auto& operator*()
+    {
+        std::get<0>(tup) = *super();
+        std::get<1>(tup) = this->point();
+        return tup;
+    }
+
+private:
+    std::tuple<Span<value_type>&, Point<std::uint32_t, dim>&> tup;
+};
+
+
+
+template<typename Array_t, typename Spans_t = FieldBoxSpans<Array_t>>
+class FieldBoxSlab : public BoxSlab<std::uint32_t, Array_t::dimension>
+{
+    auto constexpr static dim = Array_t::dimension;
+    using FieldBoxSpans_t     = Spans_t;
+    using BaseBoxSpans_t      = BoxSpans<std::uint32_t, Array_t::dimension>;
+    using Super               = BoxSlab<std::uint32_t, dim>;
+    using Super::box;
+    using Super::slab_idx;
+    using Super::span_begin;
+    using Super::span_end;
+
+
+public:
+    FieldBoxSlab(Array_t& ar, auto&&... args)
+        : Super{args...}
+        , arr{ar}
+    {
+    }
+
+    FieldBoxSpans_t begin() { return {arr, box, slab_idx, span_begin()}; }
+    FieldBoxSpans_t begin() const { return {arr, box, slab_idx, span_begin()}; }
+    BaseBoxSpans_t end() { return {box, slab_idx, span_end()}; }
+    BaseBoxSpans_t end() const { return {box, slab_idx, span_end()}; }
+
+    auto& operator*() { return *this; }
+    auto& operator*() const { return *this; }
+
+private:
+    Array_t& arr;
+};
+
+
+
+template<typename Array_t, typename Spans_t = FieldBoxSpans<Array_t>>
+class FieldBoxSpan : public BoxSpan<std::uint32_t, Array_t::dimension>
+{
+    constexpr auto static dim = Array_t::dimension;
+    using FieldBoxSlab_t      = FieldBoxSlab<Array_t, Spans_t>;
+    using Super               = BoxSpan<std::uint32_t, dim>;
+    using Super::box;
+    using Super::slab_begin;
+    using Super::slab_end;
+
+public:
+    FieldBoxSpan(Array_t& ar, auto&&... args)
+        : Super{args...}
+        , arr{ar}
+    {
+    }
+
+    FieldBoxSlab_t begin() { return {arr, box, slabs_begin()}; }
+    FieldBoxSlab_t begin() const { return {arr, box, slabs_begin()}; }
+    FieldBoxSlab_t end() { return {arr, box, slabs_end()}; }
+    FieldBoxSlab_t end() const { return {arr, box, slabs_end()}; }
+
+    std::uint32_t slabs_begin() const
+    {
+        if constexpr (dim > 2)
+            return box.lower[0];
+        return 0;
+    }
+    std::uint32_t slabs_end() const
+    {
+        if constexpr (dim > 2)
+            return box.upper[0] + 1;
+        return 1;
+    }
+
+private:
+    Array_t& arr;
+};
+
+
+
+template<typename Array_t, std::size_t dim>
+auto make_field_box_span(Box<std::uint32_t, dim> const box, Array_t& arr)
+{
+    return FieldBoxSpan<Array_t>{arr, box};
+}
+
+template<typename Array_t, std::size_t dim>
+auto make_field_box_span(Box<std::uint32_t, dim> const box, Array_t const& arr)
+{
+    return FieldBoxSpan<Array_t const>{arr, box};
+}
+
+
+template<typename Array_t, std::size_t dim>
+auto make_field_box_point_span(Box<std::uint32_t, dim> const box, Array_t& arr)
+{
+    using Row_t = FieldBoxPointSpans<Array_t>;
+    return FieldBoxSpan<Array_t, Row_t>{arr, box};
+}
+
+template<typename Array_t, std::size_t dim>
+auto make_field_box_point_span(Box<std::uint32_t, dim> const box, Array_t const& arr)
+{
+    using Row_t = FieldBoxPointSpans<Array_t const>;
+    return FieldBoxSpan<Array_t const, Row_t>{arr, box};
+}
+
+} // namespace PHARE::core
+
+
+#endif //  PHARE_CORE_DATA_FIELD_FIELD_BOX_SPAN_HPP

--- a/src/core/data/field/field_box_span.hpp
+++ b/src/core/data/field/field_box_span.hpp
@@ -12,6 +12,9 @@
 namespace PHARE::core
 {
 
+/** @brief Like BoxSpans, but dereferencing yields a Span<value_type> over the
+ * underlying array's data for the current span, instead of a (point, size) pair.
+ */
 template<typename Array_t>
 class FieldBoxSpans : public BoxSpans<std::uint32_t, Array_t::dimension>
 {
@@ -42,6 +45,11 @@ private:
 };
 
 
+/** @brief Like FieldBoxSpans, but dereferencing also yields the current span's
+ * starting point alongside its data Span, for callers that need to track the
+ * box index in step with the field data (e.g. cross-level refinement, which
+ * must know where each span sits on both the coarse and fine grids).
+ */
 template<typename Array_t>
 class FieldBoxPointSpans : public FieldBoxSpans<Array_t>
 {
@@ -53,20 +61,20 @@ public:
 
     FieldBoxPointSpans(auto&&... args)
         : Super{args...}
-        , tup{std::forward_as_tuple(*super(), Super::_point)}
+        , span_and_point{std::forward_as_tuple(*super(), Super::_point)}
     {
     }
 
     Super& super() { return *this; }
     auto& operator*()
     {
-        std::get<0>(tup) = *super();
-        std::get<1>(tup) = this->point();
-        return tup;
+        std::get<0>(span_and_point) = *super();
+        std::get<1>(span_and_point) = this->point();
+        return span_and_point;
     }
 
 private:
-    std::tuple<Span<value_type>&, Point<std::uint32_t, dim>&> tup;
+    std::tuple<Span<value_type>&, Point<std::uint32_t, dim>&> span_and_point;
 };
 
 
@@ -162,15 +170,15 @@ auto make_field_box_span(Box<std::uint32_t, dim> const box, Array_t const& arr)
 template<typename Array_t, std::size_t dim>
 auto make_field_box_point_span(Box<std::uint32_t, dim> const box, Array_t& arr)
 {
-    using Row_t = FieldBoxPointSpans<Array_t>;
-    return FieldBoxSpan<Array_t, Row_t>{arr, box};
+    using PointSpans_t = FieldBoxPointSpans<Array_t>;
+    return FieldBoxSpan<Array_t, PointSpans_t>{arr, box};
 }
 
 template<typename Array_t, std::size_t dim>
 auto make_field_box_point_span(Box<std::uint32_t, dim> const box, Array_t const& arr)
 {
-    using Row_t = FieldBoxPointSpans<Array_t const>;
-    return FieldBoxSpan<Array_t const, Row_t>{arr, box};
+    using PointSpans_t = FieldBoxPointSpans<Array_t const>;
+    return FieldBoxSpan<Array_t const, PointSpans_t>{arr, box};
 }
 
 } // namespace PHARE::core

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -6,6 +6,7 @@
 #include "core/utilities/types.hpp"
 #include "core/utilities/box/box.hpp"
 #include "core/utilities/constants.hpp"
+#include "core/data/field/field_box.hpp"
 #include "core/utilities/index/index.hpp"
 #include "core/utilities/point/point.hpp"
 
@@ -1093,30 +1094,26 @@ namespace core
         template<typename Field>
         Box<std::uint32_t, dimension> ghostBoxFor(Field const& field) const
         {
-            return BoxFor(field, [&](auto const& centering, auto const direction) {
-                return this->ghostStartToEnd(centering, direction);
-            });
+            return boxFor(field, [&](auto&&... args) { return this->ghostStartToEnd(args...); });
         }
 
 
         template<typename Field>
         Box<std::uint32_t, dimension> domainBoxFor(Field const& field) const
         {
-            return BoxFor(field, [&](auto const& centering, auto const direction) {
-                return this->physicalStartToEnd(centering, direction);
-            });
+            return boxFor(field, [&](auto&&... args) { return this->physicalStartToEnd(args...); });
         }
 
-
-        auto AMRBoxFor(auto const& field) const
+        auto FieldBoxFor(auto const& field, Box<int, dimension> box) const
         {
             auto const centerings = centering(field);
-            auto box              = AMRBox_;
+
             for (std::uint8_t i = 0; i < dimension; ++i)
                 box.upper[i] += (centerings[i] == QtyCentering::primal) ? 1 : 0;
             return box;
         }
 
+        auto AMRBoxFor(auto const& field) const { return FieldBoxFor(field, AMRBox_); }
 
         auto AMRGhostBoxFor(auto const& field) const
         {
@@ -1197,53 +1194,32 @@ namespace core
         }
 
 
-        template<typename Field, typename Fn>
-        void evalOnBox(Field& field, Fn&& fn) const
+        template<typename... Args>
+        void evalOnBox(auto const& field, auto&& fn, Args&&... args) const
         {
-            auto indices = [&](auto const& centering, auto const direction) {
-                return this->physicalStartToEnd(centering, direction);
-            };
-
-            evalOnBox_(field, fn, indices);
+            evalOnAnyBox(domainBoxFor(field), fn, std::forward<Args>(args)...);
         }
 
-        template<typename Field, typename Fn>
-        void evalOnBiggerBox(Field& field, Point<uint32_t, dimension> const& grow, Fn&& fn) const
+        template<typename... Args>
+        void evalOnBiggerBox(auto const& field, auto const& grow, auto&& fn, Args&&... args) const
         {
-            auto indices = [&](auto const& centering, auto const direction) {
-                auto [start, end] = this->physicalStartToEnd(centering, direction);
-                return std::make_pair(start - grow[static_cast<std::size_t>(direction)],
-                                      end + grow[static_cast<std::size_t>(direction)]);
-            };
-
-            evalOnBox_(field, fn, indices);
+            evalOnAnyBox(core::grow(domainBoxFor(field), grow), fn, std::forward<Args>(args)...);
         }
 
-        template<typename Field, typename Fn>
-        void evalOnShrinkedGhostBox(Field& field, Point<uint32_t, dimension> const& shrink,
-                                    Fn&& fn) const
+        template<typename... Args>
+        void evalOnShrinkedGhostBox(auto const& field, auto const& shrink, auto&& fn,
+                                    Args&&... args) const
         {
-            auto indices = [&](auto const& centering, auto const direction) {
-                auto [start, end] = this->ghostStartToEnd(centering, direction);
-                return std::make_pair(start + shrink[static_cast<std::size_t>(direction)],
-                                      end - shrink[static_cast<std::size_t>(direction)]);
-            };
-
-            evalOnBox_(field, fn, indices);
+            evalOnAnyBox(core::shrink(ghostBoxFor(field), shrink), fn, std::forward<Args>(args)...);
         }
 
-        template<typename Field, typename Fn>
-        void evalOnGhostBox(Field& field, Fn&& fn) const
+        template<typename... Args>
+        void evalOnGhostBox(auto const& field, auto&& fn, Args&&... args) const
         {
-            auto indices = [&](auto const& centering, auto const direction) {
-                return this->ghostStartToEnd(centering, direction);
-            };
-
-            evalOnBox_(field, fn, indices);
+            evalOnAnyBox(ghostBoxFor(field), fn, std::forward<Args>(args)...);
         }
 
         auto levelNumber() const { return levelNumber_; }
-
 
         auto amr_lcl_idx(auto const& box) const { return boxes_iterator{box, AMRToLocal(box)}; }
         auto amr_lcl_idx() const { return amr_lcl_idx(AMRBox()); }
@@ -1254,41 +1230,20 @@ namespace core
         }
 
     private:
-        template<typename Field, typename IndicesFn, typename Fn>
-        static void evalOnBox_(Field& field, Fn& fn, IndicesFn& startToEnd)
+        template<typename... Args>
+        void evalOnAnyBox(auto const& box, auto&& fn, Args&&... args) const
         {
-            auto const [ix0, ix1] = startToEnd(field, Direction::X);
-            for (auto ix = ix0; ix <= ix1; ++ix)
-            {
-                if constexpr (dimension == 1)
-                {
-                    fn(ix);
-                }
-                else
-                {
-                    auto const [iy0, iy1] = startToEnd(field, Direction::Y);
+            auto constexpr static IDX = dimension - 1; // Fast index
 
-                    for (auto iy = iy0; iy <= iy1; ++iy)
-                    {
-                        if constexpr (dimension == 2)
-                        {
-                            fn(ix, iy);
-                        }
-                        else
-                        {
-                            auto const [iz0, iz1] = startToEnd(field, Direction::Z);
-
-                            for (auto iz = iz0; iz <= iz1; ++iz)
-                                fn(ix, iy, iz);
-                        }
-                    }
-                }
-            }
+            for (auto const& slab : make_box_span(box))
+                for (auto const& [point, _] : slab)
+                    for (; point[IDX] <= box.upper[IDX]; ++point[IDX])
+                        fn(point, std::forward<Args>(args)...);
         }
 
 
         template<typename Field, typename Fn>
-        auto BoxFor(Field const& field, Fn startToEnd) const
+        auto boxFor(Field const& field, Fn const startToEnd) const
         {
             std::array<std::uint32_t, dimension> lower, upper;
 

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -1230,10 +1230,19 @@ namespace core
         }
 
     private:
+        // calls fn(point, args...) once per point of box, walking it span by span
+        // (see core/utilities/box/box_span.hpp) rather than allocating one Point
+        // per cell: `point` is reused and incremented in place along the fastest
+        // dimension for the length of each span.
+        //
+        // Note: although the loop binds `[point, _]` through a `const&`, `point`
+        // itself stays mutable — the span dereference returns a tuple of
+        // references (Point&, size const&), and a structured binding preserves
+        // the referenced type's own constness rather than adding one.
         template<typename... Args>
         void evalOnAnyBox(auto const& box, auto&& fn, Args&&... args) const
         {
-            auto constexpr static IDX = dimension - 1; // Fast index
+            auto constexpr static IDX = dimension - 1; // fastest-varying dimension
 
             for (auto const& slab : make_box_span(box))
                 for (auto const& [point, _] : slab)

--- a/src/core/numerics/ampere/ampere.hpp
+++ b/src/core/numerics/ampere/ampere.hpp
@@ -3,12 +3,10 @@
 
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/data/vecfield/vecfield_component.hpp"
+#include <core/utilities/types.hpp>
 
 namespace PHARE::core
 {
-
-
-
 
 template<typename GridLayout>
 class Ampere
@@ -31,66 +29,57 @@ public:
         auto& Jy = J(Component::Y);
         auto& Jz = J(Component::Z);
 
-        Point<std::uint32_t, dimension> shrink;
+        auto const shrink = ConstArray<std::size_t, dimension>(1);
 
-        for (size_t i = 0; i < dimension; ++i)
-        {
-            shrink[i] = 1;
-        }
-
-        layout_.evalOnShrinkedGhostBox(Jx, shrink,
-                                       [&](auto&... args) mutable { JxEq_(Jx, B, args...); });
-        layout_.evalOnShrinkedGhostBox(Jy, shrink,
-                                       [&](auto&... args) mutable { JyEq_(Jy, B, args...); });
-        layout_.evalOnShrinkedGhostBox(Jz, shrink,
-                                       [&](auto&... args) mutable { JzEq_(Jz, B, args...); });
+        layout_.evalOnShrinkedGhostBox(
+            Jx, shrink, [](auto&&... args) { JxEq_(args...); }, Jx, B, layout_);
+        layout_.evalOnShrinkedGhostBox(
+            Jy, shrink, [](auto&&... args) { JyEq_(args...); }, Jy, B, layout_);
+        layout_.evalOnShrinkedGhostBox(
+            Jz, shrink, [](auto&&... args) { JzEq_(args...); }, Jz, B, layout_);
     }
 
 
 private:
     GridLayout layout_;
 
-
-    template<typename VecField, typename Field, typename... Indexes>
-    void JxEq_(Field& Jx, VecField const& B, Indexes const&... ijk) const
+    static void JxEq_(auto const& ijk, auto& Jx, auto const& B, auto const& layout)
     {
         auto const& [_, By, Bz] = B();
 
         if constexpr (dimension == 1)
-            Jx(ijk...) = 0.0;
+            Jx(ijk) = 0.0;
 
         if constexpr (dimension == 2)
-            Jx(ijk...) = layout_.template deriv<Direction::Y>(Bz, {ijk...});
+            Jx(ijk) = layout.template deriv<Direction::Y>(Bz, ijk);
 
         if constexpr (dimension == 3)
-            Jx(ijk...) = layout_.template deriv<Direction::Y>(Bz, {ijk...})
-                         - layout_.template deriv<Direction::Z>(By, {ijk...});
+            Jx(ijk) = layout.template deriv<Direction::Y>(Bz, ijk)
+                      - layout.template deriv<Direction::Z>(By, ijk);
     }
 
-    template<typename VecField, typename Field, typename... Indexes>
-    void JyEq_(Field& Jy, VecField const& B, Indexes const&... ijk) const
+    static void JyEq_(auto const& ijk, auto& Jy, auto const& B, auto const& layout)
     {
         auto const& [Bx, By, Bz] = B();
 
         if constexpr (dimension == 1 || dimension == 2)
-            Jy(ijk...) = -layout_.template deriv<Direction::X>(Bz, {ijk...});
+            Jy(ijk) = -layout.template deriv<Direction::X>(Bz, ijk);
 
         if constexpr (dimension == 3)
-            Jy(ijk...) = layout_.template deriv<Direction::Z>(Bx, {ijk...})
-                         - layout_.template deriv<Direction::X>(Bz, {ijk...});
+            Jy(ijk) = layout.template deriv<Direction::Z>(Bx, ijk)
+                      - layout.template deriv<Direction::X>(Bz, ijk);
     }
 
-    template<typename VecField, typename Field, typename... Indexes>
-    void JzEq_(Field& Jz, VecField const& B, Indexes const&... ijk) const
+    static void JzEq_(auto const& ijk, auto& Jz, auto const& B, auto const& layout)
     {
         auto const& [Bx, By, Bz] = B();
 
         if constexpr (dimension == 1)
-            Jz(ijk...) = layout_.template deriv<Direction::X>(By, {ijk...});
+            Jz(ijk) = layout.template deriv<Direction::X>(By, ijk);
 
         else
-            Jz(ijk...) = layout_.template deriv<Direction::X>(By, {ijk...})
-                         - layout_.template deriv<Direction::Y>(Bx, {ijk...});
+            Jz(ijk) = layout.template deriv<Direction::X>(By, ijk)
+                      - layout.template deriv<Direction::Y>(Bx, ijk);
     }
 };
 

--- a/src/core/numerics/ampere/ampere.hpp
+++ b/src/core/numerics/ampere/ampere.hpp
@@ -31,6 +31,9 @@ public:
 
         auto const shrink = ConstArray<std::size_t, dimension>(1);
 
+        // evalOnShrinkedGhostBox calls fn(point, trailingArgs...); trailing args
+        // (Jx, B, layout_) are passed through it rather than captured, so the
+        // lambdas stay capture-free and JxEq_/JyEq_/JzEq_ can remain static
         layout_.evalOnShrinkedGhostBox(
             Jx, shrink, [](auto&&... args) { JxEq_(args...); }, Jx, B, layout_);
         layout_.evalOnShrinkedGhostBox(

--- a/src/core/numerics/faraday/faraday.hpp
+++ b/src/core/numerics/faraday/faraday.hpp
@@ -42,58 +42,63 @@ public:
         auto& Bynew = Bnew(Component::Y);
         auto& Bznew = Bnew(Component::Z);
 
-        layout_.evalOnBox(Bxnew, [&](auto&... args) mutable { BxEq_(Bx, E, Bxnew, args...); });
-        layout_.evalOnBox(Bynew, [&](auto&... args) mutable { ByEq_(By, E, Bynew, args...); });
-        layout_.evalOnBox(Bznew, [&](auto&... args) mutable { BzEq_(Bz, E, Bznew, args...); });
+        layout_.evalOnBox(
+            Bxnew, [](auto&&... args) { BxEq_(args...); }, Bx, E, Bxnew, layout_, dt_);
+        layout_.evalOnBox(
+            Bynew, [](auto&&... args) { ByEq_(args...); }, By, E, Bynew, layout_, dt_);
+        layout_.evalOnBox(
+            Bznew, [](auto&&... args) { BzEq_(args...); }, Bz, E, Bznew, layout_, dt_);
     }
-
 
 private:
     double dt_;
     GridLayout layout_;
 
-    template<typename VecField, typename Field, typename... Indexes>
-    void BxEq_(Field const& Bx, VecField const& E, Field& Bxnew, Indexes const&... ijk) const
+    static void BxEq_(auto const& ijk, auto&&... args)
     {
-        auto const& [_, Ey, Ez] = E();
+        auto const& [Bx, E, Bxnew, layout, dt] = std::forward_as_tuple(args...);
+        auto const& [_, Ey, Ez]                = E();
 
         if constexpr (dimension == 1)
-            Bxnew(ijk...) = Bx(ijk...);
+            Bxnew(ijk) = Bx(ijk);
 
         if constexpr (dimension == 2)
-            Bxnew(ijk...) = Bx(ijk...) - dt_ * layout_.template deriv<Direction::Y>(Ez, {ijk...});
+            Bxnew(ijk) = Bx(ijk) - dt * layout.template deriv<Direction::Y>(Ez, ijk);
 
         if constexpr (dimension == 3)
-            Bxnew(ijk...) = Bx(ijk...) - dt_ * layout_.template deriv<Direction::Y>(Ez, {ijk...})
-                            + dt_ * layout_.template deriv<Direction::Z>(Ey, {ijk...});
+            Bxnew(ijk) = Bx(ijk) - dt * layout.template deriv<Direction::Y>(Ez, ijk)
+                         + dt * layout.template deriv<Direction::Z>(Ey, ijk);
     }
 
-    template<typename VecField, typename Field, typename... Indexes>
-    void ByEq_(Field const& By, VecField const& E, Field& Bynew, Indexes const&... ijk) const
+
+    static void ByEq_(auto const& ijk, auto&&... args)
     {
-        auto const& [Ex, _, Ez] = E();
+        auto const& [By, E, Bynew, layout, dt] = std::forward_as_tuple(args...);
+        auto const& [Ex, _, Ez]                = E();
 
         if constexpr (dimension == 1 || dimension == 2)
-            Bynew(ijk...) = By(ijk...) + dt_ * layout_.template deriv<Direction::X>(Ez, {ijk...});
+            Bynew(ijk) = By(ijk) + dt * layout.template deriv<Direction::X>(Ez, ijk);
 
         if constexpr (dimension == 3)
-            Bynew(ijk...) = By(ijk...) - dt_ * layout_.template deriv<Direction::Z>(Ex, {ijk...})
-                            + dt_ * layout_.template deriv<Direction::X>(Ez, {ijk...});
+            Bynew(ijk) = By(ijk) - dt * layout.template deriv<Direction::Z>(Ex, ijk)
+                         + dt * layout.template deriv<Direction::X>(Ez, ijk);
     }
 
-    template<typename VecField, typename Field, typename... Indexes>
-    void BzEq_(Field const& Bz, VecField const& E, Field& Bznew, Indexes const&... ijk) const
+
+    static void BzEq_(auto const& ijk, auto&&... args)
     {
-        auto const& [Ex, Ey, _] = E();
+        auto const& [Bz, E, Bznew, layout, dt] = std::forward_as_tuple(args...);
+        auto const& [Ex, Ey, _]                = E();
 
         if constexpr (dimension == 1)
-            Bznew(ijk...) = Bz(ijk...) - dt_ * layout_.template deriv<Direction::X>(Ey, {ijk...});
+            Bznew(ijk) = Bz(ijk) - dt * layout.template deriv<Direction::X>(Ey, ijk);
 
         else
-            Bznew(ijk...) = Bz(ijk...) - dt_ * layout_.template deriv<Direction::X>(Ey, {ijk...})
-                            + dt_ * layout_.template deriv<Direction::Y>(Ex, {ijk...});
+            Bznew(ijk) = Bz(ijk) - dt * layout.template deriv<Direction::X>(Ey, ijk)
+                         + dt * layout.template deriv<Direction::Y>(Ex, ijk);
     }
 };
+
 
 } // namespace PHARE::core
 

--- a/src/core/numerics/faraday/faraday.hpp
+++ b/src/core/numerics/faraday/faraday.hpp
@@ -42,6 +42,10 @@ public:
         auto& Bynew = Bnew(Component::Y);
         auto& Bznew = Bnew(Component::Z);
 
+        // evalOnBox calls fn(point, trailingArgs...); the trailing args here
+        // (Bx/By/Bz, E, Bxnew/Bynew/Bznew, layout_, dt_) are passed through
+        // rather than captured, so BxEq_/ByEq_/BzEq_ stay static. Their order
+        // must match the std::forward_as_tuple unpacking inside each *Eq_.
         layout_.evalOnBox(
             Bxnew, [](auto&&... args) { BxEq_(args...); }, Bx, E, Bxnew, layout_, dt_);
         layout_.evalOnBox(

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -2,7 +2,6 @@
 #define PHARE_OHM_HPP
 
 
-#include "core/utilities/index/index.hpp"
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/data/vecfield/vecfield_component.hpp"
 
@@ -48,51 +47,41 @@ public:
     void operator()(Field const& n, VecField const& Ve, Field const& Pe, VecField const& B,
                     VecField const& J, VecField& Enew)
     {
-        using Pack = OhmPack<VecField, Field>;
-
         auto const& [Exnew, Eynew, Eznew] = Enew();
 
-        layout_.evalOnBox(Exnew, [&](auto&... args) mutable {
-            this->template E_Eq_<Component::X>(Pack{Enew, n, Pe, Ve, B, J}, args...);
-        });
-        layout_.evalOnBox(Eynew, [&](auto&... args) mutable {
-            this->template E_Eq_<Component::Y>(Pack{Enew, n, Pe, Ve, B, J}, args...);
-        });
-        layout_.evalOnBox(Eznew, [&](auto&... args) mutable {
-            this->template E_Eq_<Component::Z>(Pack{Enew, n, Pe, Ve, B, J}, args...);
-        });
+        layout_.evalOnBox(
+            Exnew, [](auto&&... args) { E_Eq_<Component::X>(args...); }, n, Ve, Pe, B, J, Enew,
+            *this);
+        layout_.evalOnBox(
+            Eynew, [](auto&&... args) { E_Eq_<Component::Y>(args...); }, n, Ve, Pe, B, J, Enew,
+            *this);
+        layout_.evalOnBox(
+            Eznew, [](auto&&... args) { E_Eq_<Component::Z>(args...); }, n, Ve, Pe, B, J, Enew,
+            *this);
     }
 
 private:
     GridLayout layout_;
 
-    template<typename VecField, typename Field>
-    struct OhmPack
-    {
-        VecField& Exyz;
-        Field const &n, &Pe;
-        VecField const &Ve, &B, &J;
-    };
 
-
-    template<auto Tag, typename OhmPack, typename... IDXs>
-    void E_Eq_(OhmPack&& pack, IDXs const&... ijk) const
+    template<auto Tag>
+    static void E_Eq_(auto const& ijk, auto&&... args)
     {
-        auto const& [E, n, Pe, Ve, B, J] = pack;
-        auto& Exyz                       = E(Tag);
+        auto const& [n, Ve, Pe, B, J, E, self] = std::forward_as_tuple(args...);
+        auto& Exyz                             = E(Tag);
 
         static_assert(Components::check<Tag>());
 
-        Exyz(ijk...) = ideal_<Tag>(Ve, B, {ijk...})      //
-                       + pressure_<Tag>(n, Pe, {ijk...}) //
-                       + resistive_<Tag>(J, {ijk...})    //
-                       + hyperresistive_<Tag>(J, B, n, {ijk...});
+        Exyz(ijk) = self.template ideal_<Tag>(Ve, B, ijk)      //
+                    + self.template pressure_<Tag>(n, Pe, ijk) //
+                    + self.template resistive_<Tag>(J, ijk)    //
+                    + self.template hyperresistive_<Tag>(J, B, n, ijk);
     }
 
 
 
     template<auto component, typename VecField>
-    auto ideal_(VecField const& Ve, VecField const& B, MeshIndex<dimension> index) const
+    auto ideal_(VecField const& Ve, VecField const& B, auto const index) const
     {
         if constexpr (component == Component::X)
         {
@@ -143,7 +132,7 @@ private:
 
 
     template<auto component, typename Field>
-    auto pressure_(Field const& n, Field const& Pe, MeshIndex<Field::dimension> index) const
+    auto pressure_(Field const& n, Field const& Pe, auto const index) const
     {
         if constexpr (component == Component::X)
         {
@@ -193,7 +182,7 @@ private:
 
 
     template<auto component, typename VecField>
-    auto resistive_(VecField const& J, MeshIndex<VecField::dimension> index) const
+    auto resistive_(VecField const& J, auto const index) const
     {
         auto const& Jxyx = J(component);
 
@@ -218,7 +207,7 @@ private:
 
     template<auto component, typename VecField, typename Field>
     auto hyperresistive_(VecField const& J, VecField const& B, Field const& n,
-                         MeshIndex<VecField::dimension> index) const
+                         auto const index) const
     {
         if (hyper_mode == HyperMode::constant)
             return constant_hyperresistive_<component>(J, index);
@@ -230,7 +219,7 @@ private:
 
 
     template<auto component, typename VecField>
-    auto constant_hyperresistive_(VecField const& J, MeshIndex<VecField::dimension> index) const
+    auto constant_hyperresistive_(VecField const& J, auto const index) const
     { // TODO : https://github.com/PHAREHUB/PHARE/issues/3
         return -nu * layout_.laplacian(J(component), index);
     }
@@ -238,7 +227,7 @@ private:
 
     template<auto component, typename VecField, typename Field>
     auto spatial_hyperresistive_(VecField const& J, VecField const& B, Field const& n,
-                                 MeshIndex<VecField::dimension> index) const
+                                 auto const index) const
     {
         auto const lvlCoeff        = 1. / std::pow(4, layout_.levelNumber());
         auto constexpr min_density = 0.1;
@@ -267,7 +256,7 @@ private:
                                                  GridLayout::BzToEz, GridLayout::momentsToEz>();
         }
     }
-};
+}; // namespace PHARE::core
 
 
 } // namespace PHARE::core

--- a/src/core/numerics/ohm/ohm.hpp
+++ b/src/core/numerics/ohm/ohm.hpp
@@ -49,6 +49,10 @@ public:
     {
         auto const& [Exnew, Eynew, Eznew] = Enew();
 
+        // evalOnBox calls fn(point, trailingArgs...); the trailing args here
+        // (n, Ve, Pe, B, J, Enew, *this) are passed through rather than captured,
+        // so E_Eq_ stays static. Their order must match the std::forward_as_tuple
+        // unpacking inside E_Eq_.
         layout_.evalOnBox(
             Exnew, [](auto&&... args) { E_Eq_<Component::X>(args...); }, n, Ve, Pe, B, J, Enew,
             *this);

--- a/src/core/utilities/box/box.hpp
+++ b/src/core/utilities/box/box.hpp
@@ -74,23 +74,19 @@ struct Box
     }
 
 
-    void grow(Type const& size)
-    {
-        for (auto& c : lower)
-        {
-            c -= size;
-        }
-        for (auto& c : upper)
-        {
-            c += size;
-        }
-    }
-
-    template<typename Size>
-    auto& grow(std::array<Size, dim> const& size)
+    template<typename Modifier>
+    auto& grow(Modifier const& size)
     {
         lower -= size;
         upper += size;
+        return *this;
+    }
+
+    template<typename Modifier>
+    auto& shrink(Modifier const& size)
+    {
+        lower += size;
+        upper -= size;
         return *this;
     }
 
@@ -330,6 +326,15 @@ Box<Type, dim> grow(Box<Type, dim> const& box, OType const& size)
     copy.grow(size);
     return copy;
 }
+
+template<typename Type, std::size_t dim, typename T2>
+NO_DISCARD Box<Type, dim> shrink(Box<Type, dim> const& box, T2 const& size)
+{
+    auto copy{box};
+    copy.shrink(size);
+    return copy;
+}
+
 
 template<typename Type, std::size_t dim, typename Shifter>
 NO_DISCARD Box<Type, dim> shift(Box<Type, dim> const& box, Shifter const& offset)

--- a/src/core/utilities/box/box_span.hpp
+++ b/src/core/utilities/box/box_span.hpp
@@ -1,0 +1,203 @@
+#ifndef PHARE_CORE_UTILITIES_BOX_BOX_SPAN_HPP
+#define PHARE_CORE_UTILITIES_BOX_BOX_SPAN_HPP
+
+#include "core/utilities/box/box.hpp"
+
+#include <cstddef>
+
+
+namespace PHARE::core
+{
+
+template<typename T, std::size_t dim_>
+class BoxSpans
+{
+    auto constexpr static dim = dim_;
+
+public:
+    using value_type = T;
+
+    BoxSpans(Box<T, dim> const& box, T const slab_idx, T const span_idx)
+        : box{box}
+        , slab_idx{slab_idx}
+        , span_idx{span_idx}
+        , span_size{_span_size()}
+    {
+    }
+
+    BoxSpans& operator++()
+    {
+        ++span_idx;
+        return *this;
+    }
+    BoxSpans operator++(int) // postfix increment
+    {
+        auto copy = *this;
+        ++(*this);
+        return copy;
+    }
+
+    BoxSpans& operator--()
+    {
+        --span_idx;
+        return *this;
+    }
+    BoxSpans operator--(int) // postfix decrement
+    {
+        auto copy = *this;
+        --(*this);
+        return copy;
+    }
+
+    auto& point()
+    {
+        if constexpr (dim == 1)
+            return (_point = {box.lower[0]});
+        if constexpr (dim == 2)
+            return (_point = {span_idx, box.lower[1]});
+        if constexpr (dim == 3)
+            return (_point = {slab_idx, span_idx, box.lower[2]});
+    }
+
+    auto operator*() { return std::forward_as_tuple(point(), span_size); }
+
+    bool operator==(BoxSpans const& that) const { return span_idx == that.span_idx; }
+    bool operator!=(BoxSpans const& that) const { return span_idx != that.span_idx; }
+    bool operator<(BoxSpans const& that) const { return span_idx < that.span_idx; }
+    bool operator>(BoxSpans const& that) const { return span_idx > that.span_idx; }
+
+
+protected:
+    std::uint32_t _span_size() const { return box.upper[dim - 1] - box.lower[dim - 1] + 1; }
+
+    Box<T, dim> const& box;
+    T const slab_idx;
+    T span_idx;
+    std::uint32_t const span_size;
+    Point<T, dim> _point{};
+};
+
+
+template<typename T, std::size_t dim_>
+class BoxSlab
+{
+    auto constexpr static dim = dim_;
+    using BoxSpans_t          = BoxSpans<T, dim>;
+
+public:
+    using value_type = T;
+
+    BoxSlab(Box<T, dim> const& _box, T const _slab_idx)
+        : box{_box}
+        , slab_idx{_slab_idx}
+    {
+    }
+
+    BoxSpans_t begin() { return {box, slab_idx, span_begin()}; }
+    BoxSpans_t begin() const { return {box, slab_idx, span_begin()}; }
+    BoxSpans_t end() { return {box, slab_idx, span_end()}; }
+    BoxSpans_t end() const { return {box, slab_idx, span_end()}; }
+
+    auto& operator*() { return *this; }
+    auto& operator*() const { return *this; }
+
+    bool operator==(BoxSlab const& that) const { return slab_idx == that.slab_idx; }
+    bool operator!=(BoxSlab const& that) const { return slab_idx != that.slab_idx; }
+    bool operator<(BoxSlab const& that) const { return slab_idx < that.slab_idx; }
+    bool operator>(BoxSlab const& that) const { return slab_idx > that.slab_idx; }
+
+    BoxSlab& operator++()
+    {
+        ++slab_idx;
+        return *this;
+    }
+    BoxSlab operator++(int) // postfix increment
+    {
+        auto copy = *this;
+        ++(*this);
+        return copy;
+    }
+
+    BoxSlab& operator--()
+    {
+        --slab_idx;
+        return *this;
+    }
+    BoxSlab operator--(int) // postfix decrement
+    {
+        auto copy = *this;
+        --(*this);
+        return copy;
+    }
+
+    T span_begin() const
+    {
+        if constexpr (dim > 1)
+            return box.lower[dim - 2];
+        return 0;
+    }
+    T span_end() const
+    {
+        if constexpr (dim > 1)
+            return box.upper[dim - 2] + 1;
+        return 1;
+    }
+
+protected:
+    Box<T, dim> const& box;
+    T slab_idx;
+};
+
+template<typename T, std::size_t dim_>
+class BoxSpan
+{
+    auto constexpr static dim = dim_;
+    using BoxSlab_t           = BoxSlab<T, dim>;
+
+public:
+    using value_type = T;
+
+    BoxSpan(Box<T, dim> const& _box)
+        : box{_box}
+    {
+    }
+
+    BoxSlab_t begin() { return {box, slab_begin()}; }
+    BoxSlab_t begin() const { return {box, slab_begin()}; }
+    BoxSlab_t end() { return {box, slab_end()}; }
+    BoxSlab_t end() const { return {box, slab_end()}; }
+
+    T slab_begin() const
+    {
+        if constexpr (dim > 2)
+            return box.lower[0];
+        return 0;
+    }
+    T slab_end() const
+    {
+        if constexpr (dim > 2)
+            return box.upper[0] + 1;
+        return 1;
+    }
+
+    std::uint32_t size() const
+    {
+        auto s = slab_end() - slab_begin();
+        assert(s > 0);
+        return s;
+    }
+
+protected:
+    Box<T, dim> const box;
+};
+
+
+template<typename T, std::size_t dim>
+auto make_box_span(Box<T, dim> const box)
+{ return BoxSpan<T, dim>{box}; }
+
+
+} // namespace PHARE::core
+
+
+#endif //  PHARE_CORE_UTILITIES_BOX_BOX_SPAN_HPP

--- a/src/core/utilities/box/box_span.hpp
+++ b/src/core/utilities/box/box_span.hpp
@@ -9,6 +9,34 @@
 namespace PHARE::core
 {
 
+/*
+Span-wise iteration over an N dimensional Box.
+
+Instead of visiting the box point by point, the box is decomposed into:
+  - slabs: one per index of the slowest-varying dimension (3D only,
+           1D/2D boxes are a single slab)
+  - spans: within a slab, one per index of the second-fastest dimension;
+           each span is the contiguous run of cells along the last
+           (fastest-varying) dimension
+
+    for (auto const& slab : make_box_span(box))   // 3D: one slab per x index
+        for (auto const& [start, size] : slab)    // one span per y index
+            ...  // span covers cells [start, start + size) along z
+
+This gives callers whole contiguous spans to work with (memcpy, vectorizable
+inner loops) rather than a callback per point.
+*/
+
+
+/** @brief Iterator over the spans of one slab.
+ *
+ * Dereferencing yields a (start point, span length) tuple, where the returned
+ * point references internal storage recomputed on each dereference: it is
+ * invalidated by the next dereference or increment.
+ *
+ * Comparison operators only inspect span_idx, so comparing iterators made
+ * from different boxes or slabs is meaningless.
+ */
 template<typename T, std::size_t dim_>
 class BoxSpans
 {
@@ -49,6 +77,8 @@ public:
         return copy;
     }
 
+    // starting point of the current span: fastest-varying coordinate is always
+    // box.lower[dim - 1], since a span walks that whole dimension contiguously
     auto& point()
     {
         if constexpr (dim == 1)
@@ -78,6 +108,7 @@ protected:
 };
 
 
+/** @brief One slab of a box: a fixed slowest-varying index, iterated over its spans. */
 template<typename T, std::size_t dim_>
 class BoxSlab
 {
@@ -148,6 +179,9 @@ protected:
     T slab_idx;
 };
 
+/** @brief Entry point of the span-wise iteration: iterates the slabs of a box.
+ * See make_box_span() for the usual way to construct one.
+ */
 template<typename T, std::size_t dim_>
 class BoxSpan
 {
@@ -180,6 +214,7 @@ public:
         return 1;
     }
 
+    // number of slabs (not the number of cells in the box)
     std::uint32_t size() const
     {
         auto s = slab_end() - slab_begin();
@@ -194,7 +229,9 @@ protected:
 
 template<typename T, std::size_t dim>
 auto make_box_span(Box<T, dim> const box)
-{ return BoxSpan<T, dim>{box}; }
+{
+    return BoxSpan<T, dim>{box};
+}
 
 
 } // namespace PHARE::core

--- a/src/core/utilities/span.hpp
+++ b/src/core/utilities/span.hpp
@@ -21,20 +21,33 @@ concept Spannable = requires(T t) {
 
 
 template<typename T, typename SIZE = std::size_t>
-
 struct Span
 {
-    using value_type = T;
+    using value_type = std::decay_t<T>;
+
+    Span(T* ptr_ = nullptr, SIZE s_ = 0)
+        : ptr{ptr_}
+        , s{s_}
+    {
+    }
+
+    Span(Span&&)                 = default;
+    Span(Span const&)            = default;
+    Span& operator=(Span&&)      = default;
+    Span& operator=(Span const&) = default;
 
     NO_DISCARD auto& operator[](SIZE i) { return ptr[i]; }
-    NO_DISCARD auto& operator[](SIZE i) const { return ptr[i]; }
-    NO_DISCARD T const* const& data() const { return ptr; }
-    NO_DISCARD T const* const& begin() const { return ptr; }
-    NO_DISCARD T* end() const { return ptr + s; }
+    NO_DISCARD value_type const& operator[](SIZE i) const { return ptr[i]; }
+    NO_DISCARD value_type const* data() const { return ptr; }
+    NO_DISCARD auto data() { return ptr; }
+    NO_DISCARD auto begin() { return ptr; }
+    NO_DISCARD auto begin() const { return ptr; }
+    NO_DISCARD auto end() { return ptr + s; }
+    NO_DISCARD auto end() const { return ptr + s; }
     NO_DISCARD SIZE const& size() const { return s; }
 
-    T const* ptr = nullptr;
-    SIZE s       = 0;
+    T* ptr = nullptr;
+    SIZE s = 0;
 };
 
 
@@ -88,7 +101,11 @@ struct SpanSet
     {
     }
 
-    NO_DISCARD Span<T, SIZE> operator[](SIZE i) const
+    NO_DISCARD Span<T, SIZE> operator[](SIZE i)
+    {
+        return {this->vec.data() + displs[i], this->sizes[i]};
+    }
+    NO_DISCARD Span<T const, SIZE> operator[](SIZE i) const
     {
         return {this->vec.data() + displs[i], this->sizes[i]};
     }

--- a/src/core/utilities/span.hpp
+++ b/src/core/utilities/span.hpp
@@ -20,6 +20,14 @@ concept Spannable = requires(T t) {
 };
 
 
+/** @brief Non-owning view over a contiguous range of T.
+ *
+ * Constness of the viewed data is carried by T itself (T const for a read-only
+ * span, T otherwise) rather than always storing a `T const*` internally: this
+ * lets the same template represent both a mutable and a read-only span (e.g.
+ * FieldBoxSpans picks value_type = T const only when the underlying field is
+ * const, see field_box_span.hpp), instead of needing two separate types.
+ */
 template<typename T, typename SIZE = std::size_t>
 struct Span
 {

--- a/tests/core/data/field/CMakeLists.txt
+++ b/tests/core/data/field/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required (VERSION 3.20.1)
 
-project(test-box)
+project(test-field)
 
-
-function(_box_test test_name)
+function(_field_test test_name)
 
   add_executable(${test_name} ${test_name}.cpp)
 
@@ -17,7 +16,7 @@ function(_box_test test_name)
 
   add_no_mpi_phare_test(${test_name} ${CMAKE_CURRENT_BINARY_DIR})
 
-endfunction(_box_test)
+endfunction(_field_test)
 
-_box_test(test_box)
-_box_test(test_box_span)
+_field_test(test_field_box_span)
+

--- a/tests/core/data/field/test_field_box_span.cpp
+++ b/tests/core/data/field/test_field_box_span.cpp
@@ -1,0 +1,94 @@
+
+#include "core/data/field/field_box_span.hpp"
+
+#include "phare_core.hpp"
+#include "phare_simulator_options.hpp"
+
+#include "tests/core/data/gridlayout/test_gridlayout.hpp"
+
+#include "gtest/gtest.h"
+
+#include <cstddef>
+
+
+namespace PHARE::core
+{
+
+template<std::size_t _dim>
+struct TestParam
+{
+    auto constexpr static dim = _dim;
+};
+
+
+template<typename Param>
+class FieldBoxSpanTest : public ::testing::Test
+{
+    static constexpr std::size_t dim    = Param::dim;
+    static constexpr std::size_t interp = 1;
+
+    static constexpr PHARE::SimOpts opts{dim, interp};
+    using PHARE_Types  = PHARE::core::PHARE_Types<opts>;
+    using GridLayout_t = TestGridLayout<typename PHARE_Types::GridLayout_t>;
+    using Grid_t       = PHARE_Types::Grid_t;
+
+public:
+    GridLayout_t layout{9};
+    Grid_t dst{"rho", layout, PHARE::core::HybridQuantity::Scalar::rho, 0};
+    Grid_t src{"rho", layout, PHARE::core::HybridQuantity::Scalar::rho, 0};
+};
+
+using Permutations_t = testing::Types<TestParam<1>, TestParam<2>, TestParam<3>>;
+
+TYPED_TEST_SUITE(FieldBoxSpanTest, Permutations_t, );
+
+TYPED_TEST(FieldBoxSpanTest, test_field_box_span_nd)
+{
+    auto& layout          = this->layout;
+    auto& dst             = this->dst;
+    auto& src             = this->src;
+    auto const domain_box = layout.domainBoxFor(dst);
+
+    for (auto const& bix : domain_box)
+        src(bix) = product(bix);
+
+    auto d_span       = make_field_box_span(domain_box, dst);
+    auto const s_span = make_field_box_span(domain_box, src);
+
+    auto d_slabs    = d_span.begin();
+    auto s_slabs    = s_span.begin();
+    auto const send = s_span.end();
+    for (; s_slabs != send; ++s_slabs, ++d_slabs)
+    {
+        auto d_rows      = d_slabs.begin();
+        auto s_rows      = s_slabs.begin();
+        auto const srend = s_slabs.end();
+
+        for (; s_rows != srend; ++s_rows, ++d_rows)
+        {
+            auto& s_row = *s_rows;
+            auto& d_row = *d_rows;
+
+            for (std::size_t i = 0; i < s_row.size(); ++i)
+                d_row[i] += s_row[i];
+        }
+    }
+
+
+    for (auto const& bix : domain_box)
+    {
+        EXPECT_EQ(dst(bix), product(bix));
+    }
+
+    EXPECT_EQ(sum(dst), sum(src));
+}
+
+
+} // namespace PHARE::core
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/core/data/gridlayout/test_gridlayout.hpp
+++ b/tests/core/data/gridlayout/test_gridlayout.hpp
@@ -1,9 +1,9 @@
 #ifndef TESTS_CORE_DATA_GRIDLAYOUT_TEST_GRIDLAYOUT_HPP
 #define TESTS_CORE_DATA_GRIDLAYOUT_TEST_GRIDLAYOUT_HPP
 
+#include "core/utilities/types.hpp"
 #include "core/data/grid/gridlayout.hpp"
 #include "core/data/grid/gridlayoutimplyee.hpp"
-#include "core/utilities/types.hpp"
 
 
 template<typename GridLayout>
@@ -14,14 +14,39 @@ public:
 
     TestGridLayout() = default;
 
-    TestGridLayout(std::uint32_t const cells)
-        : GridLayout{PHARE::core::ConstArray<double, dim>(1.0 / cells),
+    TestGridLayout(double const dl, std::uint32_t const cells)
+        : GridLayout{PHARE::core::ConstArray<double, dim>(dl),
                      PHARE::core::ConstArray<std::uint32_t, dim>(cells),
                      PHARE::core::Point<double, dim>{PHARE::core::ConstArray<double, dim>(0)}}
     {
     }
 
+    TestGridLayout(std::uint32_t const cells)
+        : TestGridLayout{.1, cells}
+    {
+    }
+
+
+    TestGridLayout(std::array<double, dim> const dl, auto&&... args)
+        : GridLayout{dl, args...}
+    {
+    }
+
     auto static make(std::uint32_t cells) { return TestGridLayout{cells}; }
+    auto static make(PHARE::core::Box<int, dim> const box, double const dl = .1)
+    {
+        using namespace PHARE::core;
+
+        auto const shape = for_N_make_array<dim>(
+            [&](auto i) -> std::uint32_t { return box.upper[i] - box.lower[i] + 1; });
+
+        auto const origin
+            = for_N_make_array<dim>([&](auto i) -> double { return box.lower[i] * dl; });
+
+        return TestGridLayout{PHARE::core::ConstArray<double, dim>(dl), shape, origin, box};
+    }
 };
+
+
 
 #endif /*TESTS_CORE_DATA_GRIDLAYOUT_TEST_GRIDLAYOUT_HPP*/

--- a/tests/core/data/gridlayout/test_gridlayout.hpp
+++ b/tests/core/data/gridlayout/test_gridlayout.hpp
@@ -33,6 +33,9 @@ public:
     }
 
     auto static make(std::uint32_t cells) { return TestGridLayout{cells}; }
+
+    // builds a layout whose AMRBox is exactly `box`, for tests that need a
+    // layout not starting at the origin (e.g. a fine layout offset from a coarse one)
     auto static make(PHARE::core::Box<int, dim> const box, double const dl = .1)
     {
         using namespace PHARE::core;

--- a/tests/core/utilities/box/test_box_span.cpp
+++ b/tests/core/utilities/box/test_box_span.cpp
@@ -1,0 +1,193 @@
+
+
+#include "core/utilities/box/box.hpp"
+#include "core/utilities/box/box_span.hpp"
+#include "core/data/field/field_box_span.hpp"
+
+#include "phare_core.hpp"
+#include "phare_simulator_options.hpp"
+
+#include "tests/core/data/gridlayout/test_gridlayout.hpp"
+
+#include "gtest/gtest.h"
+#include <cstdint>
+
+
+namespace PHARE::core
+{
+
+
+
+TEST(BoxSpanTest, test_reverse_iterator)
+{
+    static constexpr std::size_t dim = 3;
+    static constexpr std::size_t IDX = dim - 1;
+    static constexpr PHARE::SimOpts opts{dim, 1};
+    using PHARE_Types  = PHARE::core::PHARE_Types<opts>;
+    using GridLayout_t = TestGridLayout<typename PHARE_Types::GridLayout_t>;
+
+    GridLayout_t layout{3};
+
+    std::vector<Point<int, dim>> points;
+
+    auto const slabs = make_box_span(layout.AMRBox());
+
+    for (auto slabit = slabs.end(); slabit-- > slabs.begin();)
+    {
+        auto const& slab = *slabit;
+        for (auto spans = slab.end(); spans-- > slab.begin();)
+        {
+            auto const&& [start, size] = *spans;
+            auto point                 = start;
+            point[IDX] += size;
+            for (; point[IDX]-- > start[IDX];)
+                points.emplace_back(point);
+        }
+    }
+
+    std::vector<Point<int, dim>> const expected{
+        {2, 2, 2}, {2, 2, 1}, {2, 2, 0}, //
+        {2, 1, 2}, {2, 1, 1}, {2, 1, 0}, //
+        {2, 0, 2}, {2, 0, 1}, {2, 0, 0}, //
+        {1, 2, 2}, {1, 2, 1}, {1, 2, 0}, //
+        {1, 1, 2}, {1, 1, 1}, {1, 1, 0}, //
+        {1, 0, 2}, {1, 0, 1}, {1, 0, 0}, //
+        {0, 2, 2}, {0, 2, 1}, {0, 2, 0}, //
+        {0, 1, 2}, {0, 1, 1}, {0, 1, 0}, //
+        {0, 0, 2}, {0, 0, 1}, {0, 0, 0},
+    };
+
+    EXPECT_EQ(expected, points);
+}
+
+
+TEST(BoxSpanTest, test_reverse_iterator_unsigned_box)
+{
+    static constexpr std::size_t dim = 3;
+    static constexpr std::size_t IDX = dim - 1;
+
+    Box<std::uint32_t, dim> const box{{0, 0, 0}, {2, 2, 2}};
+
+    std::vector<Point<std::uint32_t, dim>> points;
+
+    auto const slabs = make_box_span(box);
+
+    for (auto slabit = slabs.end(); slabit-- > slabs.begin();)
+    {
+        auto const& slab = *slabit;
+        for (auto spans = slab.end(); spans-- > slab.begin();)
+        {
+            auto const&& [start, size] = *spans;
+            auto point                 = start;
+            point[IDX] += size;
+            for (; point[IDX]-- > start[IDX];)
+                points.emplace_back(point);
+        }
+    }
+
+    std::vector<Point<std::uint32_t, dim>> const expected{
+        {2, 2, 2}, {2, 2, 1}, {2, 2, 0}, //
+        {2, 1, 2}, {2, 1, 1}, {2, 1, 0}, //
+        {2, 0, 2}, {2, 0, 1}, {2, 0, 0}, //
+        {1, 2, 2}, {1, 2, 1}, {1, 2, 0}, //
+        {1, 1, 2}, {1, 1, 1}, {1, 1, 0}, //
+        {1, 0, 2}, {1, 0, 1}, {1, 0, 0}, //
+        {0, 2, 2}, {0, 2, 1}, {0, 2, 0}, //
+        {0, 1, 2}, {0, 1, 1}, {0, 1, 0}, //
+        {0, 0, 2}, {0, 0, 1}, {0, 0, 0},
+    };
+
+    EXPECT_EQ(expected, points);
+}
+
+
+TEST(BoxSpanTest, test_range_loop)
+{
+    std::size_t static constexpr dim = 3;
+    Box<std::uint32_t, dim> box{{0, 0, 0}, {9, 9, 9}};
+    std::size_t elements = 0;
+
+    for (auto const& slab : make_box_span(box))
+        for (auto const& [start, size] : slab)
+            elements += size;
+
+    EXPECT_EQ(elements, 10 * 10 * 10);
+}
+
+
+
+TEST(BoxSpanTest, test_iter_loop_dim1)
+{
+    std::size_t static constexpr dim = 1;
+    Box<std::uint32_t, dim> box{{0}, {9}};
+    std::size_t elements = 0;
+
+    auto const& slabs = make_box_span(box);
+
+    for (auto slabit = slabs.begin(); slabit != slabs.end(); ++slabit)
+    {
+        auto const& slab = *slabit;
+
+        for (auto rowit = slab.begin(); rowit != slab.end(); ++rowit)
+        {
+            auto const& [start, size] = *rowit;
+
+            elements += size;
+        }
+    }
+
+    EXPECT_EQ(elements, 10);
+}
+
+TEST(BoxSpanTest, test_iter_loop_dim2)
+{
+    std::size_t static constexpr dim = 2;
+    Box<std::uint32_t, dim> box{{0, 0}, {9, 9}};
+    std::size_t elements = 0;
+
+    auto const& slabs = make_box_span(box);
+
+    for (auto slabit = slabs.begin(); slabit != slabs.end(); ++slabit)
+    {
+        auto const& slab = *slabit;
+
+        for (auto rowit = slab.begin(); rowit != slab.end(); ++rowit)
+        {
+            auto const& [start, size] = *rowit;
+            elements += size;
+        }
+    }
+
+    EXPECT_EQ(elements, 10 * 10);
+}
+
+TEST(BoxSpanTest, test_iter_loop_dim3)
+{
+    std::size_t static constexpr dim = 3;
+    Box<std::uint32_t, dim> box{{0, 0, 0}, {9, 9, 9}};
+    std::size_t elements = 0;
+
+    auto const& slabs = make_box_span(box);
+
+    for (auto slabit = slabs.begin(); slabit != slabs.end(); ++slabit)
+    {
+        auto const& slab = *slabit;
+
+        for (auto rowit = slab.begin(); rowit != slab.end(); ++rowit)
+        {
+            auto const& [start, size] = *rowit;
+            elements += size;
+        }
+    }
+
+    EXPECT_EQ(elements, 10 * 10 * 10);
+}
+
+} // namespace PHARE::core
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tools/bench/amr/data/field/refinement/CMakeLists.txt
+++ b/tools/bench/amr/data/field/refinement/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required (VERSION 3.20.1)
+
+project(phare_bench_field_refine)
+
+add_phare_cpp_benchmark(10 ${PROJECT_NAME} bench_field_refinement ${CMAKE_CURRENT_BINARY_DIR})
+

--- a/tools/bench/amr/data/field/refinement/bench_field_refinement.cpp
+++ b/tools/bench/amr/data/field/refinement/bench_field_refinement.cpp
@@ -1,0 +1,90 @@
+
+
+#include "core/utilities/types.hpp"
+
+#include "amr/utilities/box/amr_box.hpp"
+#include "amr/data/field/refine/field_refine_operator.hpp"
+#include "amr/data/field/refine/magnetic_field_init_refiner.hpp"
+
+#include "phare_core.hpp"
+
+#include "tests/core/data/gridlayout/test_gridlayout.hpp"
+
+#include <chrono>
+#include <limits>
+#include <cstdint>
+
+#define PRINT(x) std::cout << __FILE__ << ":" << __LINE__ << " " << x << std::endl;
+
+namespace PHARE::amr::bench
+{
+
+constexpr static auto ndim = 3;
+constexpr static auto NaN  = std::numeric_limits<double>::quiet_NaN();
+constexpr static PHARE::SimOpts opts{ndim, 1};
+
+using PHARE_Types  = core::PHARE_Types<opts>;
+using GridLayout_t = TestGridLayout<typename PHARE_Types::GridLayout_t>;
+using Grid_t       = PHARE_Types::Grid_t;
+using Refiner      = MagneticFieldInitRefiner<ndim>;
+
+
+std::uint64_t static now()
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+struct ScopeTimer
+{
+    ~ScopeTimer() { PRINT("Time: " << (now() - start) / 1e6 << " ms"); }
+
+    double div                = 1;
+    std::uint64_t const start = now();
+};
+
+int test()
+{
+    std::size_t constexpr static FOR = 100;
+
+    GridLayout_t coarse_layout{.1, 300ul};
+    GridLayout_t fine_layout = GridLayout_t::make(
+        Box<int, ndim>{core::ConstArray<int, ndim>(10), core::ConstArray<int, ndim>(590)}, .1 / 2);
+
+    SAMRAI::hier::Box const coarse_box = samrai_box_from(coarse_layout.AMRBox());
+    SAMRAI::hier::Box const fine_box   = samrai_box_from(fine_layout.AMRBox());
+    SAMRAI::hier::IntVector const ratio{SAMRAI::tbox::Dimension{ndim}, 2};
+
+    Grid_t dst{"rho", fine_layout, core::HybridQuantity::Scalar::rho, 1};
+    Grid_t const src{"rho", coarse_layout, core::HybridQuantity::Scalar::rho, 1};
+    auto const& qty = dst.physicalQuantity();
+
+    {
+        auto const dst_domain_box = fine_layout.AMRBoxFor(dst);
+        ScopeTimer timer{FOR};
+        for (std::size_t L = 0; L < FOR; ++L)
+        {
+            Refiner refiner{fine_layout.centering(qty), fine_box, coarse_box, ratio};
+            // refine_field(dst, src, fine_box, refiner);
+            //             core::FieldBox;
+            core::FieldBox d{dst, fine_layout, dst_domain_box};
+            core::FieldBox s{src, coarse_layout, coarsen_box(dst_domain_box)};
+            refine_field(d, s, refiner);
+        }
+    }
+
+    PRINT("RHO SUM: " << core::to_string_with_precision(sum(dst), 20));
+    auto const mid = dst.size() / 2;
+    return dst.data()[mid - 1] != dst.data()[mid + 1];
+}
+
+} // namespace PHARE::amr::bench
+
+int main()
+{
+    std::ios::sync_with_stdio(false);
+    auto const ret = PHARE::amr::bench::test();
+    PRINT(ret);
+    return ret;
+}

--- a/tools/bench/amr/data/field/refinement/bench_field_refinement.cpp
+++ b/tools/bench/amr/data/field/refinement/bench_field_refinement.cpp
@@ -3,8 +3,9 @@
 #include "core/utilities/types.hpp"
 
 #include "amr/utilities/box/amr_box.hpp"
-#include "amr/data/field/refine/field_refine_operator.hpp"
+#include "amr/amr_constants.hpp"
 #include "amr/data/field/refine/magnetic_field_init_refiner.hpp"
+#include "core/data/field/field_box.hpp"
 
 #include "phare_core.hpp"
 
@@ -56,27 +57,25 @@ int test()
     SAMRAI::hier::Box const fine_box   = samrai_box_from(fine_layout.AMRBox());
     SAMRAI::hier::IntVector const ratio{SAMRAI::tbox::Dimension{ndim}, 2};
 
-    Grid_t dst{"rho", fine_layout, core::HybridQuantity::Scalar::rho, 1};
-    Grid_t const src{"rho", coarse_layout, core::HybridQuantity::Scalar::rho, 1};
-    auto const& qty = dst.physicalQuantity();
+    Grid_t fine{"rho", fine_layout, core::HybridQuantity::Scalar::rho, 1};
+    Grid_t const coarse{"rho", coarse_layout, core::HybridQuantity::Scalar::rho, 1};
+    auto const& qty = fine.physicalQuantity();
 
     {
-        auto const dst_domain_box = fine_layout.AMRBoxFor(dst);
+        auto const fine_domain_box = fine_layout.AMRBoxFor(fine);
         ScopeTimer timer{FOR};
         for (std::size_t L = 0; L < FOR; ++L)
         {
             Refiner refiner{fine_layout.centering(qty), fine_box, coarse_box, ratio};
-            // refine_field(dst, src, fine_box, refiner);
-            //             core::FieldBox;
-            core::FieldBox d{dst, fine_layout, dst_domain_box};
-            core::FieldBox s{src, coarse_layout, coarsen_box(dst_domain_box)};
-            refine_field(d, s, refiner);
+            core::FieldBox f{fine, fine_layout, fine_domain_box};
+            core::FieldBox c{coarse, coarse_layout, coarsen_box(fine_domain_box)};
+            core::operator_across_adjacent_levels(c, f, refinementRatio, refiner);
         }
     }
 
-    PRINT("RHO SUM: " << core::to_string_with_precision(sum(dst), 20));
-    auto const mid = dst.size() / 2;
-    return dst.data()[mid - 1] != dst.data()[mid + 1];
+    PRINT("RHO SUM: " << core::to_string_with_precision(sum(fine), 20));
+    auto const mid = fine.size() / 2;
+    return fine.data()[mid - 1] != fine.data()[mid + 1];
 }
 
 } // namespace PHARE::amr::bench


### PR DESCRIPTION
closes #1020

it's possible we should update field equations to pass the values per index, rather than do the index lookup per operation

the [changes to field_refine_operator.hpp](https://github.com/PhilipDeegan/PHARE/blob/443f89bf116854f73a7a905ab667c2c4eab1bf0f/src/amr/data/field/refine/field_refine_operator.hpp#L50)  are somewhat complex, but hopefully the benchmark results below can justify the change.

benchmark of old field refine operator for scalar field 

```
time ./tools/bench/amr/data/field/refinement/phare_bench_field_refine_bench_field_refinement
tools/bench/amr/data/field/refinement/bench_field_refinement.cpp:41 Time: 33876.3 ms
tools/bench/amr/data/field/refinement/bench_field_refinement.cpp:76 RHO SUM: 201230056
tools/bench/amr/data/field/refinement/bench_field_refinement.cpp:87 0

real 0m34.231s
user 0m33.975s
sys  0m0.149s
```

vs  new

```
time ./tools/bench/amr/data/field/refinement/phare_bench_field_refine_bench_field_refinement
tools/bench/amr/data/field/refinement/bench_field_refinement.cpp:41 Time: 8314.03 ms
tools/bench/amr/data/field/refinement/bench_field_refinement.cpp:77 RHO SUM: 201230056
tools/bench/amr/data/field/refinement/bench_field_refinement.cpp:88 0

real 0m8.682s
user 0m8.417s
sys  0m0.165s
```

[nightly artifacts](https://hephaistos.lpp.polytechnique.fr/teamcity/buildConfiguration/Phare_Phare_Users_Phil_Build/94226?buildTab=artifacts)
