### PR TITLE
python3 Vtk hierarchies

### DIFF
--- a/pyphare/pyphare/core/operators.py
+++ b/pyphare/pyphare/core/operators.py
@@ -2,60 +2,47 @@ import numpy as np
 
 from pyphare.pharesee.hierarchy import ScalarField, VectorField
 from pyphare.pharesee.hierarchy.hierarchy_utils import compute_hier_from
-from pyphare.pharesee.hierarchy.hierarchy_utils import rename
 
 
-def _compute_dot_product(patch_datas, **kwargs):
-    ref_name = next(iter(patch_datas.keys()))
-
+def _compute_dot_product(patch0, accessor, operand, **kwargs):
+    patch1 = operand[accessor]
+    ref_name = next(iter(patch0.patch_datas.keys()))
     dset = (
-        patch_datas["left_x"][:] * patch_datas["right_x"][:]
-        + patch_datas["left_y"][:] * patch_datas["right_y"][:]
-        + patch_datas["left_z"][:] * patch_datas["right_z"][:]
+        patch0["x"][:] * patch1["x"][:]
+        + patch0["y"][:] * patch1["y"][:]
+        + patch0["z"][:] * patch1["z"][:]
     )
+
+    return (patch0[ref_name].copy_as(dset, name="value"),)
+
+
+def _compute_sqrt(patch, **kwargs):
+    ref_name = next(iter(patch.patch_datas.keys()))
+
+    dset = np.sqrt(patch["value"][:])
+
+    return (patch[ref_name].copy_as(dset, name="value"),)
+
+
+def _compute_cross_product(patch0, accessor, operand, **kwargs):
+    patch1 = operand[accessor]
+    ref_name = next(iter(patch0.patch_datas.keys()))
+
+    dset_x = patch0["y"][:] * patch1["z"][:] - patch0["z"][:] * patch1["y"][:]
+    dset_y = patch0["z"][:] * patch1["x"][:] - patch0["x"][:] * patch1["z"][:]
+    dset_z = patch0["x"][:] * patch1["y"][:] - patch0["y"][:] * patch1["x"][:]
 
     return (
-        {"name": "value", "data": dset, "centering": patch_datas[ref_name].centerings},
+        patch0[ref_name].copy_as(dset_x, name="x"),
+        patch0[ref_name].copy_as(dset_y, name="y"),
+        patch0[ref_name].copy_as(dset_z, name="z"),
     )
 
 
-def _compute_sqrt(patch_datas, **kwargs):
-    ref_name = next(iter(patch_datas.keys()))
-
-    dset = np.sqrt(patch_datas["value"][:])
-
-    return (
-        {"name": "value", "data": dset, "centering": patch_datas[ref_name].centerings},
-    )
-
-
-def _compute_cross_product(patch_datas, **kwargs):
-    ref_name = next(iter(patch_datas.keys()))
-
-    dset_x = (
-        patch_datas["left_y"][:] * patch_datas["right_z"][:]
-        - patch_datas["left_z"][:] * patch_datas["right_y"][:]
-    )
-    dset_y = (
-        patch_datas["left_z"][:] * patch_datas["right_x"][:]
-        - patch_datas["left_x"][:] * patch_datas["right_z"][:]
-    )
-    dset_z = (
-        patch_datas["left_x"][:] * patch_datas["right_y"][:]
-        - patch_datas["left_y"][:] * patch_datas["right_x"][:]
-    )
-
-    return (
-        {"name": "x", "data": dset_x, "centering": patch_datas[ref_name].centerings},
-        {"name": "y", "data": dset_y, "centering": patch_datas[ref_name].centerings},
-        {"name": "z", "data": dset_z, "centering": patch_datas[ref_name].centerings},
-    )
-
-
-def _compute_grad(patch_data, **kwargs):
-    ndim = patch_data["value"].box.ndim
+def _compute_grad(patch, **kwargs):
+    ndim = patch["value"].box.ndim
     nb_ghosts = kwargs["nb_ghosts"]
-    ds = patch_data["value"].dataset
+    ds = patch["value"].dataset
 
     ds_shape = list(ds.shape)
 
@@ -74,57 +61,28 @@ def _compute_grad(patch_data, **kwargs):
         raise RuntimeError("dimension not yet implemented")
 
     return (
-        {"name": "x", "data": ds_x, "centering": patch_data["value"].centerings},
-        {"name": "y", "data": ds_y, "centering": patch_data["value"].centerings},
-        {"name": "z", "data": ds_z, "centering": patch_data["value"].centerings},
+        patch["value"].copy_as(ds_x, name="x"),
+        patch["value"].copy_as(ds_y, name="y"),
+        patch["value"].copy_as(ds_z, name="z"),
     )
 
 
-def dot(hier_left, hier_right, **kwargs):
-    if isinstance(hier_left, VectorField) and isinstance(hier_right, VectorField):
-        names_left = ["left_x", "left_y", "left_z"]
-        names_right = ["right_x", "right_y", "right_z"]
-
-    else:
+def dot(hier0, hier1, **kwargs):
+    if not all(isinstance(hier, VectorField) for hier in [hier0, hier1]):
         raise RuntimeError("type of hierarchy not yet considered")
 
-    hl = rename(hier_left, names_left)
-    hr = rename(hier_right, names_right)
-
-    h = compute_hier_from(
-        _compute_dot_product,
-        (hl, hr),
-    )
-
-    return ScalarField(h)
+    return ScalarField(compute_hier_from(_compute_dot_product, hier0, operand=hier1))
 
 
-def cross(hier_left, hier_right, **kwargs):
-    if isinstance(hier_left, VectorField) and isinstance(hier_right, VectorField):
-        names_left = ["left_x", "left_y", "left_z"]
-        names_right = ["right_x", "right_y", "right_z"]
-
-    else:
+def cross(hier0, hier1, **kwargs):
+    if not all(isinstance(hier, VectorField) for hier in [hier0, hier1]):
         raise RuntimeError("type of hierarchy not yet considered")
 
-    hl = rename(hier_left, names_left)
-    hr = rename(hier_right, names_right)
-
-    h = compute_hier_from(
-        _compute_cross_product,
-        (hl, hr),
-    )
-
-    return VectorField(h)
+    return VectorField(compute_hier_from(_compute_cross_product, hier0, operand=hier1))
 
 
 def sqrt(hier, **kwargs):
-    h = compute_hier_from(
-        _compute_sqrt,
-        hier,
-    )
-
-    return ScalarField(h)
+    return ScalarField(compute_hier_from(_compute_sqrt, hier))
 
 
 def modulus(hier):

--- a/pyphare/pyphare/core/phare_utilities.py
+++ b/pyphare/pyphare/core/phare_utilities.py
@@ -122,6 +122,18 @@ class FloatingPoint_comparator:
         return fp_gtr_equal(self.fp, other.fp, self.atol)
 
 
+class EqualityCheck:
+    def __init__(self, eq, msg=""):
+        self.eq = eq
+        self.msg = msg
+
+    def __bool__(self):
+        return self.eq
+
+    def __repr__(self):
+        return self.msg
+
+
 def is_fp32(item):
     if is_nd_array(item):
         return item.dtype == np.single

--- a/pyphare/pyphare/pharesee/geometry.py
+++ b/pyphare/pyphare/pharesee/geometry.py
@@ -23,7 +23,7 @@ def toFieldBox(box, patch_data):
 
     directions = ["X", "Y", "Z"][: box.ndim]  # drop unused directions
     for i, direction in enumerate(directions):
-        if patch_data.layout.centering[direction][patch_data.field_name] == "primal":
+        if patch_data.layout.centering[direction][patch_data.name] == "primal":
             box.upper[i] = box.upper[i] + 1
 
     return box

--- a/pyphare/pyphare/pharesee/hierarchy/__init__.py
+++ b/pyphare/pyphare/pharesee/hierarchy/__init__.py
@@ -29,6 +29,7 @@ def hierarchy_from(
     from .fromh5 import hierarchy_fromh5
     from .fromsim import hierarchy_from_sim
     from .fromfunc import hierarchy_from_func
+    from .fromvtkhdf5 import hierarchy_fromvtkhdf
 
     """
     this function reads an HDF5 PHARE file and returns a PatchHierarchy from
@@ -48,7 +49,11 @@ def hierarchy_from(
         raise ValueError("cannot pass both a simulator and a h5 file")
 
     if h5_filename is not None:
-        return hierarchy_fromh5(h5_filename, times, hier, **kwargs)
+        if h5_filename.endswith(".h5"):
+            return hierarchy_fromh5(h5_filename, times, hier, **kwargs)
+        if h5_filename.endswith(".vtkhdf"):
+            return hierarchy_fromvtkhdf(h5_filename, times, hier, **kwargs)
+        raise RuntimeError(f"Unknown h5 file type: {h5_filename}")
     if simulator is not None and qty is not None:
         return hierarchy_from_sim(simulator, qty, pop=pop)
 
@@ -59,9 +64,15 @@ def hierarchy_from(
 
 
 def all_times_from(h5_filename):
-    from .fromh5 import get_times_from_h5
+    if h5_filename.endswith(".h5"):
+        from .fromh5 import get_times_from_h5
 
-    return get_times_from_h5(h5_filename)
+        return get_times_from_h5(h5_filename)
+    if h5_filename.endswith(".vtkhdf"):
+        from .fromvtkhdf5 import get_times_from_h5
+
+        return get_times_from_h5(h5_filename)
+    raise RuntimeError(f"Unknown h5 file type: {h5_filename}")
 
 
 def default_time_from(h5_filename):

--- a/pyphare/pyphare/pharesee/hierarchy/__init__.py
+++ b/pyphare/pyphare/pharesee/hierarchy/__init__.py
@@ -1,7 +1,13 @@
+#
+#
+#
+
 from .scalarfield import ScalarField
 from .vectorfield import VectorField
 from .hierarchy import PatchHierarchy
-from pyphare.core.phare_utilities import listify
+
+
+from pyphare.core import phare_utilities as phut
 
 __all__ = [
     "ScalarField",
@@ -11,7 +17,14 @@ __all__ = [
 
 
 def hierarchy_from(
-    simulator=None, qty=None, pop="", h5_filename=None, times=None, hier=None, func=None, **kwargs
+    simulator=None,
+    qty=None,
+    pop="",
+    h5_filename=None,
+    times=None,
+    hier=None,
+    func=None,
+    **kwargs,
 ):
     from .fromh5 import hierarchy_fromh5
     from .fromsim import hierarchy_from_sim
@@ -29,14 +42,13 @@ def hierarchy_from(
     """
 
     if times is not None:
-        times = listify(times)
+        times = phut.listify(times)
 
     if simulator is not None and h5_filename is not None:
         raise ValueError("cannot pass both a simulator and a h5 file")
 
     if h5_filename is not None:
         return hierarchy_fromh5(h5_filename, times, hier, **kwargs)
-
     if simulator is not None and qty is not None:
         return hierarchy_from_sim(simulator, qty, pop=pop)
 
@@ -44,3 +56,13 @@ def hierarchy_from(
         return hierarchy_from_func(func, hier, **kwargs)
 
     raise ValueError("can't make hierarchy")
+
+
+def all_times_from(h5_filename):
+    from .fromh5 import get_times_from_h5
+
+    return get_times_from_h5(h5_filename)
+
+
+def default_time_from(h5_filename):
+    return all_times_from(h5_filename)[0]

--- a/pyphare/pyphare/pharesee/hierarchy/for_vtk/__init__.py
+++ b/pyphare/pyphare/pharesee/hierarchy/for_vtk/__init__.py
@@ -1,0 +1,2 @@
+# do not make a python file or module called "vtk"
+#  this might interfere the actual vtk module

--- a/pyphare/pyphare/pharesee/hierarchy/for_vtk/patchdata.py
+++ b/pyphare/pyphare/pharesee/hierarchy/for_vtk/patchdata.py
@@ -1,0 +1,81 @@
+#
+#
+#
+
+
+import pyphare.core.box as boxm
+from pyphare.pharesee.hierarchy import patchdata
+from pyphare.core import phare_utilities as phut
+
+
+class VtkFieldDatasetAccessor:
+    def __init__(self, dataset, cmp_idx, offset, box):
+        self.box = box
+        self.cmp_idx = cmp_idx
+        self.offset = offset
+        self.dataset = dataset
+
+    def __getitem__(self, item):
+        full = self.dataset[
+            self.offset : self.offset + self.box.size(), self.cmp_idx
+        ].reshape(self.box.shape, order="F")
+        if isinstance(item, slice) and item == slice(None):
+            return full
+        return full[item]
+
+    @property
+    def shape(self):
+        return self.box.shape
+
+
+class VtkFieldData(patchdata.FieldData):
+    def __init__(self, layout, name, data, cmp_idx, offset, **kwargs):
+        import h5py
+
+        data_t = type(data)
+        if not (data_t is h5py.Dataset or data_t is VtkFieldDatasetAccessor):
+            raise RuntimeError("VtkFieldData only handles vtkhdf datasets")
+
+        box = layout.box
+        self.field_box = boxm.Box(box.lower, box.upper + 1)
+        kwargs["ghosts_nbr"] = [0] * layout.box.ndim
+        kwargs["centering"] = ["primal"] * layout.box.ndim
+        data = (
+            data
+            if data_t is VtkFieldDatasetAccessor
+            else VtkFieldDatasetAccessor(data, cmp_idx, offset, self.field_box)
+        )
+        super().__init__(layout, name, data, **kwargs)
+
+    def compare(self, that, atol=1e-16):
+        """VTK Diagnostics do not have ghosts values!"""
+
+        try:
+            that_data = (
+                that[:]
+                if all([that.dataset.shape == self.dataset.shape])
+                else that[that.box]
+            )
+            phut.assert_fp_any_all_close(self.dataset[:], that_data, atol=atol)
+            return True
+        except AssertionError as e:
+            return phut.EqualityCheck(False, str(e))
+
+    def __eq__(self, that):
+        return self.compare(that)
+
+    def __deepcopy__(self, memo):
+        no_copy_keys = ["dataset"]  # do not copy these things
+        cpy = phut.deep_copy(self, memo, no_copy_keys)
+        cpy.dataset = self.dataset
+        return cpy
+
+    def copy_as(self, data=None, **kwargs):
+        data = self.dataset if data is None else data
+        if type(data) is VtkFieldDatasetAccessor:
+            name = kwargs.pop("name", self.name)
+            return type(self)(
+                self.layout, name, data, data.cmp_idx, data.offset, **kwargs
+            )
+        # make a normal FieldData
+        return super().copy_as(data, **kwargs)

--- a/pyphare/pyphare/pharesee/hierarchy/fromfunc.py
+++ b/pyphare/pyphare/pharesee/hierarchy/fromfunc.py
@@ -1,31 +1,35 @@
-from pyphare.pharesee.hierarchy.hierarchy_utils import compute_hier_from
+#
+#
+#
 
 import numpy as np
 
+from pyphare.pharesee.hierarchy.hierarchy_utils import compute_hier_from
+
 
 def ions_mass_density_func1d(x, **kwargs):
-    masses = kwargs["masses"]       # list of float : the ion pop masses
-    densities = kwargs["densities"] # list of callable : the ion pop density profiles
+    masses = kwargs["masses"]  # list of float : the ion pop masses
+    densities = kwargs["densities"]  # list of callable : the ion pop density profiles
 
     assert len(masses) == len(densities)
-    funcs  = np.zeros((x.size, len(masses)))
+    funcs = np.zeros((x.size, len(masses)))
 
     for i, (mass, density) in enumerate(zip(masses, densities)):
-        funcs[:,i] = mass*density(x)
+        funcs[:, i] = mass * density(x)
 
     return funcs.sum(axis=1)
 
 
 def ions_charge_density_func1d(x, **kwargs):
-    charges = kwargs["charges"]     # list of float : the ion pop charges
-    densities = kwargs["densities"] # list of callable : the ion pop density profiles
+    charges = kwargs["charges"]  # list of float : the ion pop charges
+    densities = kwargs["densities"]  # list of callable : the ion pop density profiles
 
     assert len(charges) == len(densities)
 
-    funcs  = np.zeros((x.size, len(charges)))
+    funcs = np.zeros((x.size, len(charges)))
 
     for i, (charge, density) in enumerate(zip(charges, densities)):
-        funcs[:,i] = charge*density(x)
+        funcs[:, i] = charge * density(x)
 
     return funcs.sum(axis=1)
 
@@ -33,43 +37,45 @@ def ions_charge_density_func1d(x, **kwargs):
 def hierarchy_from_func1d(func, hier, **kwargs):
     assert hier.ndim == 1
 
-    def compute_(patch_datas, **kwargs):
-        ref_name = next(iter(patch_datas.keys()))
-        x_ = patch_datas[ref_name].x
+    def compute_(patch, **kwargs):
+        ref_name = next(iter(patch.patch_datas.keys()))
+        x_ = patch[ref_name].x
 
-        return (
-            {"name": "value", "data": func(x_, **kwargs), "centering": patch_datas[ref_name].centerings},
+        new_patch_data = patch[ref_name].copy_as(
+            func(x_, **kwargs), name="value", ghosts_nbr=patch[ref_name].ghosts_nbr
         )
+
+        return (new_patch_data,)
 
     return compute_hier_from(compute_, hier, **kwargs)
 
 
 def ions_mass_density_func2d(x, y, **kwargs):
-    masses = kwargs["masses"]       # list of float : the ion pop masses
-    densities = kwargs["densities"] # list of callable : the ion pop density profiles
+    masses = kwargs["masses"]  # list of float : the ion pop masses
+    densities = kwargs["densities"]  # list of callable : the ion pop density profiles
 
     yv, xv = np.meshgrid(y, x)
 
     assert len(masses) == len(densities)
-    funcs  = np.zeros((x.size, y.size, len(masses)))
+    funcs = np.zeros((x.size, y.size, len(masses)))
 
     for i, (mass, density) in enumerate(zip(masses, densities)):
-        funcs[:,:,i] = mass*density(xv, yv)
+        funcs[:, :, i] = mass * density(xv, yv)
 
     return funcs.sum(axis=2)
 
 
 def ions_charge_density_func2d(x, y, **kwargs):
-    charges = kwargs["charges"]     # list of float : the ion pop charges
-    densities = kwargs["densities"] # list of callable : the ion pop density profiles
+    charges = kwargs["charges"]  # list of float : the ion pop charges
+    densities = kwargs["densities"]  # list of callable : the ion pop density profiles
 
     yv, xv = np.meshgrid(y, x)
 
     assert len(charges) == len(densities)
-    funcs  = np.zeros((x.size, y.size, len(charges)))
+    funcs = np.zeros((x.size, y.size, len(charges)))
 
     for i, (charge, density) in enumerate(zip(charges, densities)):
-        funcs[:,:,i] = charge*density(xv, yv)
+        funcs[:, :, i] = charge * density(xv, yv)
 
     return funcs.sum(axis=2)
 
@@ -77,14 +83,16 @@ def ions_charge_density_func2d(x, y, **kwargs):
 def hierarchy_from_func2d(func, hier, **kwargs):
     assert hier.ndim == 2
 
-    def compute_(patch_datas, **kwargs):
-        ref_name = next(iter(patch_datas.keys()))
-        x_ = patch_datas[ref_name].x
-        y_ = patch_datas[ref_name].y
+    def compute_(patch, **kwargs):
+        ref_name = next(iter(patch.patch_datas.keys()))
+        x_ = patch[ref_name].x
+        y_ = patch[ref_name].y
 
-        return (
-            {"name": "value", "data": func(x_, y_, **kwargs), "centering": patch_datas[ref_name].centerings},
+        new_patch_data = patch[ref_name].copy_as(
+            func(x_, y_, **kwargs), name="value", ghosts_nbr=patch[ref_name].ghosts_nbr
         )
+
+        return (new_patch_data,)
 
     return compute_hier_from(compute_, hier, **kwargs)
 
@@ -94,4 +102,3 @@ def hierarchy_from_func(func, hier, **kwargs):
         return hierarchy_from_func1d(func, hier, **kwargs)
     if hier.ndim == 2:
         return hierarchy_from_func2d(func, hier, **kwargs)
-

--- a/pyphare/pyphare/pharesee/hierarchy/fromh5.py
+++ b/pyphare/pyphare/pharesee/hierarchy/fromh5.py
@@ -131,7 +131,7 @@ def add_to_patchdata(patch_datas, h5_patch_grp, basename, interp_order, lvl_cell
             if is_pop_fluid_file(basename):
                 pdata_name = pop_name(basename) + "_" + pdata_name
 
-            if dataset_name in patch_datas:
+            if pdata_name in patch_datas:
                 raise ValueError("error - {} already in patchdata".format(dataset_name))
 
             patch_datas[pdata_name] = pdata
@@ -151,13 +151,11 @@ def h5_filename_from(diagInfo):
 def get_times_from_h5(filepath, as_float=True):
     import h5py  # see doc/conventions.md section 2.1.1
 
-    f = h5py.File(filepath, "r")
-    if as_float:
-        times = np.array(sorted([float(s) for s in list(f[h5_time_grp_key].keys())]))
-    else:
+    with h5py.File(filepath, "r") as f:
         times = list(f[h5_time_grp_key].keys())
-    f.close()
-    return times
+        if as_float:
+            times = np.array(sorted([float(s) for s in times]))
+        return times
 
 
 def create_from_all_times(time, hier):

--- a/pyphare/pyphare/pharesee/hierarchy/fromvtkhdf5.py
+++ b/pyphare/pyphare/pharesee/hierarchy/fromvtkhdf5.py
@@ -1,0 +1,435 @@
+import numpy as np
+from pathlib import Path
+
+from .patch import Patch
+from ...core.box import Box
+from .patchlevel import PatchLevel
+from .hierarchy import PatchHierarchy
+from .hierarchy import format_timestamp
+from .hierarchy_utils import field_qties
+from ...core.gridlayout import GridLayout
+from ...core import phare_utilities as phut
+from pyphare.core.phare_utilities import listify
+from .for_vtk.patchdata import VtkFieldData as FieldData
+
+
+base_path = "VTKHDF"
+level_base_path = base_path + "/Level"
+step_level_path = base_path + "/Steps/Level"
+h5_time_ds_path = "/VTKHDF/Steps/Values"
+
+_suffixes_per_ncols = {
+    1: [""],
+    3: ["_x", "_y", "_z"],
+    6: ["_xx", "_xy", "_xz", "_yy", "_yz", "_zz"],
+}
+
+
+def get_path_from(h5file, string):
+    keys = [v for v in string.split("/") if v]
+    node = h5file
+    for key in keys:
+        node = node[key]
+    return node
+
+
+class VtkFile:
+    def __init__(self, path):
+        if not Path(path).exists():
+            raise ValueError(f"ERROR: VTKHDF file does not exist: {path}")
+
+        import h5py  # see doc/conventions.md section 2.1.1
+
+        self.filepath = path
+        self.file = h5py.File(path, "r")
+        self._times = None
+        self._domain_box = None
+        self._level_spacing = {}
+
+    def level_spacing(self, ilvl=0):
+        if ilvl in self._level_spacing:
+            return self._level_spacing[ilvl]
+        level_group = self._get_path_from(level_base_path + str(ilvl))
+        self._level_spacing[ilvl] = level_group.attrs["Spacing"][:]
+        return self._level_spacing[ilvl]
+
+    def level_boxes(self, ilvl=0, time=0):
+        dim = self.dimension
+        time_idx = self.time_idx(time)
+        num_boxes = self._get_path_from(
+            step_level_path + str(ilvl) + "/NumberOfAMRBox"
+        )[time_idx]
+        box_offset = self._get_path_from(step_level_path + str(ilvl) + "/AMRBoxOffset")[
+            time_idx
+        ]
+        amr_box_ds = self._get_path_from(level_base_path + str(ilvl) + "/AMRBox")
+        boxes = [0] * num_boxes
+
+        for bi, boff in enumerate(range(box_offset, box_offset + num_boxes)):
+            box_vals = amr_box_ds[boff]
+            lo = np.zeros(dim)
+            up = np.zeros(dim)
+            for i, di in enumerate(range(0, dim * 2, 2)):
+                lo[i] = box_vals[di + 0]
+                up[i] = box_vals[di + 1]
+            boxes[bi] = Box(lo, up)
+        return boxes
+
+    def max_num_levels(self):
+        n = 0
+        for i in range(11):
+            if f"Level{i}" not in self.file["VTKHDF"]:
+                break
+            n += 1
+        return n
+
+    def time_idx(self, time):
+        ret = np.where(np.isclose(self.times(), float(time), 1e-10))
+        return ret[0][0]  # can throw if time is not found
+
+    def _amr_box_offset(self, ilvl, time_idx):
+        return self.file["VTKHDF"]["Steps"][f"Level{ilvl}"]["AMRBoxOffset"][time_idx]
+
+    def _num_boxes(self, ilvl, time_idx):
+        return self.file["VTKHDF"]["Steps"][f"Level{ilvl}"]["NumberOfAMRBox"][time_idx]
+
+    def _data_offset(self, ilvl, time_idx):
+        return self.file["VTKHDF"]["Steps"][f"Level{ilvl}"]["PointDataOffset"]["data"][
+            time_idx
+        ]
+
+    def _data_set(self, ilvl):
+        return self.file["VTKHDF"][f"Level{ilvl}"]["PointData"]["data"]
+
+    @property
+    def dimension(self):
+        return self.file.attrs["dimension"]
+
+    @property
+    def interp_order(self):
+        return self.file.attrs["interpOrder"]
+
+    @property
+    def domain_box(self):
+        if self._domain_box is None:
+            dbox_attr = self.file.attrs["domain_box"]
+            self._domain_box = Box([0] * len(dbox_attr), dbox_attr)
+        return self._domain_box
+
+    def has_time(self, time):
+        try:
+            return self.time_idx(time) is not None
+        except IndexError:
+            ...  # expected if time doesn't exist
+        return False
+
+    def times(self, reset=False):
+        if reset:
+            self._times = None
+        if self._times is None:
+            self._times = self._get_path_from(h5_time_ds_path)[:]
+        return self._times
+
+    def _get_path_from(self, string):
+        return get_path_from(self.file, string)
+
+
+class VtkPatchLevelInfo:
+    def __init__(self, vtk_file, ilvl, time_idx):
+        self.vtk_file = vtk_file
+        self.ilvl = ilvl
+        self.time_idx = time_idx
+        self.num_boxes = vtk_file._num_boxes(ilvl, self.time_idx)
+        self.data_offset = vtk_file._data_offset(ilvl, self.time_idx)
+        self.box_offset = vtk_file._amr_box_offset(ilvl, self.time_idx)
+        self.rolling_data_offset = self.data_offset
+
+    def boxes(self):
+        dim = self.vtk_file.dimension
+        amr_box_ds = self.vtk_file.file["VTKHDF"][f"Level{self.ilvl}"]["AMRBox"]
+        box_vals_list = amr_box_ds[self.box_offset : self.box_offset + self.num_boxes]
+        boxes = [0] * self.num_boxes
+        for bi in range(self.num_boxes):
+            lo = np.zeros(dim)
+            up = np.zeros(dim)
+            box_vals = box_vals_list[bi]
+            for i, di in enumerate(range(0, dim * 2, 2)):
+                lo[i] = box_vals[di + 0]
+                up[i] = box_vals[di + 1]
+            boxes[bi] = Box(lo, up)
+        return boxes
+
+    def __deepcopy__(self, memo):
+        no_copy_keys = ["vtk_file"]  # do not copy these things
+        cpy = phut.deep_copy(self, memo, no_copy_keys)
+        cpy.vtk_file = self.vtk_file
+        return cpy
+
+
+def get_all_available_quantities_from_h5(filepath, time=0, exclude=None, hier=None):
+    if exclude is None:
+        exclude = ["tags"]
+    time = format_timestamp(time)
+    path = Path(filepath)
+    for h5 in path.glob("*.vtkhdf"):
+        if h5.parent == path and h5.stem not in exclude:
+            hier = hierarchy_fromvtkhdf(str(h5), time, hier)
+    return hier
+
+
+def make_layout(box, origin, cell_width, interp_order):
+    ghosts_nbr = [0] * box.ndim
+    return GridLayout(
+        box, origin, cell_width, interp_order=interp_order, ghosts_nbr=ghosts_nbr
+    )
+
+
+def is_pop_fluid_file(basename):
+    return (is_particle_file(basename) is False) and "pop" in basename
+
+
+def is_particle_file(filename):
+    return False
+
+
+def pop_name(basename):
+    return basename.split("_")[2]
+
+
+def qty_from_basename(basename):
+    if basename.startswith("ions_pop_"):
+        return "_".join(basename.split("_")[3:])
+    if basename.startswith("ions_"):
+        return basename[len("ions_") :]
+    return basename
+
+
+def add_to_patchdata(vtk_file, lvl_info, patch_idx, patch_datas, basename, layout):
+    """
+    adds data in the h5_patch_grp in the given PatchData dict
+    returns True if valid h5 patch found
+    """
+
+    if is_particle_file(basename):
+        raise RuntimeError("Particle diagnostics are not supported under vtkhdf")
+
+    X_TIMES = [4, 2, 1][vtk_file.dimension - 1]  # data in file is sometimes duplicated
+    dataset = vtk_file._data_set(lvl_info.ilvl)
+    ncols = dataset.shape[1]  # decides if scalar/tensor
+
+    if ncols not in _suffixes_per_ncols:
+        raise RuntimeError(f"unsupported dataset column count {ncols} in {basename}")
+
+    qty = qty_from_basename(basename)
+    data_size = 0
+
+    for cmp_id, suffix in enumerate(_suffixes_per_ncols[ncols]):
+        ds_name = qty + suffix
+        if ds_name not in field_qties:
+            raise RuntimeError(
+                "invalid dataset name : {} is not in {}".format(ds_name, field_qties)
+            )
+        pdata_name = field_qties[ds_name]
+        pdata = FieldData(
+            layout,
+            pdata_name,
+            dataset,
+            cmp_id,
+            lvl_info.rolling_data_offset,
+        )
+        if is_pop_fluid_file(basename):
+            pdata_name = pop_name(basename) + "_" + pdata_name
+        if pdata_name in patch_datas:
+            raise ValueError("error - {} already in patchdata".format(ds_name))
+        patch_datas[pdata_name] = pdata
+        data_size = pdata.field_box.size()  # constant across components
+
+    lvl_info.rolling_data_offset += data_size * X_TIMES
+    return True  # valid patch assumed
+
+
+def patch_has_datasets(h5_patch_grp):
+    return len(h5_patch_grp.keys()) > 0
+
+
+def h5_filename_from(diagInfo):
+    # diagInfo.quantity starts with a / , hence   [1:]
+    return (diagInfo.quantity + ".vtkhdf").replace("/", "_")[1:]
+
+
+def get_times_from_h5(filepath, as_float=True):
+    import h5py  # see doc/conventions.md section 2.1.1
+
+    with h5py.File(filepath, "r") as f:
+        ds = get_path_from(f, h5_time_ds_path)
+        times = list(ds[:])
+        if as_float:
+            times = np.array(sorted([float(s) for s in times]))
+        return times
+
+
+def create_from_all_times(time, hier):
+    return time is None and hier is None
+
+
+def create_from_times(times, hier):
+    return times is not None and hier is None
+
+
+def load_all_times(time, hier):
+    return time is None and hier is not None
+
+
+def load_one_time(time, hier):
+    return time is not None and hier is not None
+
+
+def patch_levels_from_h5(vtk_file, time, selection_box=None):
+    """
+    creates a dictionary of PatchLevels from a given time in a h5 file
+    {ilvl: PatchLevel}
+    """
+
+    interp_order = vtk_file.interp_order
+    basename = Path(vtk_file.file.filename).stem
+
+    patch_levels = {}
+    h5_patch = ""  # todo
+    time_idx = vtk_file.time_idx(time)
+    for ilvl in range(vtk_file.max_num_levels()):
+        lvl_cell_width = vtk_file.level_spacing(ilvl)
+        vtk_patch_level_info = VtkPatchLevelInfo(vtk_file, ilvl, time_idx)
+
+        patches = []
+
+        for ipatch, patch_box in enumerate(vtk_patch_level_info.boxes()):
+            origin = patch_box.lower * vtk_file.level_spacing(ilvl)
+
+            intersect = None
+            if selection_box is not None:
+                pos_upper = [
+                    orig + shape * dl
+                    for orig, shape, dl in zip(origin, patch_box.shape, lvl_cell_width)
+                ]
+                pos_patch_box = Box(origin, pos_upper)
+                intersect = selection_box * pos_patch_box
+
+            if intersect is not None or selection_box is None:
+                patch_datas = {}
+                layout = make_layout(patch_box, origin, lvl_cell_width, interp_order)
+
+                # currently, there is always data for patch
+                add_to_patchdata(
+                    vtk_file,
+                    vtk_patch_level_info,
+                    ipatch,
+                    patch_datas,
+                    basename,
+                    layout,
+                )
+                patches.append(Patch(patch_datas, h5_patch, box=patch_box))
+
+        if len(patches):
+            patch_levels[ilvl] = PatchLevel(ilvl, patches)
+    return patch_levels
+
+
+def add_time_from_h5(hier, filepath, time, **kwargs):
+    # add times to 'hier'
+    # we may have a different selection box for that time as for already existing times
+    # but we need to keep them, per time
+
+    vtk_file = VtkFile(filepath)
+    selection_box = kwargs.get("selection_box", None)
+    if hier.has_time(time):
+        add_data_from_h5(hier, filepath, time)
+
+    else:
+        patch_levels = patch_levels_from_h5(vtk_file, time, selection_box=selection_box)
+        hier.add_time(time, patch_levels, vtk_file.file, selection_box=selection_box)
+
+    return hier
+
+
+def add_data_from_h5(hier, filepath, time):
+    """
+    adds new PatchDatas to an existing PatchHierarchy for an existing time
+
+    Data will be added from the given filepath.
+    Data will be extracted from the selection box of the hierarchy at that time.
+    """
+    if not hier.has_time(time):
+        raise ValueError("time does not exist in hierarchy")
+
+    vtk_file = VtkFile(filepath)
+
+    # force using the hierarchy selection box at that time if existing
+    selection_box = None
+    if hier.selection_box is not None:
+        selection_box = hier.selection_box[format_timestamp(time)]
+    patch_levels = patch_levels_from_h5(vtk_file, time, selection_box=selection_box)
+
+    for ilvl, lvl in hier.levels(time).items():
+        for ip, patch in enumerate(lvl.patches):
+            patch.patch_datas.update(patch_levels[ilvl].patches[ip].patch_datas)
+
+    return hier
+
+
+def new_from_h5(filepath, times, **kwargs):
+    selection_box = kwargs.get("selection_box", [None] * len(times))
+    if phut.none_iterable(selection_box) and phut.all_iterables(times):
+        selection_box = [selection_box] * len(times)
+
+    patch_levels_per_time = []
+
+    vtk_file = VtkFile(filepath)
+    for it, time in enumerate(times):
+        if isinstance(time, float):
+            time = f"{time:.10f}"
+        patch_levels = patch_levels_from_h5(
+            vtk_file, time, selection_box=selection_box[it]
+        )
+        patch_levels_per_time.append(patch_levels)
+
+    # in hierarchy, we need to keep selection_box now
+    # because we want that operations involving several hierarchies will need to check
+    # that each time has the same patch layout.
+    hier = PatchHierarchy(
+        patch_levels_per_time,
+        vtk_file.domain_box,
+        phut.refinement_ratio,
+        times,
+        vtk_file.file,
+        selection_box=selection_box,
+    )
+
+    return hier
+
+
+def hierarchy_fromvtkhdf(h5_filename, time=None, hier=None, silent=True, **kwargs):
+    """
+    creates a PatchHierarchy from a given time in a h5 file
+    if hier is None, a new hierarchy is created
+    if hier is not None, data is added to the hierarchy
+    """
+
+    if create_from_times(time, hier):
+        time = listify(time)
+        return new_from_h5(h5_filename, time, **kwargs)
+
+    if create_from_all_times(time, hier):
+        times = get_times_from_h5(h5_filename)
+        return new_from_h5(h5_filename, times, **kwargs)
+
+    if load_one_time(time, hier):
+        time = listify(time)
+        assert len(time) == 1
+        return add_time_from_h5(hier, h5_filename, time[0], **kwargs)
+
+    if load_all_times(time, hier):
+        for t in VtkFile(h5_filename).times():
+            add_time_from_h5(hier, h5_filename, t, **kwargs)
+        return hier
+
+    raise ValueError("unreachable: all (time, hier) combinations handled above")

--- a/pyphare/pyphare/pharesee/hierarchy/hierarchy.py
+++ b/pyphare/pyphare/pharesee/hierarchy/hierarchy.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from dataclasses import dataclass
 
 from .patch import Patch
 from .patchlevel import PatchLevel
@@ -73,8 +74,11 @@ class PatchHierarchy(object):
         no_copy_keys = ["data_files"]  # do not copy these things
         return deep_copy(self, memo, no_copy_keys)
 
-    def __getitem__(self, qty):
-        return self.__dict__[qty]
+    def __getitem__(self, that):
+        if type(that) is HierarchyAccessor:
+            accessor = that
+            return self.level(accessor.ilvl, accessor.time)[accessor.patch_idx]
+        return NotImplemented
 
     def update(self):
         if len(self.quantities()) > 1:
@@ -432,9 +436,11 @@ class PatchHierarchy(object):
                 if qty is None:
                     qty = pdata_names[0]
 
-                nbrGhosts = patch.patch_datas[qty].ghosts_nbr
-                val = patch.patch_datas[qty][patch.box]
-                x = patch.patch_datas[qty].x[nbrGhosts[0] : -nbrGhosts[0]]
+                pd = patch[qty]
+                nbrGhosts = pd.ghosts_nbr
+                any_ghosts = any(nbrGhosts)
+                val = pd[patch.box] if any_ghosts else pd[:]
+                x = pd.x[nbrGhosts[0] : -nbrGhosts[0]] if nbrGhosts[0] > 0 else pd.x
                 label = "L{level}P{patch}".format(level=lvl_nbr, patch=ip)
                 marker = kwargs.get("marker", "")
                 ls = kwargs.get("ls", "--")
@@ -620,6 +626,18 @@ class PatchHierarchy(object):
 
     def __array_function__(self, func, types, args, kwargs):
         return hierarchy_array_function(self, func, types, args, kwargs)
+
+
+@dataclass
+class HierarchyAccessor:
+    """
+    For cross hierarchy operations, so we can retrieve relevant patches etc
+    """
+
+    hier: PatchHierarchy
+    time: float
+    ilvl: int
+    patch_idx: int
 
 
 def hierarchy_array_ufunc(hier, ufunc, method, *inputs, **kwargs):

--- a/pyphare/pyphare/pharesee/hierarchy/hierarchy_compute.py
+++ b/pyphare/pyphare/pharesee/hierarchy/hierarchy_compute.py
@@ -1,0 +1,94 @@
+#
+#
+#
+
+import operator
+from copy import deepcopy
+
+from .hierarchy import PatchHierarchy
+
+
+def rename(hierarchy, names):
+    from .hierarchy_utils import compute_hier_from
+
+    return compute_hier_from(compute_rename, hierarchy, new_names=names)
+
+
+def compute_rename(patch, **kwargs):
+    new_names = kwargs["new_names"]
+    pd_attrs = []
+
+    for new_name, pd_name in zip(new_names, patch.patch_datas):
+        pd_attrs.append(patch[pd_name].copy_as(name=new_name))
+
+    return tuple(pd_attrs)
+
+
+def compute_mul(patch, **kwargs):
+    return _compute_copy_op(patch, operator.__mul__, **kwargs)
+
+
+def compute_add(patch, **kwargs):
+    return _compute_copy_op(patch, operator.__add__, **kwargs)
+
+
+def compute_sub(patch, **kwargs):
+    return _compute_copy_op(patch, operator.__sub__, **kwargs)
+
+
+def compute_truediv(patch, **kwargs):
+    return _compute_copy_op(patch, operator.__truediv__, **kwargs)
+
+
+def compute_rtruediv(patch, **kwargs):
+    return _compute_copy_rop(patch, operator.__truediv__, **kwargs)
+
+
+def _compute_copy_do(patch_data, λ):
+    return patch_data.copy_as(λ(patch_data.dataset[:]))
+
+
+def drop_ghosts(patch, **kwargs):
+    pd_attrs = []
+    ghosts_nbr = [0] * patch.box.ndim
+    for name, pd in patch.patch_datas.items():
+        data = pd[patch.box] if any(pd.ghosts_nbr) else pd[:]
+        pd_attrs.append(pd.copy_as(data, ghosts_nbr=ghosts_nbr))
+    return tuple(pd_attrs)
+
+
+class DataAccessor:
+    """
+    Resolves the right-hand operand of a patch-wise binary operation.
+
+    `accessor` is a HierarchyAccessor locating the patch currently being
+    computed (hierarchy, time, level, patch index). `operand` is either
+    another hierarchy, in which case indexing by quantity name returns its
+    dataset at that same patch location, or anything else operable against
+    a dataset (usually a scalar), which is returned unchanged regardless of
+    the key.
+    """
+
+    def __init__(self, accessor, operand):
+        self.accessor = accessor
+        self.operand = operand
+
+    def __getitem__(self, key):
+        if isinstance(self.operand, PatchHierarchy):
+            return self.operand[self.accessor][key].dataset[:]
+        return self.operand
+
+
+def _compute_copy_op(patch, op, accessor, operand, reverse=False):
+    def _(a, b):
+        return op(b, a) if reverse else op(a, b)
+
+    data = DataAccessor(accessor, operand)
+    return tuple(
+        _compute_copy_do(pd, lambda ds: _(ds, data[name]))
+        for name, pd in patch.patch_datas.items()
+    )
+
+
+def _compute_copy_rop(patch, op, accessor, operand):
+    return _compute_copy_op(patch, op, accessor, operand, reverse=True)

--- a/pyphare/pyphare/pharesee/hierarchy/hierarchy_utils.py
+++ b/pyphare/pyphare/pharesee/hierarchy/hierarchy_utils.py
@@ -1,10 +1,14 @@
-from dataclasses import dataclass, field
-from copy import deepcopy
+#
+#
+#
+
 import numpy as np
+from copy import deepcopy
+from dataclasses import dataclass, field
 
 from typing import Any, List, Tuple
 
-from .hierarchy import PatchHierarchy, format_timestamp
+from .hierarchy import PatchHierarchy, HierarchyAccessor, format_timestamp
 from .patchdata import FieldData, ParticleData
 from .patchlevel import PatchLevel
 from .patch import Patch
@@ -151,6 +155,7 @@ def compute_hier_from(compute, hierarchies, **kwargs):
     hierarchies = listify(hierarchies)
     if not are_compatible_hierarchies(hierarchies):
         raise RuntimeError("hierarchies are not compatible")
+
     reference_hier = hierarchies[0]
     domain_box = reference_hier.domain_box
     patch_levels_per_time = []
@@ -161,11 +166,13 @@ def compute_hier_from(compute, hierarchies, **kwargs):
                 ilvl, new_patches_from(compute, hierarchies, ilvl, t, **kwargs)
             )
         patch_levels_per_time.append(patch_levels)
+
     return PatchHierarchy(
         patch_levels_per_time,
         domain_box,
         refinement_ratio,
         times=reference_hier.times(),
+        data_files=reference_hier.data_files,
     )
 
 
@@ -180,30 +187,25 @@ def extract_patchdatas(hierarchies, ilvl, t, ipatch):
     return patch_datas
 
 
-def new_patchdatas_from(compute, patchdatas, layout, id, **kwargs):
-    new_patch_datas = {}
-    datas = compute(patchdatas, patch_id=id, **kwargs)
-    for data in datas:
-        extra = {k: data[k] for k in ("ghosts_nbr",) if k in data}
-        pd = FieldData(
-            layout, data["name"], data["data"], centering=data["centering"], **extra
-        )
-        new_patch_datas[data["name"]] = pd
-    return new_patch_datas
+def new_patchdatas_from(compute, patch, **kwargs):
+    return {data.name: data for data in compute(patch, **kwargs)}
 
 
 def new_patches_from(compute, hierarchies, ilvl, t, **kwargs):
     reference_hier = hierarchies[0]
     new_patches = []
     ref_patches = reference_hier.level(ilvl, time=t).patches
-    for ip, current_patch in enumerate(ref_patches):
-        layout = current_patch.layout
-        patch_datas = extract_patchdatas(hierarchies, ilvl, t, ip)
-        new_patch_datas = new_patchdatas_from(
-            compute, patch_datas, layout, id=current_patch.id, **kwargs
+    for ip, ref_patch in enumerate(ref_patches):
+        patch = ref_patch.copy_as(
+            patch_datas=extract_patchdatas(hierarchies, ilvl, t, ip)
         )
+        accessor = HierarchyAccessor(reference_hier, t, ilvl, ip)
         new_patches.append(
-            Patch(new_patch_datas, current_patch.id, attrs=current_patch.attrs)
+            ref_patch.copy_as(
+                patch_datas=new_patchdatas_from(
+                    compute, patch, accessor=accessor, **kwargs
+                ),
+            )
         )
     return new_patches
 
@@ -456,143 +458,6 @@ def flat_finest_field_2d(hierarchy, qty, time=None):
     return final_data, np.stack((tmp_x, tmp_y), axis=1)
 
 
-def compute_rename(patch_datas, **kwargs):
-    new_names = kwargs["new_names"]
-    pd_attrs = []
-
-    for new_name, pd_name in zip(new_names, patch_datas):
-        src = patch_datas[pd_name]
-        pd_attrs.append(
-            {
-                "name": new_name,
-                "data": src.dataset,
-                "centering": src.centerings,
-                "ghosts_nbr": src.ghosts_nbr,
-            }
-        )
-
-    return tuple(pd_attrs)
-
-
-def rename(hierarchy, names):
-    return compute_hier_from(compute_rename, hierarchy, new_names=names)
-
-
-def _compute_mul(patch_datas, **kwargs):
-    names = kwargs["names"]
-
-    # multiplication of a scalarField or VectorField by a scalar
-    if "other" in kwargs:
-        other = kwargs["other"]
-        pd_attrs = []
-
-        for name, pd_name in zip(names, patch_datas):
-            pd_attrs.append(
-                {
-                    "name": name,
-                    "data": other * patch_datas[pd_name].dataset[:],
-                    "centering": patch_datas[pd_name].centerings,
-                }
-            )
-    # multiplication of 2 scalarField
-    elif "self_value" in patch_datas:
-        dset_value = (
-            patch_datas["self_value"].dataset[:] * patch_datas["other_value"].dataset[:]
-        )
-        pd_attrs = (
-            {
-                "name": "value",
-                "data": dset_value,
-                "centering": patch_datas["self_value"].centerings,
-            },
-        )
-
-    return tuple(pd_attrs)
-
-
-def _compute_add(patch_datas, **kwargs):
-    ref_name = next(iter(patch_datas.keys()))
-
-    dset_x = patch_datas["self_x"].dataset[:] + patch_datas["other_x"].dataset[:]
-    dset_y = patch_datas["self_y"].dataset[:] + patch_datas["other_y"].dataset[:]
-    dset_z = patch_datas["self_z"].dataset[:] + patch_datas["other_z"].dataset[:]
-
-    return (
-        {"name": "x", "data": dset_x, "centering": patch_datas[ref_name].centerings},
-        {"name": "y", "data": dset_y, "centering": patch_datas[ref_name].centerings},
-        {"name": "z", "data": dset_z, "centering": patch_datas[ref_name].centerings},
-    )
-
-
-def _compute_sub(patch_datas, **kwargs):
-    ref_name = next(iter(patch_datas.keys()))
-
-    dset_x = patch_datas["self_x"].dataset[:] - patch_datas["other_x"].dataset[:]
-    dset_y = patch_datas["self_y"].dataset[:] - patch_datas["other_y"].dataset[:]
-    dset_z = patch_datas["self_z"].dataset[:] - patch_datas["other_z"].dataset[:]
-
-    return (
-        {"name": "x", "data": dset_x, "centering": patch_datas[ref_name].centerings},
-        {"name": "y", "data": dset_y, "centering": patch_datas[ref_name].centerings},
-        {"name": "z", "data": dset_z, "centering": patch_datas[ref_name].centerings},
-    )
-
-
-def _compute_neg(patch_datas, **kwargs):
-    names = kwargs["new_names"]
-    pd_attrs = []
-
-    for name in names:
-        pd_attrs.append(
-            {
-                "name": name,
-                "data": -patch_datas[name].dataset[:],
-                "centering": patch_datas[name].centerings,
-            }
-        )
-
-    return tuple(pd_attrs)
-
-
-def _compute_truediv(patch_datas, **kwargs):
-    names = kwargs["res_names"]
-    pd_attrs = []
-
-    # the denominator is a scalar field which name is "value"
-    # hence the associated patchdata has to be removed from the list
-    # of patchdata from the vectorField of the numerator
-    left_ops = {k: v for k, v in patch_datas.items() if k != "value"}
-    right_op = patch_datas["value"]
-    for name, left_op in zip(names, left_ops.values()):
-        pd_attrs.append(
-            {
-                "name": name,
-                "data": left_op.dataset / right_op.dataset,
-                "centering": patch_datas[name].centerings,
-            }
-        )
-
-    return tuple(pd_attrs)
-
-
-def _compute_scalardiv(patch_datas, **kwargs):
-    names = kwargs["res_names"]
-    scalar = kwargs["scalar"]
-    pd_attrs = []
-
-    left_ops = {k: v for k, v in patch_datas.items()}
-    for name, left_op in zip(names, left_ops.values()):
-        pd_attrs.append(
-            {
-                "name": name,
-                "data": left_op.dataset / scalar,
-                "centering": patch_datas[name].centerings,
-            }
-        )
-
-    return tuple(pd_attrs)
-
-
 @dataclass
 class EqualityReport:
     failed: List[Tuple[str, Any, Any]] = field(default_factory=lambda: [])
@@ -608,7 +473,7 @@ class EqualityReport:
                     phut.assert_fp_any_all_close(ref[:], cmp[:], atol=1e-16)
             except AssertionError as e:
                 print(e)
-        return self.failed[0][0]
+        return self.failed[0][0] if self.failed else "=="
 
     def __call__(self, reason, ref=None, cmp=None):
         self.failed.append((reason, ref, cmp))
@@ -651,6 +516,9 @@ def hierarchy_compare(this, that, atol=1e-16):
                 patch_ref = patch_level_ref.patches[patch_idx]
                 patch_cmp = patch_level_cmp.patches[patch_idx]
 
+                if patch_ref.box != patch_cmp.box:
+                    return eqr("patch box mismatch", patch_ref.box, patch_cmp.box)
+
                 if patch_ref.patch_datas.keys() != patch_cmp.patch_datas.keys():
                     return eqr("data keys mismatch")
 
@@ -658,8 +526,11 @@ def hierarchy_compare(this, that, atol=1e-16):
                     patch_data_ref = patch_ref.patch_datas[patch_data_key]
                     patch_data_cmp = patch_cmp.patch_datas[patch_data_key]
 
-                    if not patch_data_cmp.compare(patch_data_ref, atol=atol):
+                    ret = patch_data_ref.compare(patch_data_cmp, atol=atol)
+                    if not bool(ret):
                         msg = f"data mismatch: {type(patch_data_ref).__name__} {patch_data_key}"
+                        if type(ret) is not bool:
+                            msg += "\n" + str(ret)
                         eqr(msg, patch_data_cmp, patch_data_ref)
 
                 if not eqr:
@@ -690,7 +561,7 @@ def single_patch_for_LO(hier, qties=None, skip=None):
             if isinstance(v, FieldData):
                 l0_pds[k] = FieldData(
                     layout,
-                    v.field_name,
+                    v.name,
                     None,
                     centering=v.centerings,
                     ghosts_nbr=v.ghosts_nbr,

--- a/pyphare/pyphare/pharesee/hierarchy/patch.py
+++ b/pyphare/pyphare/pharesee/hierarchy/patch.py
@@ -48,6 +48,12 @@ class Patch:
 
         return deepcopy(self)
 
+    def copy_as(self, patch_datas=None, patch_id=None, attrs=None):
+        patch_datas = patch_datas if patch_datas is not None else self.patch_datas
+        patch_id = patch_id if patch_id is not None else self.id
+        attrs = attrs if attrs is not None else self.attrs
+        return type(self)(patch_datas, patch_id, box=self.box, attrs=attrs)
+
     def __copy__(self):
         return self.copy()
 

--- a/pyphare/pyphare/pharesee/hierarchy/patchdata.py
+++ b/pyphare/pyphare/pharesee/hierarchy/patchdata.py
@@ -28,7 +28,9 @@ class PatchData:
 
     def __deepcopy__(self, memo):
         no_copy_keys = ["dataset"]  # do not copy these things
-        return phut.deep_copy(self, memo, no_copy_keys)
+        cpy = phut.deep_copy(self, memo, no_copy_keys)
+        cpy.dataset = self.dataset
+        return cpy
 
 
 class FieldData(PatchData):
@@ -60,16 +62,18 @@ class FieldData(PatchData):
 
     def __str__(self):
         return "FieldData: (box=({}, {}), key={})".format(
-            self.layout.box, self.layout.box.shape, self.field_name
+            self.layout.box, self.layout.box.shape, self.name
         )
 
     def __repr__(self):
         return self.__str__()
 
     def compare(self, that, atol=1e-16):
-        return self.field_name == that.field_name and phut.fp_any_all_close(
-            self.dataset[:], that.dataset[:], atol=atol
-        )
+        try:
+            phut.assert_fp_any_all_close(self.dataset[:], that.dataset[:], atol=atol)
+        except AssertionError as e:
+            return phut.EqualityCheck(False, str(e))
+        return self.name == that.name
 
     def __eq__(self, that):
         return self.compare(that)
@@ -109,10 +113,10 @@ class FieldData(PatchData):
     def __setitem__(self, box_or_slice, val):
         self.__getitem__(box_or_slice)[:] = val
 
-    def __init__(self, layout, field_name, data, **kwargs):
+    def __init__(self, layout, name, data, **kwargs):
         """
         :param layout: A GridLayout representing the domain on which data is defined
-        :param field_name: the name of the field (e.g. "Bx")
+        :param name: the name of the field (e.g. "Bx")
         :param data: the dataset from which data can be accessed
         """
         super().__init__(layout, "field")
@@ -121,8 +125,7 @@ class FieldData(PatchData):
         self._z = None
 
         self.dl = np.asarray(layout.dl)
-        self.field_name = field_name
-        self.name = field_name
+        self.name = name
         self.ndim = layout.box.ndim
 
         self.centerings = self._resolve_centering(**kwargs)
@@ -154,11 +157,18 @@ class FieldData(PatchData):
             return tuple(g[select] for g in mesh)
         return mesh
 
+    def copy_as(self, data=None, **kwargs):
+        data = data if data is not None else self.dataset
+        name = kwargs.pop("name", self.name)
+        kwargs["centering"] = kwargs.get("centering", self.centerings)
+        kwargs["ghosts_nbr"] = kwargs.get("ghosts_nbr", self.ghosts_nbr)
+        return FieldData(self.layout, name, data, **kwargs)
+
     def yeeCoordsFor(self, idx):
         return self.layout.yeeCoordsFor(
-            self.field_name,
+            self.name,
             gridlayout.directions[idx],
-            withGhosts=any(self.ghosts_nbr) and self.field_name != "tags",
+            withGhosts=any(self.ghosts_nbr) and self.name != "tags",
             centering=self.centerings[idx],
             ghosts_nbr=self.ghosts_nbr[idx],
         )
@@ -167,13 +177,13 @@ class FieldData(PatchData):
         layout = self.layout
         ghosts_nbr = kwargs.get("ghosts_nbr", np.zeros(self.ndim, dtype=int))
         if "ghosts_nbr" not in kwargs:
-            if self.field_name != "tags":
+            if self.name != "tags":
                 for i, centering in enumerate(self.centerings):
                     ghosts_nbr[i] = layout.nbrGhosts(layout.interp_order, centering)
         return phut.np_array_ify(ghosts_nbr, layout.box.ndim)
 
     def _resolve_centering(self, **kwargs):
-        field_name = self.field_name
+        name = self.name
         if "centering" in kwargs:
             if isinstance(kwargs["centering"], list):
                 assert len(kwargs["centering"]) == self.ndim
@@ -185,16 +195,14 @@ class FieldData(PatchData):
                     )
                 return phut.listify(kwargs["centering"])
 
-        if field_name in self.layout.centering["X"]:
+        if name in self.layout.centering["X"]:
             directions = ["X", "Y", "Z"][: self.ndim]  # drop unused directions
             return [
-                self.layout.qtyCentering(field_name, direction)
-                for direction in directions
+                self.layout.qtyCentering(name, direction) for direction in directions
             ]
         raise ValueError(
-            f"centering not specified and cannot be inferred from field name : {field_name}"
+            f"centering not specified and cannot be inferred from field name : {name}"
         )
-
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         return field_data_array_ufunc(self, ufunc, method, *inputs, **kwargs)
@@ -213,7 +221,7 @@ def field_data_array_ufunc(patch_data, ufunc, method, *inputs, **kwargs):
     if isinstance(out_, np.ndarray) and out_.shape == patch_data.dataset.shape:
         return type(patch_data)(
             layout=patch_data.layout,
-            field_name=patch_data.field_name,
+            name=patch_data.name,
             data=out_,
             centering=patch_data.centerings,
             ghosts_nbr=patch_data.ghosts_nbr,
@@ -229,7 +237,7 @@ def field_data_array_function(patch_data, func, types, args, kwargs):
     if isinstance(out_, np.ndarray) and out_.shape == patch_data.dataset.shape:
         return type(patch_data)(
             layout=patch_data.layout,
-            field_name=patch_data.field_name,
+            name=patch_data.name,
             data=out_,
             centering=patch_data.centerings,
             ghosts_nbr=patch_data.ghosts_nbr,

--- a/pyphare/pyphare/pharesee/hierarchy/scalarfield.py
+++ b/pyphare/pyphare/pharesee/hierarchy/scalarfield.py
@@ -1,10 +1,11 @@
+from . import hierarchy_compute as hc
 from .hierarchy import PatchHierarchy
-from .hierarchy_utils import compute_hier_from, compute_rename, rename, _compute_neg
+from .hierarchy_utils import compute_hier_from
 
 
 class ScalarField(PatchHierarchy):
     def __init__(self, hier):
-        renamed_hier = compute_hier_from(compute_rename, hier, new_names=("value",))
+        renamed_hier = compute_hier_from(hc.compute_rename, hier, new_names=("value",))
         patch_levels = renamed_hier.patch_levels
         domain_box = renamed_hier.domain_box
         refinement_ratio = renamed_hier.refinement_ratio
@@ -15,198 +16,25 @@ class ScalarField(PatchHierarchy):
         )
 
     def __add__(self, other):
-        assert isinstance(other, (ScalarField, int, float))
-        h_self = rename(self, ["self_value"])
-
-        if isinstance(other, ScalarField):
-            h_other = rename(other, ["other_value"])
-            h = compute_hier_from(
-                self._compute_add,
-                (h_self, h_other),
-            )
-        elif isinstance(other, (int, float)):
-            h = compute_hier_from(self._compute_add, (h_self,), other=other)
-        else:
-            raise RuntimeError("right operand not supported")
-
-        return ScalarField(h)
+        return ScalarField(compute_hier_from(hc.compute_add, self, operand=other))
 
     def __radd__(self, other):
         return self.__add__(other)
 
     def __sub__(self, other):
-        assert isinstance(other, (ScalarField, int, float))
-        h_self = rename(self, ["self_value"])
-
-        if isinstance(other, ScalarField):
-            h_other = rename(other, ["other_value"])
-            h = compute_hier_from(
-                self._compute_sub,
-                (h_self, h_other),
-            )
-        elif isinstance(other, (int, float)):
-            h = compute_hier_from(self._compute_sub, (h_self,), other=other)
-        else:
-            raise RuntimeError("right operand not supported")
-
-        return ScalarField(h)
+        return ScalarField(compute_hier_from(hc.compute_sub, self, operand=other))
 
     def __mul__(self, other):
-        assert isinstance(other, (ScalarField, int, float))
-        h_self = rename(self, ["self_value"])
-
-        if isinstance(other, ScalarField):
-            h_other = rename(other, ["other_value"])
-            h = compute_hier_from(self._compute_mul, (h_self, h_other))
-        elif isinstance(other, (int, float)):
-            h = compute_hier_from(self._compute_mul, (h_self,), other=other)
-        else:
-            raise RuntimeError("right operand not supported")
-
-        return ScalarField(h)
+        return ScalarField(compute_hier_from(hc.compute_mul, self, operand=other))
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        assert isinstance(other, (ScalarField, int, float))
-        h_self = rename(self, ["self_value"])
-
-        if isinstance(other, ScalarField):
-            h_other = rename(other, ["other_value"])
-            h = compute_hier_from(self._compute_truediv, (h_self, h_other))
-        elif isinstance(other, (int, float)):
-            h = compute_hier_from(self._compute_truediv, (h_self,), other=other)
-        else:
-            raise RuntimeError("right operand not supported")
-
-        return ScalarField(h)
+        return ScalarField(compute_hier_from(hc.compute_truediv, self, operand=other))
 
     def __rtruediv__(self, other):
-        assert isinstance(other, (int, float))
-        h_self = rename(self, ["self_value"])
-
-        h = compute_hier_from(self._compute_rtruediv, (h_self,), other=other)
-
-        return ScalarField(h)
-
-    def _compute_add(self, patch_datas, **kwargs):
-        ref_name = next(iter(patch_datas.keys()))
-
-        if "other" in kwargs:
-            other = kwargs["other"]
-            dset_value = patch_datas["self_value"].dataset[:] + other
-        else:
-            dset_value = (
-                patch_datas["self_value"].dataset[:]
-                + patch_datas["other_value"].dataset[:]
-            )
-
-        return (
-            {
-                "name": "value",
-                "data": dset_value,
-                "centering": patch_datas[ref_name].centerings,
-            },
-        )
-
-    def _compute_sub(self, patch_datas, **kwargs):
-        # subtract a scalar from the dataset of a scalarField
-        if "other" in kwargs:
-            other = kwargs["other"]
-            dset_value = patch_datas["self_value"].dataset[:] - other
-        # substraction of 2 scalarFields
-        else:
-            dset_value = (
-                patch_datas["self_value"].dataset[:]
-                - patch_datas["other_value"].dataset[:]
-            )
-
-        return (
-            {
-                "name": "value",
-                "data": dset_value,
-                "centering": patch_datas["self_value"].centerings,
-            },
-        )
-
-    def _compute_mul(self, patch_datas, **kwargs):
-        # multiplication of a scalarField by a scalar
-        if "other" in kwargs:
-            other = kwargs["other"]
-            pd_attrs = []
-
-            for pd_name in patch_datas:
-                pd_attrs.append(
-                    {
-                        "name": "value",
-                        "data": other * patch_datas[pd_name].dataset[:],
-                        "centering": patch_datas[pd_name].centerings,
-                    }
-                )
-        # multiplication of 2 scalarField
-        else:
-            dset_value = (
-                patch_datas["self_value"].dataset[:]
-                * patch_datas["other_value"].dataset[:]
-            )
-            pd_attrs = (
-                {
-                    "name": "value",
-                    "data": dset_value,
-                    "centering": patch_datas["self_value"].centerings,
-                },
-            )
-
-        return tuple(pd_attrs)
-
-    def _compute_truediv(self, patch_datas, **kwargs):
-        # multiplication of a scalarField by a scalar
-        if "other" in kwargs:
-            other = kwargs["other"]
-            pd_attrs = []
-
-            for pd_name in patch_datas:
-                pd_attrs.append(
-                    {
-                        "name": "value",
-                        "data": patch_datas[pd_name].dataset[:] / other,
-                        "centering": patch_datas[pd_name].centerings,
-                    }
-                )
-        # multiplication of 2 scalarField
-        else:
-            dset_value = (
-                patch_datas["self_value"].dataset[:]
-                / patch_datas["other_value"].dataset[:]
-            )
-            pd_attrs = (
-                {
-                    "name": "value",
-                    "data": dset_value,
-                    "centering": patch_datas["self_value"].centerings,
-                },
-            )
-
-        return tuple(pd_attrs)
-
-    def _compute_rtruediv(self, patch_datas, **kwargs):
-        # Scalar divided by a scalarField
-        other = kwargs["other"]
-        pd_attrs = []
-
-        for pd_name in patch_datas:
-            pd_attrs.append(
-                {
-                    "name": "value",
-                    "data": other / patch_datas[pd_name].dataset[:],
-                    "centering": patch_datas[pd_name].centerings,
-                }
-            )
-
-        return tuple(pd_attrs)
+        return ScalarField(compute_hier_from(hc.compute_rtruediv, self, operand=other))
 
     def __neg__(self):
-        names_self = self.quantities()
-        h = compute_hier_from(_compute_neg, self, new_names=names_self)
-        return ScalarField(h)
+        return self * -1

--- a/pyphare/pyphare/pharesee/hierarchy/vectorfield.py
+++ b/pyphare/pyphare/pharesee/hierarchy/vectorfield.py
@@ -1,21 +1,12 @@
+from . import hierarchy_compute as hc
 from .hierarchy import PatchHierarchy
-from .hierarchy_utils import (
-    compute_hier_from,
-    compute_rename,
-    rename,
-    _compute_mul,
-    _compute_add,
-    _compute_sub,
-    _compute_truediv,
-    _compute_scalardiv,
-)
-from .scalarfield import ScalarField
+from .hierarchy_utils import compute_hier_from
 
 
 class VectorField(PatchHierarchy):
     def __init__(self, hier):
         renamed_hier = compute_hier_from(
-            compute_rename, hier, new_names=("x", "y", "z")
+            hc.compute_rename, hier, new_names=("x", "y", "z")
         )
         patch_levels = renamed_hier.patch_levels
         domain_box = renamed_hier.domain_box
@@ -29,72 +20,20 @@ class VectorField(PatchHierarchy):
         )
 
     def __mul__(self, other):
-        assert isinstance(other, (int, float))
-        h = compute_hier_from(_compute_mul, self, names=["x", "y", "z"], other=other)
-        return VectorField(h)
+        if type(other) is VectorField:
+            raise ValueError(
+                "VectorField * VectorField is ambiguous, use pyphare.core.operators.dot or .prod"
+            )
+        return VectorField(compute_hier_from(hc.compute_mul, self, operand=other))
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
     def __add__(self, other):
-        names_self_kept = self.quantities()
-        names_other_kept = other.quantities()
-
-        if isinstance(other, VectorField):
-            names_self = ["self_x", "self_y", "self_z"]
-            names_other = ["other_x", "other_y", "other_z"]
-        else:
-            raise RuntimeError("type of hierarchy not yet considered")
-
-        h_self = rename(self, names_self)
-        h_other = rename(other, names_other)
-
-        h = compute_hier_from(
-            _compute_add,
-            (h_self, h_other),
-        )
-
-        self = rename(h_self, names_self_kept)  # needed ?
-        other = rename(h_other, names_other_kept)
-
-        return VectorField(h)
+        return VectorField(compute_hier_from(hc.compute_add, self, operand=other))
 
     def __sub__(self, other):
-        names_self_kept = self.quantities()
-        names_other_kept = other.quantities()
-
-        if isinstance(other, VectorField):
-            names_self = ["self_x", "self_y", "self_z"]
-            names_other = ["other_x", "other_y", "other_z"]
-        else:
-            raise RuntimeError("type of hierarchy not yet considered")
-
-        h_self = rename(self, names_self)
-        h_other = rename(other, names_other)
-
-        h = compute_hier_from(
-            _compute_sub,
-            (h_self, h_other),
-        )
-
-        self = rename(h_self, names_self_kept)
-        other = rename(h_other, names_other_kept)
-
-        return VectorField(h)
+        return VectorField(compute_hier_from(hc.compute_sub, self, operand=other))
 
     def __truediv__(self, other):
-        if not isinstance(other, (ScalarField, int, float)):
-            raise RuntimeError("type of operand not considered")
-
-        if isinstance(other, ScalarField):
-            return VectorField(
-                compute_hier_from(
-                    _compute_truediv, (self, other), res_names=("x", "y", "z")
-                )
-            )
-        elif isinstance(other, (int, float)):
-            return VectorField(
-                compute_hier_from(
-                    _compute_scalardiv, (self,), res_names=("x", "y", "z"), scalar=other
-                )
-            )
+        return VectorField(compute_hier_from(hc.compute_truediv, self, operand=other))

--- a/pyphare/pyphare/pharesee/run/run.py
+++ b/pyphare/pyphare/pharesee/run/run.py
@@ -44,7 +44,7 @@ class Run:
     def GetB(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
         if merged:
             all_primal = False
-        hier = self._get_hierarchy(time, "EM_B.h5", **kwargs)
+        hier = self._get_hier_for(time, "EM_B", **kwargs)
         if not all_primal:
             return self._get(hier, time, merged, interp)
 
@@ -53,36 +53,34 @@ class Run:
     def GetE(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
         if merged:
             all_primal = False
-        hier = self._get_hierarchy(time, "EM_E.h5", **kwargs)
+        hier = self._get_hier_for(time, "EM_E", **kwargs)
         if not all_primal:
             return self._get(hier, time, merged, interp)
 
         return VectorField(compute_hier_from(_compute_to_primal, hier))
 
     def GetMassDensity(self, time, merged=False, interp="nearest", **kwargs):
-        hier = self._get_hierarchy(time, "ions_mass_density.h5", **kwargs)
+        hier = self._get_hier_for(time, "ions_mass_density", **kwargs)
         return ScalarField(self._get(hier, time, merged, interp))
 
     def GetNi(self, time, merged=False, interp="nearest", **kwargs):
-        hier = self._get_hierarchy(time, "ions_charge_density.h5", **kwargs)
+        hier = self._get_hier_for(time, "ions_charge_density", **kwargs)
         return ScalarField(self._get(hier, time, merged, interp, drop_ghosts=True))
 
     def GetN(self, time, pop_name, merged=False, interp="nearest", **kwargs):
-        hier = self._get_hierarchy(time, f"ions_pop_{pop_name}_density.h5", **kwargs)
+        hier = self._get_hier_for(time, f"ions_pop_{pop_name}_density", **kwargs)
         return ScalarField(self._get(hier, time, merged, interp))
 
     def GetVi(self, time, merged=False, interp="nearest", **kwargs):
-        hier = self._get_hierarchy(time, "ions_bulkVelocity.h5", **kwargs)
+        hier = self._get_hier_for(time, "ions_bulkVelocity", **kwargs)
         return VectorField(self._get(hier, time, merged, interp, drop_ghosts=True))
 
     def GetFlux(self, time, pop_name, merged=False, interp="nearest", **kwargs):
-        hier = self._get_hierarchy(time, f"ions_pop_{pop_name}_flux.h5", **kwargs)
+        hier = self._get_hier_for(time, f"ions_pop_{pop_name}_flux", **kwargs)
         return VectorField(self._get(hier, time, merged, interp))
 
     def GetPressure(self, time, pop_name, merged=False, interp="nearest", **kwargs):
-        M = self._get_hierarchy(
-            time, f"ions_pop_{pop_name}_momentum_tensor.h5", **kwargs
-        )
+        M = self._get_hier_for(time, f"ions_pop_{pop_name}_momentum_tensor", **kwargs)
         V = self.GetFlux(time, pop_name, **kwargs)
         N = self.GetN(time, pop_name, **kwargs)
         P = compute_hier_from(
@@ -94,14 +92,14 @@ class Run:
         return self._get(P, time, merged, interp)  # should later be a TensorField
 
     def GetPi(self, time, merged=False, interp="nearest", **kwargs):
-        M = self._get_hierarchy(time, "ions_momentum_tensor.h5", **kwargs)
+        M = self._get_hier_for(time, "ions_momentum_tensor", **kwargs)
         massDensity = self.GetMassDensity(time, **kwargs)
-        Vi = self._get_hierarchy(time, "ions_bulkVelocity.h5", **kwargs)
+        Vi = self._get_hier_for(time, "ions_bulkVelocity", **kwargs)
         Pi = compute_hier_from(_compute_pressure, (M, massDensity, Vi))
         return self._get(Pi, time, merged, interp)  # should later be a TensorField
 
     def GetPe(self, time, merged=False, interp="nearest", all_primal=True):
-        hier = self._get_hierarchy(time, "ions_charge_density.h5")
+        hier = self._get_hier_for(time, "ions_charge_density")
         Te = hier.sim.electrons.closure.Te
         if not all_primal:
             return Te * self._get(hier, time, merged, interp)
@@ -325,12 +323,25 @@ class Run:
 
     def _available_diags(self):
         files = glob.glob(os.path.join(self.path, "*.h5"))
-        if not files:
-            raise RuntimeError(f"No HDF5 files found at: {self.path}")
-        return files
+        if files:
+            return files
+        files = glob.glob(os.path.join(self.path, "*.vtkhdf"))
+        if files:
+            return files
+        raise RuntimeError(f"No HDF5 files found at: {self.path}")
+
+    def _get_hier_for(self, time, qty, **kwargs):
+        path = Path(self.path) / f"{qty}.h5"
+        if path.exists():
+            return self._get_hierarchy(time, f"{qty}.h5", **kwargs)
+        path = Path(self.path) / f"{qty}.vtkhdf"
+        if path.exists():
+            return self._get_hierarchy(time, f"{qty}.vtkhdf", **kwargs)
+        raise RuntimeError(f"No HDF5 file found for: {qty}")
 
     def _get_any_hierarchy(self, time):
-        return self._get_hierarchy(time, os.path.basename(self.available_diags[0]))
+        ref_file = Path(self.available_diags[0]).stem
+        return self._get_hier_for(time, ref_file)
 
     def _get_hierarchy(self, times, filename, hier=None, **kwargs):
         from pyphare.core.box import Box

--- a/pyphare/pyphare/pharesee/run/run.py
+++ b/pyphare/pyphare/pharesee/run/run.py
@@ -1,13 +1,20 @@
+#
+#
+#
+
 import os
 import glob
-import numpy as np
+from pathlib import Path
 
+from pyphare.pharesee.hierarchy import all_times_from
+from pyphare.pharesee.hierarchy import default_time_from
 from pyphare.pharesee.hierarchy import hierarchy_from
+from pyphare.pharesee.hierarchy import hierarchy_compute as hc
 from pyphare.pharesee.hierarchy import ScalarField, VectorField
 
+from pyphare.core import phare_utilities as phut
 from pyphare.pharesee.hierarchy.hierarchy_utils import compute_hier_from
 from pyphare.pharesee.hierarchy.hierarchy_utils import flat_finest_field
-from pyphare.core.phare_utilities import listify
 
 from pyphare.logger import getLogger
 from .utils import (
@@ -23,72 +30,12 @@ from .utils import (
 
 logger = getLogger(__name__)
 
-quantities_per_file = {
-    "EM_B": "B",
-    "EM_E": "E",
-    "ions_bulkVelocity": "Vi",
-    "ions_charge_density": "Ni",
-    "particle_count": "nppc",
-    "mhd_rho": "mhd_rho",
-    "mhd_V": "mhd_V",
-    "mhd_P": "mhd_P",
-    "mhd_rhoV": "mhd_rhoV",
-    "mhd_Etot": "mhd_Etot",
-}
-
 
 class Run:
     def __init__(self, path, default_time=None):
         self.path = path
         self.default_time_ = default_time
-        self.available_diags = glob.glob(os.path.join(self.path, "*.h5"))
-
-    def _get_hierarchy(self, times, filename, hier=None, **kwargs):
-        from pyphare.core.box import Box
-
-        times = listify(times)
-        times = [f"{t:.10f}" for t in times]
-        if "selection_box" in kwargs:
-            if isinstance(kwargs["selection_box"], tuple):
-                lower = kwargs["selection_box"][:2]
-                upper = kwargs["selection_box"][2:]
-                kwargs["selection_box"] = Box(lower, upper)
-
-        def _get_hier(h):
-            return hierarchy_from(
-                h5_filename=os.path.join(self.path, filename),
-                times=times,
-                hier=h,
-                **kwargs,
-            )
-
-        return _get_hier(hier)
-
-    # TODO maybe transform that so multiple times can be accepted
-    def _get(self, hierarchy, time, merged, interp):
-        """
-        if merged=True, will return an interpolator and a tuple of 1d arrays
-        with the coordinates of the finest grid where the interpolator
-        can be calculated (that is the return of flat_finest_field)
-        """
-        if merged:
-            domain = self.GetDomainSize()
-            dl = self.GetDl(time=time)
-
-            # assumes all qties in the hierarchy have the same ghost width
-            # so take the first patch data of the first patch of the first level....
-            nbrGhosts = list(hierarchy.level(0).patches[0].patch_datas.values())[
-                0
-            ].ghosts_nbr
-            merged_qties = {}
-            for qty in hierarchy.quantities():
-                data, coords = flat_finest_field(hierarchy, qty, time=time)
-                merged_qties[qty] = make_interpolator(
-                    data, coords, interp, domain, dl, qty, nbrGhosts
-                )
-            return merged_qties
-        else:
-            return hierarchy
+        self.available_diags = self._available_diags()
 
     def GetTags(self, time, merged=False, **kwargs):
         hier = self._get_hierarchy(time, "tags.h5")
@@ -101,8 +48,7 @@ class Run:
         if not all_primal:
             return self._get(hier, time, merged, interp)
 
-        h = compute_hier_from(_compute_to_primal, hier, x="Bx", y="By", z="Bz")
-        return VectorField(h)
+        return VectorField(compute_hier_from(_compute_to_primal, hier))
 
     def GetE(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
         if merged:
@@ -111,8 +57,7 @@ class Run:
         if not all_primal:
             return self._get(hier, time, merged, interp)
 
-        h = compute_hier_from(_compute_to_primal, hier, x="Ex", y="Ey", z="Ez")
-        return VectorField(h)
+        return VectorField(compute_hier_from(_compute_to_primal, hier))
 
     def GetMassDensity(self, time, merged=False, interp="nearest", **kwargs):
         hier = self._get_hierarchy(time, "ions_mass_density.h5", **kwargs)
@@ -120,7 +65,7 @@ class Run:
 
     def GetNi(self, time, merged=False, interp="nearest", **kwargs):
         hier = self._get_hierarchy(time, "ions_charge_density.h5", **kwargs)
-        return ScalarField(self._get(hier, time, merged, interp))
+        return ScalarField(self._get(hier, time, merged, interp, drop_ghosts=True))
 
     def GetN(self, time, pop_name, merged=False, interp="nearest", **kwargs):
         hier = self._get_hierarchy(time, f"ions_pop_{pop_name}_density.h5", **kwargs)
@@ -128,7 +73,7 @@ class Run:
 
     def GetVi(self, time, merged=False, interp="nearest", **kwargs):
         hier = self._get_hierarchy(time, "ions_bulkVelocity.h5", **kwargs)
-        return VectorField(self._get(hier, time, merged, interp))
+        return VectorField(self._get(hier, time, merged, interp, drop_ghosts=True))
 
     def GetFlux(self, time, pop_name, merged=False, interp="nearest", **kwargs):
         hier = self._get_hierarchy(time, f"ions_pop_{pop_name}_flux.h5", **kwargs)
@@ -157,13 +102,10 @@ class Run:
 
     def GetPe(self, time, merged=False, interp="nearest", all_primal=True):
         hier = self._get_hierarchy(time, "ions_charge_density.h5")
-
         Te = hier.sim.electrons.closure.Te
-
         if not all_primal:
             return Te * self._get(hier, time, merged, interp)
-
-        h = compute_hier_from(_compute_to_primal, hier, scalar="rho")
+        h = compute_hier_from(hc.drop_ghosts, hier)
         return ScalarField(h) * Te
 
     def GetJ(self, time, merged=False, interp="nearest", all_primal=True, **kwargs):
@@ -173,8 +115,8 @@ class Run:
         J = compute_hier_from(_compute_current, B)
         if not all_primal:
             return self._get(J, time, merged, interp)
-        h = compute_hier_from(_compute_to_primal, J, x="Jx", y="Jy", z="Jz")
-        return VectorField(h)
+        J = compute_hier_from(_compute_to_primal, J)
+        return VectorField(J)
 
     def GetDivB(self, time, merged=False, interp="nearest", **kwargs):
         B = self.GetB(time, all_primal=False, **kwargs)
@@ -355,12 +297,10 @@ class Run:
         return list_of_mass[0]
 
     def GetDomainSize(self, **kwargs):
-        import h5py
-
-        data_file = h5py.File(self.available_diags[0], "r")  # That is the first file in th available diags
-        root_cell_width = np.asarray(data_file.attrs["cell_width"])
-
-        return (data_file.attrs["domain_box"] + 1) * root_cell_width
+        hier = self._get_any_hierarchy(self.default_time)
+        root_cell_width = hier.level(0).cell_width
+        domain_box = hier.domain_box
+        return (domain_box.upper + 1) * root_cell_width
 
     def GetDl(self, level="finest", time=None):
         """
@@ -372,55 +312,80 @@ class Run:
         :param time: the time because level depends on it
         """
 
-        import h5py
-
-        def _get_time():
-            if time:
-                return time
-            if self.default_time_:
-                return self.default_time_
-            self.default_time_ = float(list(data_file[h5_time_grp_key].keys())[0])
-            return self.default_time_
-
-        h5_time_grp_key = "t"
-        files = self.available_diags
-
-        for h5_filename in files:
-            data_file = h5py.File(h5_filename, "r")
-
-            time = _get_time()
-
-            try:
-                hier = self._get_hierarchy(time, h5_filename.split("/")[-1])
-
-                if level == "finest":
-                    level = hier.finest_level(time)
-                fac = np.power(hier.refinement_ratio, level)
-
-                root_cell_width = np.asarray(data_file.attrs["cell_width"])
-
-                return root_cell_width / fac
-
-            except KeyError:
-                ...  # time may not be avilaable for given quantity
-
-        raise RuntimeError("Unable toGetDl")
+        time = time if time is not None else self.default_time
+        hier = self._get_any_hierarchy(time)
+        level = hier.finest_level(time) if level == "finest" else level
+        return hier.level(level).cell_width
 
     def all_times(self):
-        import h5py
-
-        files = self.available_diags
-        ts = {}
-        for file in files:
-            basename = os.path.basename(file).split(".")[0]
-            ff = h5py.File(file)
-            time_keys = ff["t"].keys()
-            time = np.zeros(len(time_keys))
-            for it, t in enumerate(time_keys):
-                time[it] = float(t)
-            ts[quantities_per_file[basename]] = time
-            ff.close()
-        return ts
+        return {Path(file).stem: all_times_from(file) for file in self.available_diags}
 
     def times(self, qty):
         return self.all_times()[qty]
+
+    def _available_diags(self):
+        files = glob.glob(os.path.join(self.path, "*.h5"))
+        if not files:
+            raise RuntimeError(f"No HDF5 files found at: {self.path}")
+        return files
+
+    def _get_any_hierarchy(self, time):
+        return self._get_hierarchy(time, os.path.basename(self.available_diags[0]))
+
+    def _get_hierarchy(self, times, filename, hier=None, **kwargs):
+        from pyphare.core.box import Box
+
+        times = phut.listify(times)
+        times = [f"{t:.10f}" for t in times]
+        if "selection_box" in kwargs:
+            if isinstance(kwargs["selection_box"], tuple):
+                lower = kwargs["selection_box"][:2]
+                upper = kwargs["selection_box"][2:]
+                kwargs["selection_box"] = Box(lower, upper)
+
+        def _get_hier(h):
+            return hierarchy_from(
+                h5_filename=os.path.join(self.path, filename),
+                times=times,
+                hier=h,
+                **kwargs,
+            )
+
+        return _get_hier(hier)
+
+    # TODO maybe transform that so multiple times can be accepted
+    def _get(self, hierarchy, time, merged, interp, drop_ghosts=False):
+        """
+        if merged=True, will return an interpolator and a tuple of 1d arrays
+        with the coordinates of the finest grid where the interpolator
+        can be calculated (that is the return of flat_finest_field)
+        """
+        if merged:
+            domain = self.GetDomainSize()
+            dl = self.GetDl(time=time)
+
+            # assumes all qties in the hierarchy have the same ghost width
+            # so take the first patch data of the first patch of the first level....
+            nbrGhosts = list(hierarchy.level(0).patches[0].patch_datas.values())[
+                0
+            ].ghosts_nbr
+            merged_qties = {}
+            for qty in hierarchy.quantities():
+                data, coords = flat_finest_field(hierarchy, qty, time=time)
+                merged_qties[qty] = make_interpolator(
+                    data, coords, interp, domain, dl, qty, nbrGhosts
+                )
+            return merged_qties
+        else:
+            return (
+                compute_hier_from(hc.drop_ghosts, hierarchy)
+                if drop_ghosts
+                else hierarchy
+            )
+
+    @property
+    def default_time(self):
+        if self.default_time_ is None:
+            ref_file = self.available_diags[0]
+            self.default_time_ = default_time_from(ref_file)
+        return self.default_time_

--- a/pyphare/pyphare/pharesee/run/utils.py
+++ b/pyphare/pyphare/pharesee/run/utils.py
@@ -342,6 +342,13 @@ def _compute_to_primal(patch, **kwargs):
         nb_ghosts = ref_pd.layout.nbrGhosts(ref_pd.layout.interp_order, "primal")
         ref_ds = ref_pd.dataset
 
+        should_skip = all(  # vtkhdf is all primal with no ghosts
+            [ref_pd.centerings == ["primal"] * ndim, not any(ref_pd.ghosts_nbr)]
+        )
+        if should_skip:
+            pd_attrs.append(ref_pd)
+            continue
+
         ds_shape = list(ref_ds.shape)
         for i in range(ndim):
             if ref_pd.centerings[i] == "dual":

--- a/pyphare/pyphare/pharesee/run/utils.py
+++ b/pyphare/pyphare/pharesee/run/utils.py
@@ -1,5 +1,11 @@
-from pyphare.core.gridlayout import yee_centering
+#
+#
+#
+
 import numpy as np
+
+
+from pyphare.core.gridlayout import yee_centering
 
 
 def _current1d(by, bz, xby, xbz):
@@ -59,59 +65,44 @@ def _current2d(bx, by, bz, dx, dy):
     return jx, jy, jz
 
 
-def _compute_current(patchdatas, **kwargs):
-    reference_pd = patchdatas["Bx"]  # take Bx as a reference, but could be any other
+def _compute_current(patch, **kwargs):
+    reference_pd = patch["Bx"]  # take Bx as a reference, but could be any other
 
     ndim = reference_pd.box.ndim
     if ndim == 1:
-        By = patchdatas["By"].dataset[:]
-        xby = patchdatas["By"].x
-        Bz = patchdatas["Bz"].dataset[:]
-        xbz = patchdatas["Bz"].x
-        Jy, Jz = _current1d(By, Bz, xby, xbz)
+        By = patch["By"]
+        xby = By.x
+        Bz = patch["Bz"]
+        xbz = Bz.x
+        Jy, Jz = _current1d(By[:], Bz[:], xby, xbz)
         return (
-            {"name": "Jy", "data": Jy, "centering": "primal"},
-            {"name": "Jz", "data": Jz, "centering": "primal"},
+            By.copy_as(Jy, name="Jy", centering="primal"),
+            Bz.copy_as(Jz, name="Jz", centering="primal"),
         )
 
     elif ndim == 2:
-        Bx = patchdatas["Bx"].dataset[:]
-        By = patchdatas["By"].dataset[:]
-        Bz = patchdatas["Bz"].dataset[:]
+        Bx = patch["Bx"]
+        By = patch["By"]
+        Bz = patch["Bz"]
 
         dx, dy = reference_pd.dl
+        Jx, Jy, Jz = _current2d(Bx[:], By[:], Bz[:], dx, dy)
 
-        Jx, Jy, Jz = _current2d(Bx, By, Bz, dx, dy)
-
-        components = ("Jx", "Jy", "Jz")
         centering = {
             component: [
                 reference_pd.layout.centering[direction][component]
                 for direction in ("X", "Y")
             ]
-            for component in components
+            for component in ("Jx", "Jy", "Jz")
         }
 
         return (
-            {
-                "name": "Jx",
-                "data": Jx,
-                "centering": centering["Jx"],
-                "ghosts_nbr": reference_pd.ghosts_nbr,
-            },
-            {
-                "name": "Jy",
-                "data": Jy,
-                "centering": centering["Jy"],
-                "ghosts_nbr": reference_pd.ghosts_nbr,
-            },
-            {
-                "name": "Jz",
-                "data": Jz,
-                "centering": centering["Jz"],
-                "ghosts_nbr": reference_pd.ghosts_nbr,
-            },
+            Bx.copy_as(Jx, name="Jx", centering=centering["Jx"]),
+            By.copy_as(Jy, name="Jy", centering=centering["Jy"]),
+            Bz.copy_as(Jz, name="Jz", centering=centering["Jz"]),
         )
+
+    raise RuntimeError("dimension not implemented")
 
 
 def _divB2D(Bx, By, xBx, yBy):
@@ -120,31 +111,26 @@ def _divB2D(Bx, By, xBx, yBy):
     return dxbx + dyby
 
 
-def _compute_divB(patchdatas, **kwargs):
-    reference_pd = patchdatas["Bx"]  # take Bx as a reference, but could be any other
+def _compute_divB(patch, **kwargs):
+    reference_pd = patch["Bx"]  # take Bx as a reference, but could be any other
     ndim = reference_pd.box.ndim
 
     if ndim == 1:
         raise ValueError("divB is 0 by construction in 1D")
 
-    elif ndim == 2:
-        By = patchdatas["By"].dataset[:]
-        Bx = patchdatas["Bx"].dataset[:]
-        xBx = patchdatas["Bx"].x
-        yBy = patchdatas["By"].y
-        divB = _divB2D(Bx, By, xBx, yBy)
+    centering = ["dual"] * ndim
 
-        return (
-            {
-                "name": "divB",
-                "data": divB,
-                "centering": ["dual", "dual"],
-                # "ghosts_nbr": reference_pd.ghosts_nbr,
-            },
+    if ndim == 2:
+        By = patch["By"].dataset[:]
+        Bx = patch["Bx"].dataset[:]
+        xBx = patch["Bx"].x
+        yBy = patch["By"].y
+        divB = reference_pd.copy_as(
+            _divB2D(Bx, By, xBx, yBy), name="divB", centering=centering
         )
+        return (divB,)
 
-    else:
-        raise RuntimeError("dimension not implemented")
+    raise RuntimeError("dimension not implemented")
 
 
 def _ppp_to_ppp_domain_slicing(**kwargs):
@@ -176,11 +162,12 @@ def _pdd_to_ppp_domain_slicing(**kwargs):
     if ndim == 1:
         inner_all = tuple([inner] * ndim)
         return inner_all, (inner_all,)
-    elif ndim == 2:
+
+    if ndim == 2:
         inner_all = tuple([inner] * ndim)
         return inner_all, ((inner, inner_shift_left), (inner, inner_shift_right))
-    else:
-        raise RuntimeError("dimension not yet implemented")
+
+    raise RuntimeError("dimension not yet implemented")
 
 
 def _dpd_to_ppp_domain_slicing(**kwargs):
@@ -342,53 +329,42 @@ def slices_to_primal(pdname, **kwargs):
     return slices_to_primal_[merge_centerings(pdname)](**kwargs)
 
 
-def _compute_to_primal(patchdatas, patch_id, **kwargs):
+def _compute_to_primal(patch, **kwargs):
     """
     datasets have NaN in their ghosts... might need to be properly filled
     with their neighbors already properly projected on primal
     """
 
-    reference_name = next(iter(kwargs.values()))
-    reference_pd = patchdatas[reference_name]
-    ndim = reference_pd.box.ndim
-
-    centerings = ["primal"] * ndim
+    ndim = patch.box.ndim
 
     pd_attrs = []
-    for name, pd_name in kwargs.items():
-        pd = patchdatas[pd_name]
-        nb_ghosts = int(pd.ghosts_nbr[0])
+    for name, ref_pd in patch.patch_datas.items():
+        nb_ghosts = ref_pd.layout.nbrGhosts(ref_pd.layout.interp_order, "primal")
+        ref_ds = ref_pd.dataset
 
-        ds = pd.dataset
-
-        ds_shape = list(ds.shape)
+        ds_shape = list(ref_ds.shape)
         for i in range(ndim):
-            if pd.centerings[i] == "dual":
+            if ref_pd.centerings[i] == "dual":
                 ds_shape[i] += 1
 
         # should be something else than nan values when the ghosts cells
         # will be filled with correct values coming from the neighbors
-        ds_all_primal = np.full(ds_shape, np.nan)
         ds_ = np.zeros(ds_shape)
 
         # inner is the slice containing the points that are updated
         # in the all_primal dataset
         # chunks is a tupls of all the slices coming from the initial dataset
         # that are needed to calculate the average for the all_primal dataset
-        inner, chunks = slices_to_primal(pd_name, nb_ghosts=nb_ghosts, ndim=ndim)
+        inner, chunks = slices_to_primal(name, nb_ghosts=nb_ghosts, ndim=ndim)
 
         for chunk in chunks:
-            ds_[inner] = np.add(ds_[inner], ds[chunk] / len(chunks))
-        ds_all_primal[inner] = ds_[inner]
+            ds_[inner] = np.add(ds_[inner], ref_ds[chunk] / len(chunks))
 
-        pd_attrs.append(
-            {
-                "name": name,
-                "data": ds_all_primal,
-                "centering": centerings,
-                "ghosts_nbr": [nb_ghosts] * ndim,
-            }
+        copy_pd = ref_pd.copy_as(
+            ds_[inner], name=name, centering=["primal"] * ndim, ghosts_nbr=[0] * ndim
         )
+
+        pd_attrs.append(copy_pd)
 
     return tuple(pd_attrs)
 
@@ -401,18 +377,18 @@ def _inner_slices(nb_ghosts):
     return inner, inner_shift_left, inner_shift_right
 
 
-def _get_rank(patchdatas, patch_id, **kwargs):
+def _get_rank(patch, **kwargs):
     """
     make a field dataset cell centered coding the MPI rank
     rank is obtained from patch global id == "rank#local_patch_id"
     """
     from pyphare.core.box import grow
 
-    reference_pd = patchdatas["Bx"]  # Bx as a ref, but could be any other
+    reference_pd = patch["Bx"]  # Bx as a ref, but could be any other
     ndim = reference_pd.box.ndim
 
     layout = reference_pd.layout
-    centering = "dual"
+    centering = ["dual"] * ndim
     nbrGhosts = reference_pd.ghosts_nbr[0]
     shape = grow(reference_pd.box, [nbrGhosts] * 2).shape
 
@@ -420,49 +396,43 @@ def _get_rank(patchdatas, patch_id, **kwargs):
         pass
 
     elif ndim == 2:
-        data = np.zeros(shape) + int(patch_id.strip("p").split("#")[0])
-        return (
-            {
-                "name": "rank",
-                "data": data,
-                "centering": [centering] * 2,
-                # "ghosts_nbr": reference_pd.ghosts_nbr,
-            },
-        )
+        data = np.zeros(shape) + int(patch.id.strip("p").split("#")[0])
+        pd = reference_pd.copy_as(data, name="rank", centering=centering)
+        return (pd,)
     else:
         raise RuntimeError("Not Implemented yet")
 
 
-def _compute_pressure(patch_datas, **kwargs):
-    Mxx = patch_datas["Mxx"].dataset[:]
-    Mxy = patch_datas["Mxy"].dataset[:]
-    Mxz = patch_datas["Mxz"].dataset[:]
-    Myy = patch_datas["Myy"].dataset[:]
-    Myz = patch_datas["Myz"].dataset[:]
-    Mzz = patch_datas["Mzz"].dataset[:]
-    massDensity = patch_datas["value"].dataset[:]
-    Vix = patch_datas["Vx"].dataset[:]
-    Viy = patch_datas["Vy"].dataset[:]
-    Viz = patch_datas["Vz"].dataset[:]
+def _compute_pressure(patch, **kwargs):
+    Mxx = patch["Mxx"]
+    Mxy = patch["Mxy"]
+    Mxz = patch["Mxz"]
+    Myy = patch["Myy"]
+    Myz = patch["Myz"]
+    Mzz = patch["Mzz"]
+    massDensity = patch["value"][:]
+    Vix = patch["Vx"][:]
+    Viy = patch["Vy"][:]
+    Viz = patch["Vz"][:]
 
-    Pxx = Mxx - Vix * Vix * massDensity
-    Pxy = Mxy - Vix * Viy * massDensity
-    Pxz = Mxz - Vix * Viz * massDensity
-    Pyy = Myy - Viy * Viy * massDensity
-    Pyz = Myz - Viy * Viz * massDensity
-    Pzz = Mzz - Viz * Viz * massDensity
+    Pxx = Mxx[:] - Vix * Vix * massDensity
+    Pxy = Mxy[:] - Vix * Viy * massDensity
+    Pxz = Mxz[:] - Vix * Viz * massDensity
+    Pyy = Myy[:] - Viy * Viy * massDensity
+    Pyz = Myz[:] - Viy * Viz * massDensity
+    Pzz = Mzz[:] - Viz * Viz * massDensity
 
     return (
-        {"name": "Pxx", "data": Pxx, "centering": ["primal", "primal"]},
-        {"name": "Pxy", "data": Pxy, "centering": ["primal", "primal"]},
-        {"name": "Pxz", "data": Pxz, "centering": ["primal", "primal"]},
-        {"name": "Pyy", "data": Pyy, "centering": ["primal", "primal"]},
-        {"name": "Pyz", "data": Pyz, "centering": ["primal", "primal"]},
-        {"name": "Pzz", "data": Pzz, "centering": ["primal", "primal"]},
+        Mxx.copy_as(Pxx, name="Pxx"),
+        Mxy.copy_as(Pxy, name="Pxy"),
+        Mxz.copy_as(Pxz, name="Pxz"),
+        Myy.copy_as(Pyy, name="Pyy"),
+        Myz.copy_as(Pyz, name="Pyz"),
+        Mzz.copy_as(Pzz, name="Pzz"),
     )
 
 
-def _compute_pop_pressure(patch_datas, **kwargs):
+def _compute_pop_pressure(patch, **kwargs):
     """
     computes the pressure tensor for a given population
     this method is different from _compute_pressure in that:
@@ -473,33 +443,33 @@ def _compute_pop_pressure(patch_datas, **kwargs):
         P = M - F*F/N * mass
     """
     popname = kwargs["popname"]
-    Mxx = patch_datas[popname + "_Mxx"].dataset[:]
-    Mxy = patch_datas[popname + "_Mxy"].dataset[:]
-    Mxz = patch_datas[popname + "_Mxz"].dataset[:]
-    Myy = patch_datas[popname + "_Myy"].dataset[:]
-    Myz = patch_datas[popname + "_Myz"].dataset[:]
-    Mzz = patch_datas[popname + "_Mzz"].dataset[:]
-    Fx = patch_datas["x"].dataset[:]
-    Fy = patch_datas["y"].dataset[:]
-    Fz = patch_datas["z"].dataset[:]
-    N = patch_datas["value"].dataset[:]
+    Mxx = patch[popname + "_Mxx"]
+    Mxy = patch[popname + "_Mxy"]
+    Mxz = patch[popname + "_Mxz"]
+    Myy = patch[popname + "_Myy"]
+    Myz = patch[popname + "_Myz"]
+    Mzz = patch[popname + "_Mzz"]
+    Fx = patch["x"][:]
+    Fy = patch["y"][:]
+    Fz = patch["z"][:]
+    N = patch["value"][:]
 
     mass = kwargs["mass"]
 
-    Pxx = Mxx - Fx * Fx * mass / N
-    Pxy = Mxy - Fx * Fy * mass / N
-    Pxz = Mxz - Fx * Fz * mass / N
-    Pyy = Myy - Fy * Fy * mass / N
-    Pyz = Myz - Fy * Fz * mass / N
-    Pzz = Mzz - Fz * Fz * mass / N
+    Pxx = Mxx[:] - Fx * Fx * mass / N
+    Pxy = Mxy[:] - Fx * Fy * mass / N
+    Pxz = Mxz[:] - Fx * Fz * mass / N
+    Pyy = Myy[:] - Fy * Fy * mass / N
+    Pyz = Myz[:] - Fy * Fz * mass / N
+    Pzz = Mzz[:] - Fz * Fz * mass / N
 
     return (
-        {"name": popname + "_Pxx", "data": Pxx, "centering": ["primal", "primal"]},
-        {"name": popname + "_Pxy", "data": Pxy, "centering": ["primal", "primal"]},
-        {"name": popname + "_Pxz", "data": Pxz, "centering": ["primal", "primal"]},
-        {"name": popname + "_Pyy", "data": Pyy, "centering": ["primal", "primal"]},
-        {"name": popname + "_Pyz", "data": Pyz, "centering": ["primal", "primal"]},
-        {"name": popname + "_Pzz", "data": Pzz, "centering": ["primal", "primal"]},
+        Mxx.copy_as(Pxx, name=popname + "_Pxx"),
+        Mxy.copy_as(Pxy, name=popname + "_Pxy"),
+        Mxz.copy_as(Pxz, name=popname + "_Pxz"),
+        Myy.copy_as(Pyy, name=popname + "_Pyy"),
+        Myz.copy_as(Pyz, name=popname + "_Pyz"),
+        Mzz.copy_as(Pzz, name=popname + "_Pzz"),
     )
 
 

--- a/src/amr/wrappers/hierarchy.hpp
+++ b/src/amr/wrappers/hierarchy.hpp
@@ -88,7 +88,9 @@ public:
     void closeRestartFile() { SamraiLifeCycle::getRestartManager()->closeRestartFile(); }
 
     NO_DISCARD bool isFromRestart() const
-    { return SamraiLifeCycle::getRestartManager()->isFromRestart(); }
+    {
+        return SamraiLifeCycle::getRestartManager()->isFromRestart();
+    }
 
 private:
     std::optional<std::string> static restartFilePath(auto const& dict)

--- a/tests/amr/data/field/refine/test_refine_field.py
+++ b/tests/amr/data/field/refine/test_refine_field.py
@@ -58,7 +58,7 @@ def cropToFieldData(fine_data, field):
             field.ghosts_nbr[2] : -field.ghosts_nbr[2],
         ]
     fine_layout = fine_layout_from(field)
-    return FieldData(fine_layout, field.field_name, data=fine_data)
+    return FieldData(fine_layout, field.name, data=fine_data)
 
 
 def refine_electric(field, **kwargs):
@@ -77,7 +77,7 @@ def refine_electric(field, **kwargs):
         # the algo for electric refinement is that fine edges falling on top of coarse
         # ones share their value. So here we just take the coarse value whatever the
         # centering.
-        print(field.field_name)
+        print(field.name)
         print(field.box.shape)
         print(field.dataset.shape)
         fine_data[::2] = coarse_data

--- a/tests/simulator/initialize/density_check.py
+++ b/tests/simulator/initialize/density_check.py
@@ -1,24 +1,16 @@
 import os
-
-from pyphare.simulator.simulator import Simulator
-from pyphare.pharesee.run import Run
+import numpy as np
+import matplotlib as mpl
 
 import pyphare.pharein as ph
-
+from pyphare.pharesee.run import Run
 from pyphare.pharein import global_vars
-from tests.diagnostic import all_timestamps
-
+from pyphare.pharesee.hierarchy import fromfunc
+from pyphare.simulator.simulator import Simulator
+from pyphare.pharesee.hierarchy import hierarchy_from
 from pyphare.pharein.diagnostics import FluidDiagnostics
 
-import matplotlib.pyplot as plt
-import matplotlib as mpl
-import numpy as np
-
-from pyphare.pharesee.hierarchy import hierarchy_from
-from pyphare.pharesee.hierarchy.fromfunc import ions_mass_density_func1d
-from pyphare.pharesee.hierarchy.fromfunc import ions_charge_density_func1d
-from pyphare.pharesee.hierarchy.fromfunc import ions_mass_density_func2d
-from pyphare.pharesee.hierarchy.fromfunc import ions_charge_density_func2d
+from tests.diagnostic import all_timestamps
 
 mpl.use("Agg")
 
@@ -219,6 +211,8 @@ def config_2d():
 
 
 def main():
+    import matplotlib.pyplot as plt
+
     Simulator(config_1d()).run().reset()
     ph.global_vars.sim = None
     Simulator(config_2d()).run().reset()
@@ -248,13 +242,13 @@ def main():
 
     H1 = hierarchy_from(
         hier=h1,
-        func=ions_mass_density_func1d,
+        func=fromfunc.ions_mass_density_func1d,
         masses=masses,
         densities=(densityMain_1d, densityBeam_1d),
     )
     H2 = hierarchy_from(
         hier=h2,
-        func=ions_charge_density_func1d,
+        func=fromfunc.ions_charge_density_func1d,
         charges=charges,
         densities=(densityMain_1d, densityBeam_1d),
     )
@@ -283,13 +277,13 @@ def main():
 
     H1 = hierarchy_from(
         hier=h1,
-        func=ions_mass_density_func2d,
+        func=fromfunc.ions_mass_density_func2d,
         masses=masses,
         densities=(densityMain_2d, densityBeam_2d),
     )
     H2 = hierarchy_from(
         hier=h2,
-        func=ions_charge_density_func2d,
+        func=fromfunc.ions_charge_density_func2d,
         charges=charges,
         densities=(densityMain_2d, densityBeam_2d),
     )

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -143,7 +143,7 @@ class InitializationTest(SimulatorTest):
 
                 pdatas = patch.patch_datas
                 layout = pdatas["protons_Fx"].layout
-                centering = layout.centering["X"][pdatas["protons_Fx"].field_name]
+                centering = layout.centering["X"][pdatas["protons_Fx"].name]
                 nbrGhosts = layout.nbrGhosts(
                     interp_order, centering
                 )  # primal in all directions
@@ -206,7 +206,7 @@ class InitializationTest(SimulatorTest):
                 x = patch.patch_datas["rho"].x
 
                 layout = patch.patch_datas["rho"].layout
-                centering = layout.centering["X"][patch.patch_datas["rho"].field_name]
+                centering = layout.centering["X"][patch.patch_datas["rho"].name]
                 nbrGhosts = layout.nbrGhosts(interp_order, centering)
                 select = tuple([slice(nbrGhosts, -nbrGhosts) for i in range(ndim)])
 
@@ -265,7 +265,7 @@ class InitializationTest(SimulatorTest):
             patch = hier.level(0).patches[0]
             layout = patch.patch_datas["rho"].layout
 
-            centering = layout.centering["X"][patch.patch_datas["rho"].field_name]
+            centering = layout.centering["X"][patch.patch_datas["rho"].name]
             nbrGhosts = layout.nbrGhosts(interp_order, centering)
             select = tuple([slice(nbrGhosts, -nbrGhosts) for i in range(dim)])
             ion_density = patch.patch_datas["rho"].dataset[:]

--- a/tests/simulator/test_run.py
+++ b/tests/simulator/test_run.py
@@ -14,19 +14,17 @@ ph.NO_GUI()
 
 time_step = 0.005
 final_time = 0.01
+time_step_nbr = int(final_time / time_step)
 timestamps = [0, time_step, final_time]
-diag_dir = "phare_outputs/test_run"
-plot_dir = Path(f"{diag_dir}_plots")
-plot_dir.mkdir(parents=True, exist_ok=True)
 
 
-def config():
+def config(diag_dir, diag_format):
     L = 0.5
 
     sim = ph.Simulation(
         time_step=time_step,
         final_time=final_time,
-        cells=(40, 40),
+        cells=(20, 20),
         dl=(0.40, 0.40),
         refinement="tagging",
         max_nbr_levels=3,
@@ -36,7 +34,7 @@ def config():
         hyper_resistivity=0.002,
         resistivity=0.001,
         diag_options={
-            "format": "phareh5",
+            "format": diag_format,
             "options": {"dir": diag_dir, "mode": "overwrite"},
         },
     )
@@ -159,65 +157,75 @@ def config():
     return sim
 
 
-def plot_file_for_qty(qty, time):
+def plot_file_for_qty(plot_dir, qty, time):
     return f"{plot_dir}/harris_{qty}_t{time}.png"
 
 
 def plot(diag_dir):
+    """common across phareh5 and vtk"""
     run = Run(diag_dir)
+    plot_dir = Path(f"{diag_dir}_plots")
+    plot_dir.mkdir(parents=True, exist_ok=True)
+
+    pop_name = "protons"
+    for time in timestamps:
+        run.GetN(time, pop_name=pop_name).plot(
+            filename=plot_file_for_qty(plot_dir, "N", time), plot_patches=True
+        )
+        for c in ["x", "y", "z"]:
+            run.GetB(time, all_primal=False).plot(
+                filename=plot_file_for_qty(plot_dir, f"b{c}", time),
+                qty=f"B{c}",
+                plot_patches=True,
+            )
+    return plot_dir
+
+
+def plot_phareh5(diag_dir):
+    """only works for phareh5 currently"""
+    run = Run(diag_dir)
+    plot_dir = Path(f"{diag_dir}_plots")
+    plot_dir.mkdir(parents=True, exist_ok=True)
+
     pop_name = "protons"
     for time in timestamps:
         run.GetDivB(time).plot(
-            filename=plot_file_for_qty("divb", time),
+            filename=plot_file_for_qty(plot_dir, "divb", time),
             plot_patches=True,
             vmin=1e-11,
             vmax=2e-10,
         )
         run.GetRanks(time).plot(
-            filename=plot_file_for_qty("Ranks", time), plot_patches=True
+            filename=plot_file_for_qty(plot_dir, "Ranks", time), plot_patches=True
         )
-        run.GetN(time, pop_name=pop_name).plot(
-            filename=plot_file_for_qty("N", time), plot_patches=True
-        )
-
-        B = run.GetB(time, all_primal=False)
-        Bexp = np.exp(B)
-        for c in ["x", "y", "z"]:
-            B.plot(
-                filename=plot_file_for_qty(f"b{c}", time),
-                qty=f"B{c}",
-                plot_patches=True,
-            )
-            Bexp.plot(filename=plot_file_for_qty(f"b{c}_exp", time), qty=f"B{c}")
-
         run.GetJ(time).plot(
-            all_primal=False,
-            filename=plot_file_for_qty("jz", time),
+            filename=plot_file_for_qty(plot_dir, "jz", time),
             qty="z",
             plot_patches=True,
             vmin=-2,
             vmax=2,
         )
         run.GetPressure(time, pop_name=pop_name).plot(
-            filename=plot_file_for_qty(f"{pop_name}_Pxx", time),
+            filename=plot_file_for_qty(plot_dir, f"{pop_name}_Pxx", time),
             qty=pop_name + "_Pxx",
             plot_patches=True,
         )
         run.GetPressure(time, pop_name=pop_name).plot(
-            filename=plot_file_for_qty(f"{pop_name}_Pzz", time),
+            filename=plot_file_for_qty(plot_dir, f"{pop_name}_Pzz", time),
             qty=pop_name + "_Pzz",
             plot_patches=True,
         )
         run.GetPi(time).plot(
-            filename=plot_file_for_qty("Pxx", time),
+            filename=plot_file_for_qty(plot_dir, "Pxx", time),
             qty="Pxx",
             plot_patches=True,
         )
         run.GetPi(time).plot(
-            filename=plot_file_for_qty("Pzz", time),
+            filename=plot_file_for_qty(plot_dir, "Pzz", time),
             qty="Pzz",
             plot_patches=True,
         )
+    return plot_dir
 
 
 def assert_file_exists_with_size_at_least(file, size=10000):
@@ -243,31 +251,40 @@ class RunTest(SimulatorTest):
         self.simulator = None
         ph.global_vars.sim = None
 
-    def test_run(self):
-        sim = config()
+    def _run_simulation(self, sim, diag_dir):
         self.register_diag_dir_for_cleanup(diag_dir)
         Simulator(sim).run().reset()
 
-        run = Run(diag_dir)
-        B = run.GetB(timestamps[-1], all_primal=False)
-        self.assertTrue(B.levels()[0].patches[0].attrs)
-
-        B = run.GetB(timestamps[-1])
-        self.assertTrue(B.levels()[0].patches[0].attrs)
+    def test_run_phareh5(self):
+        diag_dir = "phare_outputs/test_run_phareh5"
+        sim = config(diag_dir, "phareh5")
+        self._run_simulation(sim, diag_dir)
 
         if cpp.mpi_rank() == 0:
-            plot(diag_dir)
-
+            plot_phareh5(diag_dir)
+            plot_dir = plot(diag_dir)
             for time in timestamps:
                 for q in ["divb", "Ranks", "N", "jz"]:
-                    assert_file_exists_with_size_at_least(plot_file_for_qty(q, time))
+                    assert_file_exists_with_size_at_least(
+                        plot_file_for_qty(plot_dir, q, time)
+                    )
 
                 for c in ["x", "y", "z"]:
                     assert_file_exists_with_size_at_least(
-                        plot_file_for_qty(f"b{c}", time)
+                        plot_file_for_qty(plot_dir, f"b{c}", time)
                     )
 
-        cpp.mpi_barrier()
+    def test_run_pharevtkhdf(self):
+        diag_dir = "phare_outputs/test_run_pharevtkhdf"
+        sim = config(diag_dir, "pharevtkhdf")
+        self._run_simulation(sim, diag_dir)
+        if cpp.mpi_rank() == 0:
+            plot_dir = plot(diag_dir)
+            for time in timestamps:
+                for c in ["x", "y", "z"]:
+                    assert_file_exists_with_size_at_least(
+                        plot_file_for_qty(plot_dir, f"b{c}", time)
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/simulator/test_vtk_diagnostics.py
+++ b/tests/simulator/test_vtk_diagnostics.py
@@ -8,9 +8,12 @@ from ddt import data, ddt, unpack
 
 from pyphare import cpp
 import pyphare.pharein as ph
+from pyphare.pharesee.run import Run
 from pyphare.core import phare_utilities as phut
 from pyphare.simulator.simulator import startMPI
 from pyphare.simulator.simulator import Simulator
+from pyphare.pharein.simulation import supported_dimensions
+from pyphare.pharesee.hierarchy import hierarchy_utils as hootils
 
 from tests.simulator import SimulatorTest
 from tests.diagnostic import dump_all_diags
@@ -22,91 +25,62 @@ ppc_per_dim = [100, 25, 10]
 def config(sim):
     ppc = ppc_per_dim[sim.ndim - 1]
 
-    L = 0.5
+    def density(*xyz):
+        return 1.0
 
-    def density(x, y):
-        Ly = sim.simulation_domain()[1]
-        return (
-            0.4
-            + 1.0 / np.cosh((y - Ly * 0.3) / L) ** 2
-            + 1.0 / np.cosh((y - Ly * 0.7) / L) ** 2
-        )
-
-    def S(y, y0, l):
-        return 0.5 * (1.0 + np.tanh((y - y0) / l))
-
-    def by(x, y):
-        Lx = sim.simulation_domain()[0]
-        Ly = sim.simulation_domain()[1]
-        sigma = 1.0
-        dB = 0.1
-
-        x0 = x - 0.5 * Lx
-        y1 = y - 0.3 * Ly
-        y2 = y - 0.7 * Ly
-
-        dBy1 = 2 * dB * x0 * np.exp(-(x0**2 + y1**2) / (sigma) ** 2)
-        dBy2 = -2 * dB * x0 * np.exp(-(x0**2 + y2**2) / (sigma) ** 2)
-
-        return dBy1 + dBy2
-
-    def bx(x, y):
-        Lx = sim.simulation_domain()[0]
-        Ly = sim.simulation_domain()[1]
-        sigma = 1.0
-        dB = 0.1
-
-        x0 = x - 0.5 * Lx
-        y1 = y - 0.3 * Ly
-        y2 = y - 0.7 * Ly
-
-        dBx1 = -2 * dB * y1 * np.exp(-(x0**2 + y1**2) / (sigma) ** 2)
-        dBx2 = 2 * dB * y2 * np.exp(-(x0**2 + y2**2) / (sigma) ** 2)
-
-        v1 = -1
-        v2 = 1.0
-        return v1 + (v2 - v1) * (S(y, Ly * 0.3, L) - S(y, Ly * 0.7, L)) + dBx1 + dBx2
-
-    def bz(x, y):
+    def bx(*xyz):
         return 0.0
 
-    def b2(x, y):
-        return bx(x, y) ** 2 + by(x, y) ** 2 + bz(x, y) ** 2
+    def S(x, x0, l):
+        return 0.5 * (1 + np.tanh((x - x0) / l))
 
-    def T(x, y):
-        K = 0.7
-        temp = 1.0 / density(x, y) * (K - b2(x, y) * 0.5)
-        assert np.all(temp > 0)
-        return temp
+    def by(*xyz):
+        L = ph.global_vars.sim.simulation_domain()[0]
+        v1, v2 = -1, 1.0
+        return v1 + (v2 - v1) * (S(xyz[0], L * 0.25, 1) - S(xyz[0], L * 0.75, 1))
 
-    def vx(x, y):
+    def bz(*xyz):
+        return 0.5
+
+    def b2(*xyz):
+        return bx(xyz[0]) ** 2 + by(xyz[0]) ** 2 + bz(xyz[0]) ** 2
+
+    def T(*xyz):
+        K = 1
+        return 1 / density(xyz[0]) * (K - b2(xyz[0]) * 0.5)
+
+    def vx(*xyz):
+        return 2.0
+
+    def vy(*xyz):
         return 0.0
 
-    def vy(x, y):
+    def vz(*xyz):
         return 0.0
 
-    def vz(x, y):
-        return 0.0
+    def vxalpha(*xyz):
+        return 3.0
 
-    def vthx(x, y):
-        return np.sqrt(T(x, y))
-
-    def vthy(x, y):
-        return np.sqrt(T(x, y))
-
-    def vthz(x, y):
-        return np.sqrt(T(x, y))
+    def vthxyz(*xyz):
+        return T(xyz[0])
 
     vvv = {
         "vbulkx": vx,
         "vbulky": vy,
         "vbulkz": vz,
-        "vthx": vthx,
-        "vthy": vthy,
-        "vthz": vthz,
+        "vthx": vthxyz,
+        "vthy": vthxyz,
+        "vthz": vthxyz,
     }
-
-    ph.MaxwellianFluidModel(
+    vvvalpha = {
+        "vbulkx": vxalpha,
+        "vbulky": vy,
+        "vbulkz": vz,
+        "vthx": vthxyz,
+        "vthy": vthxyz,
+        "vthz": vthxyz,
+    }
+    model = ph.MaxwellianFluidModel(
         bx=bx,
         by=by,
         bz=bz,
@@ -119,10 +93,10 @@ def config(sim):
             "init": {"seed": 1337},
         },
         alpha={
-            "mass": 4,
+            "mass": 4.0,
             "charge": 1,
             "density": density,
-            **vvv,
+            **vvvalpha,
             "nbr_part_per_cell": ppc,
             "init": {"seed": 2334},
         },
@@ -145,7 +119,7 @@ simArgs = {
 
 
 def permute(dic):
-    ndims = [2]
+    ndims = supported_dimensions()
     interp_orders = [1]
     dic.update(simArgs.copy())
     return [
@@ -190,6 +164,67 @@ class VTKDiagnosticsTest(SimulatorTest):
                 plot_vtk(local_out + "/EM_E.vtkhdf", f"E{ndim}d_interp{interp}.vtk.png")
             except ModuleNotFoundError:
                 print("WARNING: vtk python module not found - cannot make plots")
+
+    @data(*permute({}))
+    @unpack
+    def test_compare_l0_primal_to_phareh5(self, ndim, interp, simInput):
+        print("test_compare_l0_primal_to_phareh5 dim/interp:{}/{}".format(ndim, interp))
+
+        b0 = [[10 for i in range(ndim)], [19 for i in range(ndim)]]
+        simInput["refinement_boxes"] = {"L0": {"B0": b0}}
+        vtk_diags = self._run(ndim, interp, simInput, "test_vtk")
+
+        simInput["diag_options"]["format"] = "phareh5"
+        simInput["diag_options"]["options"]["dir"] += "/phareh5"
+        phareh5_diags = self._run(ndim, interp, simInput, "test_h5")
+
+        # not binary == with more than 2 cores
+        atol = 0 if cpp.mpi_size() <= 2 else [1e-15, 1e-14, 1e-14][ndim - 1]
+        time = 0
+        # choose all primal value generally
+        phareh5_hier = Run(phareh5_diags).GetVi(time)
+        vtk_hier = Run(vtk_diags).GetVi(time)
+
+        self.assertTrue(phareh5_hier.data_files)
+        self.assertTrue(vtk_hier.data_files)
+        self.assertTrue(vtk_hier.data_files != phareh5_hier.data_files)
+        eqr = hootils.hierarchy_compare(vtk_hier, phareh5_hier, atol)
+        if not eqr:
+            print(eqr)
+        self.assertTrue(eqr)
+
+    @data(*permute({}))
+    @unpack
+    def test_missing_level_case(self, ndim, interp, simInput):
+        simInput.update(
+            dict(
+                refinement="tagging",
+                max_nbr_levels=2,
+                tagging_threshold=0.99,  # prevent level,
+            )
+        )
+        simInput["restart_options"] = dict(mode="overwrite", timestamps=[0.001])
+        vtk_diags = self._run(ndim, interp, simInput, "test_padding_vtk")
+
+        simInput.update(
+            dict(
+                final_time=0.002,
+                tagging_threshold=0.01,  # prefer level
+            )
+        )
+
+        simInput["restart_options"]["timestamps"] = []
+        simInput["restart_options"]["restart_time"] = 0.001
+        del simInput["diag_options"]["options"]["mode"]  # do not truncate diags
+        vtk_diags = self._run(ndim, interp, simInput, "test_padding_vtk")
+
+        hier0 = Run(vtk_diags).GetVi(0)
+        hier1 = Run(vtk_diags).GetVi(0.001)
+        hier2 = Run(vtk_diags).GetVi(0.002)
+
+        self.assertTrue(1 not in hier0.levels())
+        self.assertTrue(1 not in hier1.levels())
+        self.assertTrue(1 in hier2.levels())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
vtk patch hierarchies
cleanup compute_hier from stuff for extensibilty/ease of understanding 

the main reason for the compute_heir changes is that now, we need to be able to copy either a regular FieldData, or a VTKFieldData, and so must be able to copy per context

as visible here in these files in the new `*.copy_as()` functions :
`vtk/pyphare/pyphare/pharesee/hierarchy/patchdata.py`
`vtk/pyphare/pyphare/pharesee/hierarchy/for_vtk/patchdata.py`

possible the compute/rename stuff could be done before vtk hierarchies

this is intial work for future changes which include lazy loading instead if computing the entier hierarchy and such