### PR TITLE
allow arbitrary vector allocators for restarts

### DIFF
--- a/src/amr/data/field/field_data.hpp
+++ b/src/amr/data/field/field_data.hpp
@@ -6,6 +6,7 @@
 #include "core/logger.hpp"
 #include "core/data/field/field_box.hpp"
 
+#include "amr/samrai.hpp" // restarts
 #include "amr/resources_manager/amr_utils.hpp"
 
 #include "field_geometry.hpp"
@@ -84,16 +85,14 @@ namespace amr
         {
             Super::getFromRestart(restart_db);
 
-            assert(field.vector().size() > 0);
-            restart_db->getDoubleArray("field_" + field.name(), field.vector().data(),
-                                       field.vector().size()); // do not reallocate!
+            getVectorFromRestart(*restart_db, "field_" + field.name(), field.vector());
         }
 
         void putToRestart(std::shared_ptr<SAMRAI::tbox::Database> const& restart_db) const override
         {
             Super::putToRestart(restart_db);
 
-            restart_db->putVector("field_" + field.name(), field.vector());
+            putVectorToRestart(*restart_db, "field_" + field.name(), field.vector());
         };
 
 

--- a/src/amr/data/particles/particles_data.hpp
+++ b/src/amr/data/particles/particles_data.hpp
@@ -8,7 +8,7 @@
 #include "core/data/particles/particle_packer.hpp"
 #include "core/data/ions/ion_population/particle_pack.hpp"
 
-#include "amr/samrai.hpp" // IWYU pragma: keep
+#include "amr/samrai.hpp"
 #include "amr/utilities/box/amr_box.hpp"
 #include "amr/resources_manager/amr_utils.hpp"
 #include <amr/data/particles/particles_variable_fill_pattern.hpp>
@@ -122,7 +122,7 @@ namespace amr
 
                 std::size_t part_idx = 0;
                 core::apply(soa.as_tuple(), [&](auto const& arg) {
-                    restart_db->putVector(name + "_" + packer.keys()[part_idx++], arg);
+                    putVectorToRestart(*restart_db, name + "_" + packer.keys()[part_idx++], arg);
                 });
             };
 
@@ -160,7 +160,8 @@ namespace amr
                 {
                     std::size_t part_idx = 0;
                     core::apply(soa.as_tuple(), [&](auto& arg) {
-                        restart_db->getVector(name + "_" + Packer::keys()[part_idx++], arg);
+                        getVectorFromRestart(*restart_db, name + "_" + Packer::keys()[part_idx++],
+                                             arg);
                     });
                 }
 
@@ -200,7 +201,7 @@ namespace amr
 
             SAMRAI::hier::Box const& sourceBox  = pSource.getBox();
             SAMRAI::hier::Box const& myGhostBox = getGhostBox();
-            const SAMRAI::hier::Box intersectionBox{sourceBox * myGhostBox};
+            SAMRAI::hier::Box const intersectionBox{sourceBox * myGhostBox};
 
             if (!intersectionBox.empty())
             {

--- a/src/amr/data/tensorfield/tensor_field_data.hpp
+++ b/src/amr/data/tensorfield/tensor_field_data.hpp
@@ -7,6 +7,7 @@
 #include "core/data/field/field_box.hpp"
 #include "core/data/tensorfield/tensorfield.hpp"
 
+#include "amr/samrai.hpp"
 #include "amr/data/field/field_geometry.hpp"
 #include "amr/resources_manager/amr_utils.hpp"
 #include "amr/data/tensorfield/tensor_field_overlap.hpp"
@@ -87,11 +88,7 @@ public:
         Super::getFromRestart(restart_db);
 
         for (std::uint16_t c = 0; c < N; ++c)
-        {
-            assert(grids[c].vector().size() > 0);
-            restart_db->getDoubleArray("field_" + grids[c].name(), grids[c].vector().data(),
-                                       grids[c].vector().size()); // do not reallocate!
-        }
+            getVectorFromRestart(*restart_db, "field_" + grids[c].name(), grids[c].vector());
     }
 
     void putToRestart(std::shared_ptr<SAMRAI::tbox::Database> const& restart_db) const override
@@ -99,7 +96,7 @@ public:
         Super::putToRestart(restart_db);
 
         for (std::uint16_t c = 0; c < N; ++c)
-            restart_db->putVector("field_" + grids[c].name(), grids[c].vector());
+            putVectorToRestart(*restart_db, "field_" + grids[c].name(), grids[c].vector());
     };
 
 

--- a/src/amr/samrai.cpp
+++ b/src/amr/samrai.cpp
@@ -1,5 +1,12 @@
+
+#include "core/def/phlop.hpp" // IWYU pragma: keep // scope timing
+#include "core/utilities/mpi_utils.hpp"
+
+#include "initializer/data_provider.hpp"
+
 #include "samrai.hpp"
 
+#include <SAMRAI/tbox/SAMRAIManager.h>
 
 namespace PHARE
 {

--- a/src/amr/samrai.hpp
+++ b/src/amr/samrai.hpp
@@ -1,17 +1,13 @@
-
 #ifndef PHARE_AMR_SAMRAI_HPP
 #define PHARE_AMR_SAMRAI_HPP
 
-#include "core/def/phlop.hpp" // scope timing
+#include "core/def/phare_mpi.hpp" // IWYU pragma: keep
+#include "core/utilities/types.hpp"
 
-#include "amr/wrappers/integrator.hpp"
-#include "core/utilities/mpi_utils.hpp"
-
-#include <SAMRAI/hier/VariableDatabase.h>
 #include <SAMRAI/tbox/RestartManager.h>
+#include <SAMRAI/hier/VariableDatabase.h>
 #include <SAMRAI/hier/PatchDataRestartManager.h>
 
-#include <memory>
 #include <iostream>
 
 namespace PHARE
@@ -49,5 +45,44 @@ public:
 
 } // namespace PHARE
 
+namespace PHARE::amr
+{
+
+
+template<typename T, typename A>
+auto& getVectorFromRestart(auto& db, auto const& path, std::vector<T, A>& vec)
+{
+    if (vec.size() == 0)
+        throw std::runtime_error("SAMRAI Restarts: vectors must be presized as expected");
+
+    if constexpr (std::is_same_v<T, double>)
+        db.getDoubleArray(path, vec.data(), vec.size());
+
+    else if constexpr (std::is_same_v<T, int>)
+        db.getIntegerArray(path, vec.data(), vec.size());
+
+    else
+        static_assert(core::dependent_false_v<T>,
+                      "SAMRAI getFromRestart Vector not supported, add it!");
+
+    return vec;
+};
+
+template<typename T, typename A>
+void putVectorToRestart(auto& db, auto const& path, std::vector<T, A> const& vec)
+{
+    if constexpr (std::is_same_v<T, double>)
+        db.putDoubleArray(path, vec.data(), vec.size());
+
+    else if constexpr (std::is_same_v<T, int>)
+        db.putIntegerArray(path, vec.data(), vec.size());
+
+    else
+        static_assert(core::dependent_false_v<T>,
+                      "SAMRAI putToRestart Vector not supported, add it!");
+};
+
+
+} // namespace PHARE::amr
 
 #endif /*PHARE_AMR_SAMRAI_HPP*/

--- a/src/core/utilities/types.hpp
+++ b/src/core/utilities/types.hpp
@@ -30,6 +30,8 @@ namespace core
     enum class Basis { Magnetic, Cartesian };
 
 
+    template<typename>
+    inline constexpr bool dependent_false_v = false;
 
 
     template<typename T>


### PR DESCRIPTION
samrai restart `putVector` style functions only support vectors with the default standard allocator

we could ask samrai folks to allow for other allocators, but that might never even happen