### PR TITLE
try not duplicate levelghosts across overlapping patch ghost boxes

### DIFF
--- a/src/amr/data/particles/particles_data.hpp
+++ b/src/amr/data/particles/particles_data.hpp
@@ -11,6 +11,7 @@
 #include "amr/samrai.hpp"
 #include "amr/utilities/box/amr_box.hpp"
 #include "amr/resources_manager/amr_utils.hpp"
+#include <SAMRAI/hier/BoxContainer.h>
 #include <amr/data/particles/particles_variable_fill_pattern.hpp>
 
 
@@ -464,6 +465,9 @@ namespace amr
 
         core::ParticlesPack<ParticleArray> pack;
 
+        // set externally (in registerLevel) to the subset of the level ghost region this
+        // patch owns exclusively — used to avoid filling duplicate particles across patches
+        SAMRAI::hier::BoxContainer ownedLevelGhostBoxes;
 
     private:
         //! interiorLocalBox_ is the box, in local index space, that goes from the first to the

--- a/src/amr/data/particles/refine/particles_data_split.hpp
+++ b/src/amr/data/particles/refine/particles_data_split.hpp
@@ -52,6 +52,12 @@ namespace amr
     template<typename ParticleArray, ParticlesDataSplitType splitType, typename Splitter>
     class ParticlesRefineOperator : public SAMRAI::hier::RefineOperator
     {
+        bool static constexpr putParticlesInCoarseBoundary
+            = splitType == ParticlesDataSplitType::coarseBoundary
+              || splitType == ParticlesDataSplitType::coarseBoundaryOld
+              || splitType == ParticlesDataSplitType::coarseBoundaryNew;
+
+
     public:
         static constexpr auto dim           = Splitter::dimension;
         static constexpr auto interpOrder   = Splitter::interp_order;
@@ -154,9 +160,11 @@ namespace amr
             // new patches) or coarse to fine boundaries (during advance), so we need references to
             // these arrays on the destination. We don't fill patch ghost particles with this
             // operator
-            auto const& destBoxes = destFieldOverlap.getDestinationBoxContainer();
+
+            auto& destBoxes = destFieldOverlap.getDestinationBoxContainer();
 
             // used when initializing a new patch
+
             auto& destDomainParticles = destParticlesData.domainParticles;
 
             // used when filling level ghost boundaries
@@ -174,14 +182,11 @@ namespace amr
             // The PatchLevelFillPattern had compute boxes that correspond to the expected filling.
             // In case of a coarseBoundary it will most likely give multiple boxes
             // in case of interior, this will be just one box usually
-            for (auto const& destinationBox : destBoxes)
-            {
-                auto const splitBox = getSplitBox(destinationBox);
-
-                auto const isInDest = [&destinationBox](auto const& particle) {
-                    return isInBox(destinationBox, particle);
+            auto fillBox = [&](SAMRAI::hier::Box const& box) {
+                auto const splitBox = getSplitBox(box);
+                auto const isInDest = [&box](auto const& particle) {
+                    return isInBox(box, particle);
                 };
-
 
                 for (auto const& particle : srcInteriorParticles)
                 {
@@ -192,56 +197,43 @@ namespace amr
                     {
                         split(particleRefinedPos, refinedParticles);
 
-
-                        // we need to know in which of interior or levelGhostParticlesXXXX
-                        // arrays we must put particles
-
-                        bool constexpr putParticlesInCoarseBoundary
-                            = splitType == ParticlesDataSplitType::coarseBoundary
-                              || splitType == ParticlesDataSplitType::coarseBoundaryOld
-                              || splitType == ParticlesDataSplitType::coarseBoundaryNew;
-
-
-
                         if constexpr (putParticlesInCoarseBoundary)
                         {
                             if constexpr (splitType == ParticlesDataSplitType::coarseBoundary)
-                            {
-                                /*std::cout << "copying " << refinedParticles.size()
-                                          << " particles into levelGhost\n";*/
-                                std::copy_if(
-                                    std::begin(refinedParticles), std::end(refinedParticles),
-                                    std::back_inserter(destCoarseBoundaryParticles), isInDest);
-                            }
+                                std::copy_if(std::begin(refinedParticles),
+                                             std::end(refinedParticles),
+                                             std::back_inserter(destCoarseBoundaryParticles),
+                                             isInDest);
                             else if constexpr (splitType
                                                == ParticlesDataSplitType::coarseBoundaryOld)
-                            {
-                                /*std::cout << "copying " << refinedParticles.size()
-                                          << " particles into levelGhostOld\n";*/
-                                std::copy_if(
-                                    std::begin(refinedParticles), std::end(refinedParticles),
-                                    std::back_inserter(destCoarseBoundaryOldParticles), isInDest);
-                            }
-                            else //  splitType is coarseBoundaryNew
-                            {
-                                /*std::cout << "copying " << refinedParticles.size()
-                                          << " particles into levelGhostNew\n";*/
-                                std::copy_if(
-                                    std::begin(refinedParticles), std::end(refinedParticles),
-                                    std::back_inserter(destCoarseBoundaryNewParticles), isInDest);
-                            }
+                                std::copy_if(std::begin(refinedParticles),
+                                             std::end(refinedParticles),
+                                             std::back_inserter(destCoarseBoundaryOldParticles),
+                                             isInDest);
+                            else
+                                std::copy_if(std::begin(refinedParticles),
+                                             std::end(refinedParticles),
+                                             std::back_inserter(destCoarseBoundaryNewParticles),
+                                             isInDest);
                         }
-
                         else
-                        {
-                            /*std::cout << "copying " << refinedParticles.size()
-                                      << " particles into domain\n";*/
                             std::copy_if(std::begin(refinedParticles), std::end(refinedParticles),
                                          std::back_inserter(destDomainParticles), isInDest);
-                        }
-                    } // end is candidate for split
-                } // end loop on source particle arrays
-            } // loop on destination box
+                    }
+                }
+            };
+
+            for (auto const& destinationBox : destBoxes)
+            {
+                if constexpr (putParticlesInCoarseBoundary)
+                {
+                    for (auto const& ownedBox : destParticlesData.ownedLevelGhostBoxes)
+                        if (auto const eff = ownedBox * destinationBox; !eff.empty())
+                            fillBox(eff);
+                }
+                else
+                    fillBox(destinationBox);
+            }
         }
 
 

--- a/src/amr/level_initializer/hybrid_level_initializer.hpp
+++ b/src/amr/level_initializer/hybrid_level_initializer.hpp
@@ -104,6 +104,9 @@ namespace solver
                 auto layout = amr::layoutFromPatch<GridLayoutT>(*patch);
                 core::resetMoments(ions);
                 core::depositParticles(ions, layout, interpolate_, core::DomainDeposit{});
+
+                if (!isRootLevel(levelNumber))
+                    core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
             }
 
             // at this point flux and density is computed for all pops
@@ -117,15 +120,7 @@ namespace solver
             // we now complete them by depositing levelghost particles
             for (auto& patch : rm.enumerate(level, ions))
             {
-                if (!isRootLevel(levelNumber))
-                {
-                    auto layout = amr::layoutFromPatch<GridLayoutT>(*patch);
-                    core::depositParticles(ions, layout, interpolate_, core::LevelGhostDeposit{});
-                }
-
-
-                // now all nodes are complete, the total ion moments
-                // can safely be computed.
+                // now all nodes are complete, the total ion moments can safely be computed.
                 ions.computeChargeDensity();
                 ions.computeBulkVelocity();
             }

--- a/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
+++ b/src/amr/messengers/hybrid_hybrid_messenger_strategy.hpp
@@ -15,6 +15,7 @@
 #include "amr/types/amr_types.hpp"
 #include "amr/messengers/messenger_info.hpp"
 #include "amr/resources_manager/amr_utils.hpp"
+#include "amr/data/particles/particles_data.hpp"
 #include "amr/data/field/refine/field_refiner.hpp"
 #include "amr/data/field/refine/field_moments_refiner.hpp"
 #include "amr/messengers/hybrid_messenger_info.hpp"
@@ -39,6 +40,7 @@
 #include <SAMRAI/xfer/BoxGeometryVariableFillPattern.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <iomanip>
@@ -269,6 +271,8 @@ namespace amr
                 domainParticlesRefiners_.registerLevel(hierarchy, level);
                 lvlGhostPartOldRefiners_.registerLevel(hierarchy, level);
                 lvlGhostPartNewRefiners_.registerLevel(hierarchy, level);
+
+                setOwnedLevelGhostBoxes_(*level, *hierarchy);
 
                 // and these for coarsening
                 electroSynchronizers_.registerLevel(hierarchy, level);
@@ -850,10 +854,23 @@ namespace amr
                                                        levelGhostParticlesOldOp_,
                                                        info->levelGhostParticlesOld);
 
-
             lvlGhostPartNewRefiners_.addStaticRefiners(info->levelGhostParticlesNew,
                                                        levelGhostParticlesNewOp_,
                                                        info->levelGhostParticlesNew);
+
+            if (lgPartOldIDs_.size() || lgPartNewIDs_.size())
+                throw std::runtime_error("Unexpected case for levelghost resource IDs");
+
+            for (auto const& name : info->levelGhostParticlesOld)
+            {
+                auto [id] = resourcesManager_->getIDsList(name);
+                lgPartOldIDs_.push_back(id);
+            }
+            for (auto const& name : info->levelGhostParticlesNew)
+            {
+                auto [id] = resourcesManager_->getIDsList(name);
+                lgPartNewIDs_.push_back(id);
+            }
 
 
             domainGhostPartRefiners_.addStaticRefiners(
@@ -906,6 +923,25 @@ namespace amr
         }
 
 
+
+
+        void setOwnedLevelGhostBoxes_(level_t const& level,
+                                      SAMRAI::hier::PatchHierarchy const& hierarchy)
+        {
+            using PData_t = ParticlesData<typename HybridModel::particle_array_type>;
+            for (auto const& patch : level)
+            {
+                auto const owned = makeLevelGhostParticleBoxFor<GridLayoutT>(*patch, hierarchy);
+                for (int id : lgPartOldIDs_)
+                    std::dynamic_pointer_cast<PData_t>(patch->getPatchData(id))
+                        ->ownedLevelGhostBoxes
+                        = owned;
+                for (int id : lgPartNewIDs_)
+                    std::dynamic_pointer_cast<PData_t>(patch->getPatchData(id))
+                        ->ownedLevelGhostBoxes
+                        = owned;
+            }
+        }
 
 
         void copyLevelGhostOldToPushable_(level_t& level, IPhysicalModel& model)
@@ -1119,6 +1155,8 @@ namespace amr
         RefinerPool<rm_t, LGRefT> lvlGhostPartNewRefiners_{resourcesManager_};
         RefOp_ptr levelGhostParticlesOldOp_{std::make_shared<CoarseToFineRefineOpOld>()};
         RefOp_ptr levelGhostParticlesNewOp_{std::make_shared<CoarseToFineRefineOpNew>()};
+        std::vector<int> lgPartOldIDs_;
+        std::vector<int> lgPartNewIDs_;
 
 
         //! to grab particle leaving neighboring patches and inject into domain

--- a/src/amr/resources_manager/amr_utils.hpp
+++ b/src/amr/resources_manager/amr_utils.hpp
@@ -3,9 +3,10 @@
 
 
 #include "core/def.hpp"
-#include "core/def/phare_mpi.hpp" // IWYU pragma: keep
+#include "core/def/phare_mpi.hpp" // IW#YU pragma: keep
 #include "core/utilities/mpi_utils.hpp"
 #include "core/utilities/constants.hpp"
+#include "core/data/particles/particle.hpp"
 
 #include "amr/amr_constants.hpp"
 #include "amr/types/amr_types.hpp"
@@ -13,6 +14,7 @@
 
 #include <SAMRAI/hier/Box.h>
 #include <SAMRAI/hier/Patch.h>
+#include <SAMRAI/tbox/Dimension.h>
 #include <SAMRAI/hier/IntVector.h>
 #include <SAMRAI/hier/PatchData.h>
 #include <SAMRAI/hier/BoxOverlap.h>
@@ -72,6 +74,14 @@ namespace amr
      * local index relative to referenceAMRBox
      */
     NO_DISCARD SAMRAI::hier::IntVector localToAMRVector(SAMRAI::hier::Box const& referenceAMRBox);
+
+
+    template<std::size_t dim>
+    NO_DISCARD SAMRAI::hier::Box grow(SAMRAI::hier::Box const& box, int const by)
+    {
+        return SAMRAI::hier::Box::grow(box,
+                                       SAMRAI::hier::IntVector{SAMRAI::tbox::Dimension{dim}, by});
+    }
 
 
     /**
@@ -203,12 +213,14 @@ namespace amr
 
 
     NO_DISCARD auto inline getSameLevelNeighbors(SAMRAI::hier::Patch const& patch,
-                                                 SAMRAI::hier::PatchHierarchy const& hierarchy)
-    {
-        auto const lvlNbr = patch.getPatchLevelNumber();
-
-        return SAMRAI::hier::HierarchyNeighbors{hierarchy, lvlNbr, lvlNbr}.getSameLevelNeighbors(
-            patch.getBox(), lvlNbr);
+                                                 SAMRAI::hier::PatchHierarchy const& hierarchy,
+                                                 int const width = 1)
+    { // with 1 == immediate neighbors no ghost box
+        auto const lvlNbr                 = patch.getPatchLevelNumber();
+        bool constexpr do_same_level_nbrs = true;
+        return SAMRAI::hier::HierarchyNeighbors{hierarchy, lvlNbr, lvlNbr, do_same_level_nbrs,
+                                                width}
+            .getSameLevelNeighbors(patch.getBox(), lvlNbr);
     }
 
     void inline noDomainOverlapsOn(SAMRAI::hier::PatchHierarchy const& hierarchy, int const ilvl)
@@ -233,16 +245,13 @@ namespace amr
     NO_DISCARD auto makeNonLevelGhostBoxFor(SAMRAI::hier::Patch const& patch,
                                             SAMRAI::hier::PatchHierarchy const& hierarchy)
     {
-        auto constexpr dimension       = GridLayoutT::dimension;
-        auto const lvlNbr              = patch.getPatchLevelNumber();
-        SAMRAI::hier::Box const domain = patch.getBox();
-        auto const domBox              = phare_box_from<dimension>(domain);
-        auto const particleGhostBox    = grow(domBox, GridLayoutT::nbrParticleGhosts());
-
-        auto const neighbors = getSameLevelNeighbors(patch, hierarchy);
-        std::vector<core::Box<int, GridLayoutT::dimension>> patchGhostLayerBoxes;
+        auto constexpr dimension    = GridLayoutT::dimension;
+        auto const domain           = phare_box_from<dimension>(patch.getBox());
+        auto const particleGhostBox = grow(domain, GridLayoutT::nbrParticleGhosts());
+        auto const neighbors        = getSameLevelNeighbors(patch, hierarchy);
+        std::vector<core::Box<int, dimension>> patchGhostLayerBoxes;
         patchGhostLayerBoxes.reserve(neighbors.size() + 1);
-        patchGhostLayerBoxes.emplace_back(domBox);
+        patchGhostLayerBoxes.emplace_back(domain);
         for (auto const& neighbox : neighbors)
             patchGhostLayerBoxes.emplace_back(
                 *(particleGhostBox * phare_box_from<dimension>(neighbox)));
@@ -250,12 +259,34 @@ namespace amr
         return patchGhostLayerBoxes;
     }
 
-    inline auto to_string(auto const& id)
+
+
+    // returns level ghost box areas for where this patch is considered the sole owner of the ghost
+    template<typename GridLayoutT>
+    NO_DISCARD auto makeLevelGhostParticleBoxFor(SAMRAI::hier::Patch const& patch,
+                                                 SAMRAI::hier::PatchHierarchy const& hierarchy)
     {
-        std::stringstream patchID;
-        patchID << id;
-        return patchID.str();
+        auto constexpr static ghosts    = static_cast<int>(GridLayoutT::nbrParticleGhosts());
+        auto constexpr static dimension = GridLayoutT::dimension;
+
+        auto const patch_box = phare_box_from<dimension>(patch.getBox());
+        auto const patch_idx = core::CellFlattener{patch_box}(patch_box.lower);
+
+        auto level_ghost_boxes
+            = SAMRAI::hier::BoxContainer{grow<dimension>(patch.getBox(), ghosts)};
+        level_ghost_boxes.removeIntersections(patch.getBox());
+
+        for (auto const& neighbox : getSameLevelNeighbors(patch, hierarchy, ghosts + 1))
+        {
+            auto const box = phare_box_from<dimension>(neighbox);
+            auto const idx = core::CellFlattener{box}(box.lower);
+            if (idx < patch_idx)
+                level_ghost_boxes.removeIntersections(grow<dimension>(neighbox, ghosts));
+        }
+
+        return level_ghost_boxes;
     }
+
 
     template<typename GridLayout, typename ResMan, typename Action, typename... Args>
     void visitLevel(SAMRAI_Types::level_t& level, ResMan& resman, Action&& action, Args&&... args)
@@ -264,7 +295,7 @@ namespace amr
         {
             auto guard        = resman.setOnPatch(*patch, args...);
             GridLayout layout = layoutFromPatch<GridLayout>(*patch);
-            action(layout, to_string(patch->getGlobalId()),
+            action(layout, core::to_string(patch->getGlobalId()),
                    static_cast<std::size_t>(level.getLevelNumber()));
         }
     }

--- a/src/amr/solvers/solver_ppc.hpp
+++ b/src/amr/solvers/solver_ppc.hpp
@@ -182,7 +182,7 @@ private:
 
         for (auto const& patch : level)
             if (auto [it, suc] = levelBoxing.try_emplace(
-                    amr::to_string(patch->getGlobalId()),
+                    core::to_string(patch->getGlobalId()),
                     Boxing_t{amr::layoutFromPatch<GridLayout>(*patch),
                              amr::makeNonLevelGhostBoxFor<GridLayout>(*patch, hierarchy)});
                 !suc)
@@ -560,7 +560,7 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, ModelViews_t& 
         for (auto& state : views)
             ionUpdater_.updatePopulations(
                 state.ions, state.electromagAvg,
-                levelBoxing.at(amr::to_string(state.patch->getGlobalId())), dt, mode);
+                levelBoxing.at(core::to_string(state.patch->getGlobalId())), dt, mode);
     }
     catch (core::DictionaryException const& ex)
     {
@@ -572,9 +572,9 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, ModelViews_t& 
     // this needs to be done before calling the messenger
     setTime([](auto& state) -> auto& { return state.ions; });
 
+    fromCoarser.fillIonPopMomentGhosts(views.model().state.ions, level, newTime);
     fromCoarser.fillFluxBorders(views.model().state.ions, level, newTime);
     fromCoarser.fillDensityBorders(views.model().state.ions, level, newTime);
-    fromCoarser.fillIonPopMomentGhosts(views.model().state.ions, level, newTime);
     fromCoarser.fillIonGhostParticles(views.model().state.ions, level, newTime);
 
     for (auto& state : views)

--- a/src/amr/tagging/hybrid_tagger.hpp
+++ b/src/amr/tagging/hybrid_tagger.hpp
@@ -70,7 +70,7 @@ void HybridTagger<HybridModel>::tag(PHARE::solver::IPhysicalModel<amr_t>& model,
         // These tags will be saved even if they are not used in diags during this advance
         // hybridModel.tags may contain vectors for patches and levels that no longer exist
         auto key = std::to_string(patch.getPatchLevelNumber()) + "_"
-                   + amr::to_string(patch.getGlobalId());
+                   + core::to_string(patch.getGlobalId());
 
         auto nCells = core::product(layout.nbrCells());
 

--- a/src/core/data/particles/particle.hpp
+++ b/src/core/data/particles/particle.hpp
@@ -111,6 +111,22 @@ struct ParticleView
 };
 
 
+template<typename Box_t, typename RValue = std::size_t>
+struct CellFlattener
+{
+    template<typename Icell>
+    NO_DISCARD RValue operator()(Icell const& icell) const
+    {
+        if constexpr (Box_t::dimension == 2)
+            return icell[1] + icell[0] * shape[1];
+        if constexpr (Box_t::dimension == 3)
+            return icell[2] + icell[1] * shape[2] + icell[0] * shape[1] * shape[2];
+        return icell[0];
+    }
+
+    Box_t const box;
+    std::array<int, Box_t::dimension> shape = box.shape().toArray();
+};
 
 
 template<std::size_t dim, typename T>

--- a/src/core/utilities/types.hpp
+++ b/src/core/utilities/types.hpp
@@ -175,6 +175,13 @@ namespace core
         T var;
     };
 
+    auto to_string(auto const& obj)
+    {
+        std::stringstream ss;
+        ss << obj;
+        return ss.str();
+    }
+
     template<typename T>
     NO_DISCARD std::string to_string_with_precision(T const& a_value, std::size_t const len)
     {

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -681,13 +681,52 @@ class InitializationTest(SimulatorTest):
                     == coarse_particles.size() * sim.refined_particle_nbr
                 )
 
+                # gaboxes_list may have multiple entries per patch (one per ghost-area
+                # side), so deduplicate by identity to get one pdata per patch.
+                unique_pdatas = list(
+                    {id(g["pdata"]): g["pdata"] for g in gaboxes_list}.values()
+                )
                 for gabox in gaboxes_list:
-                    gabox_patchData = gabox["pdata"]
-
                     for ghostBox in gabox["boxes"]:
-                        part1 = gabox_patchData.dataset.select(ghostBox)
+                        # Each patch fills only its owned subset of the ghost region
+                        # to avoid duplicates, so aggregate across all unique patches.
+                        combined = None
+                        for pdata in unique_pdatas:
+                            parts = pdata.dataset.select(ghostBox)
+                            if parts.size() > 0:
+                                if combined is None:
+                                    combined = parts
+                                else:
+                                    combined.add(parts)
+                        if combined is None:
+                            continue
                         part2 = coarse_split_particles.select(ghostBox)
-                        self.assertEqual(part1, part2)
+                        self.assertEqual(combined, part2)
+
+        # check no duplicate level ghost particles across patch ghost boxes
+        for ilvl, particle_gaboxes in particle_level_ghost_boxes_per_level.items():
+            for pop_name, gaboxes_list in particle_gaboxes.items():
+                all_icells = []
+                all_deltas = []
+                for gabox in gaboxes_list:
+                    pdata = gabox["pdata"]
+                    for ghostBox in gabox["boxes"]:
+                        parts = pdata.dataset.select(ghostBox)
+                        if parts.size() > 0:
+                            all_icells.append(parts.iCells)
+                            all_deltas.append(parts.deltas)
+                if not all_icells:
+                    continue
+                combined_icells = np.concatenate(all_icells, axis=0)
+                combined_deltas = np.concatenate(all_deltas, axis=0)
+                combined = np.hstack([combined_icells, combined_deltas])
+                n_total = combined.shape[0]
+                n_unique = np.unique(combined, axis=0).shape[0]
+                self.assertEqual(
+                    n_unique,
+                    n_total,
+                    f"level {ilvl} pop {pop_name}: found {n_total - n_unique} duplicate level ghost particles across patch ghost boxes",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this can be further extended for tiling such that there are not duplicate level ghost across tile ghost boxes

there's a secondary attempt which uses a fill pattern to just prevent the undesired overlaps, [see](https://github.com/PhilipDeegan/PHARE/pull/131/changes)