### PR TITLE
minimize dynamic allocation for patch data transfer operations

### DIFF
--- a/res/cmake/test.cmake
+++ b/res/cmake/test.cmake
@@ -7,6 +7,7 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
   configure_file(${CMAKE_SOURCE_DIR}/tests/__init__.py ${CMAKE_BINARY_DIR}/tests/__init__.py @ONLY)
 
 
+  add_subdirectory(tests/core/data/minimizing_vector)
   add_subdirectory(tests/core/data/ndarray)
   add_subdirectory(tests/core/data/grid)
   add_subdirectory(tests/core/data/gridlayout)

--- a/src/amr/data/field/field_data.hpp
+++ b/src/amr/data/field/field_data.hpp
@@ -4,6 +4,7 @@
 #include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 
 #include "core/logger.hpp"
+#include "core/data/vector.hpp"
 #include "core/data/field/field_box.hpp"
 
 #include "amr/samrai.hpp" // restarts
@@ -220,8 +221,8 @@ namespace amr
             if (transformation.getRotation() != NO_ROTATE)
                 throw std::runtime_error("Rotations are not supported in PHARE");
 
-            std::vector<value_type> buffer;
-            buffer.reserve(getDataStreamSize_(overlap) / sizeof(double));
+            auto const buffer_size = getDataStreamSize_(overlap) / sizeof(value_type);
+            auto& buffer           = tmp.reserve_and_clear(buffer_size)();
 
             for (auto const& box : fieldOverlap.getDestinationBoxContainer())
             {
@@ -265,7 +266,7 @@ namespace amr
                 throw std::runtime_error("Rotations are not supported in PHARE");
 
             // For unpacking we need to know how much element we will need to extract
-            std::vector<double> buffer(getDataStreamSize(overlap) / sizeof(value_type), 0.);
+            auto& buffer = tmp.get_no_copy(getDataStreamSize(overlap) / sizeof(value_type))();
 
             // We flush a portion of the stream on the buffer.
             stream.unpack(buffer.data(), buffer.size());
@@ -327,6 +328,7 @@ namespace amr
 
     private:
         PhysicalQuantity quantity_; ///! PhysicalQuantity used for this field data
+        static inline core::MinimizingVector<value_type> tmp; // LESS ALLOCATIONS
 
 
 

--- a/src/amr/data/particles/particles_data.hpp
+++ b/src/amr/data/particles/particles_data.hpp
@@ -2,7 +2,8 @@
 #define PHARE_SRC_AMR_DATA_PARTICLES_PARTICLES_DATA_HPP
 
 
-#include "core/def.hpp"           // IWYU pragma: keep
+#include "core/def.hpp" // IWYU pragma: keep
+#include "core/data/vector.hpp"
 #include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 #include "core/data/particles/particle_array.hpp"
 #include "core/data/particles/particle_packer.hpp"
@@ -309,8 +310,6 @@ namespace amr
         void pack_from_cell_overlap(SAMRAI::tbox::MessageStream& stream,
                                     SAMRAI::pdat::CellOverlap const& pOverlap) const
         {
-            std::vector<Particle_t> outBuffer;
-
             if (pOverlap.isOverlapEmpty())
             {
                 constexpr std::size_t zero = 0;
@@ -318,10 +317,7 @@ namespace amr
             }
             else
             {
-                SAMRAI::hier::Transformation const& transformation = pOverlap.getTransformation();
-                SAMRAI::hier::BoxContainer const& boxContainer
-                    = pOverlap.getDestinationBoxContainer();
-                pack_(pOverlap, transformation, outBuffer);
+                auto& outBuffer = pack_(pOverlap);
                 stream << outBuffer.size();
                 stream.growBufferAsNeeded();
                 stream.pack(outBuffer.data(), outBuffer.size());
@@ -471,6 +467,8 @@ namespace amr
         //! physical end index"
         SAMRAI::hier::Box interiorLocalBox_;
         std::string name_;
+        static inline core::MinimizingVector<Particle_t> tmp; // LESS ALLOCATIONS
+
 
         void copy_(SAMRAI::hier::Box const& overlapBox, ParticlesData const& sourceData)
         {
@@ -650,9 +648,7 @@ namespace amr
 
 
 
-        void pack_(SAMRAI::pdat::CellOverlap const& overlap,
-                   SAMRAI::hier::Transformation const& transformation,
-                   std::vector<Particle_t>& outBuffer) const
+        auto& pack_(SAMRAI::pdat::CellOverlap const& overlap) const
         {
             PHARE_LOG_SCOPE(3, "ParticleData::pack_");
             // we want to put particles from our domain and patchghost arrays
@@ -662,6 +658,7 @@ namespace amr
             // destination space.  Therefore we need to inverse transform the
             // overlap box into our index space, intersect each of them with
             // our ghost box and put export them with the transformation offset
+            SAMRAI::hier::Transformation const& transformation = overlap.getTransformation();
             auto overlapBoxes = overlap.getDestinationBoxContainer();
             auto offset       = transformation.getOffset();
             std::size_t size  = 0;
@@ -680,7 +677,7 @@ namespace amr
                 auto toTakeFrom_p = phare_box_from<dim>(toTakeFrom);
                 size += domainParticles.nbr_particles_in(toTakeFrom_p);
             }
-            outBuffer.reserve(size);
+            auto& outBuffer = tmp.reserve_and_clear(size)();
             for (auto const& box : overlapBoxes)
             {
                 auto toTakeFrom{box};
@@ -688,6 +685,7 @@ namespace amr
                 auto toTakeFrom_p = phare_box_from<dim>(toTakeFrom);
                 domainParticles.export_particles(toTakeFrom_p, outBuffer, offseter);
             }
+            return outBuffer;
         }
     };
 
@@ -739,7 +737,7 @@ void ParticlesData<ParticleArray_t>::pack_from_ghost(SAMRAI::tbox::MessageStream
         return;
     }
 
-    std::vector<Particle_t> outBuffer;
+    auto& outBuffer     = tmp.clear()();
     auto& src_particles = patchGhostParticles;
     auto const& offset  = as_point<dim>(pOverlap.getTransformation());
     auto const& noffset = offset * -1;
@@ -772,7 +770,7 @@ void ParticlesData<ParticleArray_t>::unpack_from_ghost(SAMRAI::tbox::MessageStre
 
     std::size_t numberParticles = 0;
     stream >> numberParticles;
-    std::vector<Particle_t> particleArray(numberParticles);
+    auto& particleArray = *tmp.get(numberParticles);
     stream.unpack(particleArray.data(), numberParticles);
 
     domainParticles.reserve(domainParticles.size() + numberParticles);

--- a/src/amr/data/tensorfield/tensor_field_data.hpp
+++ b/src/amr/data/tensorfield/tensor_field_data.hpp
@@ -1,6 +1,7 @@
 #ifndef PHARE_SRC_AMR_TENSORFIELD_TENSORFIELD_DATA_HPP
 #define PHARE_SRC_AMR_TENSORFIELD_TENSORFIELD_DATA_HPP
 
+#include "core/data/vector.hpp"
 #include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 
 #include "core/logger.hpp"
@@ -228,10 +229,8 @@ public:
         PHARE_LOG_SCOPE(3, "TensorFieldData::packStream");
 
         std::size_t const expectedSize = getDataStreamSize_(overlap) / sizeof(value_type);
-        std::vector<typename Grid_t::type> buffer;
-        buffer.reserve(expectedSize);
-
-        auto& tFieldOverlap = dynamic_cast<TensorFieldOverlap_t const&>(overlap);
+        auto& buffer                   = tmp.reserve_and_clear(expectedSize)();
+        auto& tFieldOverlap            = dynamic_cast<TensorFieldOverlap_t const&>(overlap);
 
         SAMRAI::hier::Transformation const& transformation = tFieldOverlap.getTransformation();
 
@@ -240,10 +239,7 @@ public:
                 "Rotations are not supported in PHARE (TensorFieldData::packStream)");
 
         for (std::size_t c = 0; c < N; ++c)
-        {
-            auto const& fOverlap = tFieldOverlap[c];
-
-            for (auto const& box : fOverlap->getDestinationBoxContainer())
+            for (auto const& box : tFieldOverlap[c]->getDestinationBoxContainer())
             {
                 auto const& source = grids[c];
                 SAMRAI::hier::Box packBox{box};
@@ -258,7 +254,6 @@ public:
                 core::FieldBox<Grid_t const> src{source, gridLayout, finalBox};
                 src.append_to(buffer);
             }
-        }
 
         // Once we have fill the buffer, we send it on the stream
         stream.pack(buffer.data(), buffer.size());
@@ -288,7 +283,7 @@ public:
             throw std::runtime_error("Rotations are not supported in PHARE");
 
         // For unpacking we need to know how much element we will need to extract
-        std::vector<value_type> buffer(getDataStreamSize(overlap) / sizeof(value_type), 0.);
+        auto& buffer = tmp.get_no_copy(getDataStreamSize(overlap) / sizeof(value_type))();
 
         // We flush a portion of the stream on the buffer.
         stream.unpack(buffer.data(), buffer.size());
@@ -349,6 +344,7 @@ public:
 private:
     tensor_t quantity_; ///! PhysicalQuantity used for this field data
 
+    static inline core::MinimizingVector<value_type> tmp; // LESS ALLOCATIONS
 
 
 

--- a/src/core/data/vector.hpp
+++ b/src/core/data/vector.hpp
@@ -1,0 +1,110 @@
+#ifndef PHARE_CORE_DATA_VECTOR_HPP
+#define PHARE_CORE_DATA_VECTOR_HPP
+
+
+
+#include <vector>
+#include <cstdint>
+
+namespace PHARE::core
+{
+
+// Will automagically shrink itself if the requested sizes are
+//  below a threshold for some number of requests
+template<typename T>
+struct MinimizingVector
+{
+    using vector_t = std::vector<T>;
+
+    // resize to s, preserving existing content
+    auto& get(std::size_t s)
+    {
+        _maybe_shrink<true>(s);
+        vec.resize(s);
+        return *this;
+    }
+
+    // resize to s, discarding existing content
+    auto& get_no_copy(std::size_t s)
+    {
+        _maybe_shrink<false>(s);
+        vec.resize(s);
+        return *this;
+    }
+
+    // reserve capacity for s elements, size stays 0
+    auto& reserve_and_clear(std::size_t s)
+    {
+        _maybe_shrink<false>(s);
+        vec.clear();
+        vec.reserve(s);
+        return *this;
+    }
+
+    auto& resize(std::size_t s) { return get(s); }
+    auto& clear()
+    {
+        vec.clear();
+        return *this;
+    }
+    void destroy() { vec = vector_t{}; }
+
+    auto& operator[](std::size_t i) { return vec.data()[i]; }
+    auto& operator[](std::size_t i) const { return vec.data()[i]; }
+    auto& operator*() { return vec; }
+    auto& operator()() { return vec; }
+    auto& operator()() const { return vec; }
+
+    auto& emplace_back(auto&&... args)
+    {
+        return vec.emplace_back(std::forward<decltype(args)>(args)...);
+    }
+    void push_back(auto&&... args) { vec.push_back(std::forward<decltype(args)>(args)...); }
+    auto data() { return vec.data(); }
+    auto data() const { return vec.data(); }
+    auto size() const { return vec.size(); }
+    auto capacity() const { return vec.capacity(); }
+
+
+    // public overridable
+    double const percentile  = .80;
+    double const realloc_to  = .85;
+    std::size_t const period = 100;
+
+private:
+    template<bool copy_old>
+    void _maybe_shrink(std::size_t s)
+    {
+        if (s < vec.capacity() * percentile)
+            ++curr_access;
+        else
+            curr_access = 0;
+
+        if (curr_access != period)
+            return;
+
+        auto const new_cap = static_cast<std::size_t>(vec.capacity() * realloc_to);
+        if constexpr (copy_old)
+        {
+            vector_t r;
+            r.reserve(new_cap);
+            r   = vec;
+            vec = std::move(r);
+        }
+        else
+        {
+            vec = vector_t{};
+            vec.reserve(new_cap);
+        }
+        curr_access = 0;
+    }
+
+    vector_t vec{};
+    std::uint16_t curr_access = 0;
+};
+
+
+} // namespace PHARE::core
+
+
+#endif /* PHARE_CORE_DATA_VECTOR_HPP */

--- a/tests/core/data/minimizing_vector/CMakeLists.txt
+++ b/tests/core/data/minimizing_vector/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required (VERSION 3.20.1)
+
+project(test-minimizing-vector)
+
+set(SOURCES test_minimizing_vector.cpp)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${GTEST_INCLUDE_DIRS}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  phare_core
+  ${GTEST_LIBS})
+
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/core/data/minimizing_vector/test_minimizing_vector.cpp
+++ b/tests/core/data/minimizing_vector/test_minimizing_vector.cpp
@@ -1,0 +1,219 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "core/data/vector.hpp"
+
+using namespace PHARE::core;
+
+
+TEST(MinimizingVector, defaultConstruct)
+{
+    MinimizingVector<int> v;
+    EXPECT_EQ(v.size(), 0u);
+    EXPECT_EQ(v.capacity(), 0u);
+}
+
+
+TEST(MinimizingVector, getResizesVector)
+{
+    MinimizingVector<int> v;
+    v.get(10);
+    EXPECT_EQ(v.size(), 10u);
+}
+
+
+TEST(MinimizingVector, getPreservesContent)
+{
+    MinimizingVector<int> v;
+    v.get(5);
+    for (std::size_t i = 0; i < 5; ++i)
+        v[i] = static_cast<int>(i);
+
+    v.get(5);
+    for (std::size_t i = 0; i < 5; ++i)
+        EXPECT_EQ(v[i], static_cast<int>(i));
+}
+
+
+TEST(MinimizingVector, getNoNoCopyResizesVector)
+{
+    MinimizingVector<int> v;
+    v.get_no_copy(20);
+    EXPECT_EQ(v.size(), 20u);
+}
+
+
+TEST(MinimizingVector, reserveAndClearSetsCapacityAndZeroSize)
+{
+    MinimizingVector<int> v;
+    v.reserve_and_clear(50);
+    EXPECT_EQ(v.size(), 0u);
+    EXPECT_GE(v.capacity(), 50u);
+}
+
+
+TEST(MinimizingVector, clearSetsSize0)
+{
+    MinimizingVector<int> v;
+    v.get(10);
+    v.clear();
+    EXPECT_EQ(v.size(), 0u);
+}
+
+
+TEST(MinimizingVector, destroyReleasesMemory)
+{
+    MinimizingVector<int> v;
+    v.get(100);
+    v.destroy();
+    EXPECT_EQ(v.size(), 0u);
+    EXPECT_EQ(v.capacity(), 0u);
+}
+
+
+TEST(MinimizingVector, resizeIsAliasForGet)
+{
+    MinimizingVector<int> v;
+    v.resize(7);
+    EXPECT_EQ(v.size(), 7u);
+}
+
+
+TEST(MinimizingVector, emplaceBack)
+{
+    MinimizingVector<int> v;
+    v.emplace_back(42);
+    v.emplace_back(99);
+    EXPECT_EQ(v.size(), 2u);
+    EXPECT_EQ(v[0], 42);
+    EXPECT_EQ(v[1], 99);
+}
+
+
+TEST(MinimizingVector, pushBack)
+{
+    MinimizingVector<int> v;
+    v.push_back(7);
+    v.push_back(13);
+    EXPECT_EQ(v.size(), 2u);
+    EXPECT_EQ(v[0], 7);
+    EXPECT_EQ(v[1], 13);
+}
+
+
+TEST(MinimizingVector, dataPointerMatchesElements)
+{
+    MinimizingVector<int> v;
+    v.get(4);
+    v[0] = 1; v[1] = 2; v[2] = 3; v[3] = 4;
+    auto* p = v.data();
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(p[i], i + 1);
+}
+
+
+TEST(MinimizingVector, operatorStarReturnsUnderlyingVector)
+{
+    MinimizingVector<int> v;
+    v.get(3);
+    v[0] = 10; v[1] = 20; v[2] = 30;
+    auto& inner = *v;
+    EXPECT_EQ(inner.size(), 3u);
+    EXPECT_EQ(inner[1], 20);
+}
+
+
+TEST(MinimizingVector, operatorCallReturnsUnderlyingVector)
+{
+    MinimizingVector<int> v;
+    v.get(3);
+    v[0] = 5;
+    EXPECT_EQ(v()[0], 5);
+}
+
+
+// After `period` consecutive accesses where s < capacity * percentile,
+// the vector should shrink its capacity toward capacity * realloc_to.
+TEST(MinimizingVector, shrinksAfterPeriodSmallRequests)
+{
+    MinimizingVector<int> v;
+    // Establish a large capacity
+    v.get(1000);
+    auto const large_cap = v.capacity();
+    EXPECT_GE(large_cap, 1000u);
+
+    // Drive period (100) consecutive small requests — each well below percentile (80%)
+    std::size_t const small = 100; // 100 << 800 (= 1000 * 0.8)
+    for (std::size_t i = 0; i < v.period; ++i)
+        v.get(small);
+
+    // After exactly period requests the shrink fires
+    EXPECT_LT(v.capacity(), large_cap);
+}
+
+
+TEST(MinimizingVector, doesNotShrinkBeforePeriod)
+{
+    MinimizingVector<int> v;
+    v.get(1000);
+    auto const large_cap = v.capacity();
+
+    std::size_t const small = 100;
+    for (std::size_t i = 0; i < v.period - 1; ++i)
+        v.get(small);
+
+    EXPECT_EQ(v.capacity(), large_cap);
+}
+
+
+TEST(MinimizingVector, counterResetWhenLargeRequest)
+{
+    MinimizingVector<int> v;
+    v.get(1000);
+    auto const large_cap = v.capacity();
+
+    // 50 small requests, then one large — counter should reset
+    for (std::size_t i = 0; i < 50; ++i)
+        v.get(100);
+
+    v.get(1000); // large — resets counter
+
+    // 50 more small requests: total small streak is 50, not 100 → no shrink yet
+    for (std::size_t i = 0; i < 50; ++i)
+        v.get(100);
+
+    EXPECT_EQ(v.capacity(), large_cap);
+}
+
+
+TEST(MinimizingVector, getNoCopyShrinks)
+{
+    MinimizingVector<int> v;
+    v.get_no_copy(1000);
+    auto const large_cap = v.capacity();
+
+    for (std::size_t i = 0; i < v.period; ++i)
+        v.get_no_copy(100);
+
+    EXPECT_LT(v.capacity(), large_cap);
+}
+
+
+TEST(MinimizingVector, reserveAndClearShrinks)
+{
+    MinimizingVector<int> v;
+    v.reserve_and_clear(1000);
+    auto const large_cap = v.capacity();
+
+    for (std::size_t i = 0; i < v.period; ++i)
+        v.reserve_and_clear(100);
+
+    EXPECT_LT(v.capacity(), large_cap);
+}
+
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
probably not the best idea to be doing heap allocation during SAMRAI schedule operations