### PR TITLE
allow serial and parallel tests at the same time

### DIFF
--- a/tests/diagnostic/job_1d.py.in
+++ b/tests/diagnostic/job_1d.py.in
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 import pyphare.pharein as ph
-
 from tests.diagnostic import dump_all_diags
 from tests.simulator import basicSimulatorArgs, makeBasicModel
 
-out = "phare_outputs/diags_1d/"
+from pyphare import cpp  # concurrent serial vs parallel tests
+
+out = f"phare_outputs/diags_1d/{cpp.mpi_size()}"
 simInput = {
     "diag_options": {"format": "phareh5", "options": {"dir": out, "mode": "overwrite"}}
 }

--- a/tests/diagnostic/job_2d.py.in
+++ b/tests/diagnostic/job_2d.py.in
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 import pyphare.pharein as ph
-
 from tests.diagnostic import dump_all_diags
 from tests.simulator import basicSimulatorArgs, makeBasicModel
 
-out = "phare_outputs/diags_2d/"
+from pyphare import cpp  # concurrent serial vs parallel tests
+
+out = f"phare_outputs/diags_2d/{cpp.mpi_size()}"
 simInput = {
     "diag_options": {"format": "phareh5", "options": {"dir": out, "mode": "overwrite"}}
 }

--- a/tests/diagnostic/test-diagnostics_1d.cpp
+++ b/tests/diagnostic/test-diagnostics_1d.cpp
@@ -4,7 +4,7 @@
 #include "test_diagnostics.ipp"
 
 static std::string const job_file = "job_1d";
-static std::string const out_dir  = "phare_outputs/diags_1d/";
+static std::string out_dir        = "phare_outputs/diags_1d/";
 
 TYPED_TEST(Simulator1dTest, fluid)
 {
@@ -31,5 +31,6 @@ int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     PHARE::SamraiLifeCycle samsam(argc, argv);
+    out_dir += std::to_string(core::mpi::size()) + "/"; // concurrent tests
     return RUN_ALL_TESTS();
 }

--- a/tests/diagnostic/test-diagnostics_2d.cpp
+++ b/tests/diagnostic/test-diagnostics_2d.cpp
@@ -4,7 +4,7 @@
 #include "test_diagnostics.ipp"
 
 static std::string const job_file = "job_2d";
-static std::string const out_dir  = "phare_outputs/diags_2d/";
+static std::string out_dir        = "phare_outputs/diags_2d/";
 
 TYPED_TEST(Simulator2dTest, fluid)
 {
@@ -31,5 +31,6 @@ int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     PHARE::SamraiLifeCycle samsam(argc, argv);
+    out_dir += std::to_string(core::mpi::size()) + "/"; // concurrent tests
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
configure diag output directories with mpi::size so we can run serial and parallel tests at the same time

we do this in python already but never changed this