### PR TITLE
expose TileClustering tile_size and allow_remote_tile_extent params

### DIFF
--- a/pyphare/pyphare/pharein/initialize/general.py
+++ b/pyphare/pyphare/pharein/initialize/general.py
@@ -110,7 +110,14 @@ def populateDict(sim):
     add_double("simulation/time_step", sim.time_step)
     add_int("simulation/time_step_nbr", sim.time_step_nbr)
 
-    add_string("simulation/AMR/clustering", sim.clustering)
+    add_string("simulation/AMR/clustering", sim.clustering["method"])
+    if "tile_size" in sim.clustering:
+        add_vector_int("simulation/AMR/tile_size", sim.clustering["tile_size"])
+    if "allow_remote_tile_extent" in sim.clustering:
+        add_bool(
+            "simulation/AMR/allow_remote_tile_extent",
+            sim.clustering["allow_remote_tile_extent"],
+        )
     add_vector_int("simulation/AMR/nesting_buffer", sim.nesting_buffer)
     add_int("simulation/AMR/tag_buffer", sim.tag_buffer)
 

--- a/pyphare/pyphare/pharein/initialize/general.py
+++ b/pyphare/pyphare/pharein/initialize/general.py
@@ -90,6 +90,9 @@ def populateDict(sim):
     if sim.largest_patch_size is not None:
         add_vector_int("simulation/AMR/largest_patch_size", sim.largest_patch_size)
 
+    add_bool("simulation/AMR/allow_patches_smaller_than_minimum_size_to_prevent_overlaps",
+             sim.allow_patches_smaller_than_minimum_size_to_prevent_overlaps)
+
     add_string("simulation/grid/layout_type", sim.layout)
     add_int("simulation/grid/nbr_cells/x", sim.cells[0])
     add_double("simulation/grid/meshsize/x", sim.dl[0])

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -641,12 +641,43 @@ def check_hyper_resistivity(**kwargs):
 
 
 def check_clustering(**kwargs):
-    valid_keys = ["berger", "tile"]
+    valid_methods = ["berger", "tile"]
+    valid_tile_keys = {"method", "tile_size", "allow_remote_tile_extent"}
+    valid_berger_keys = {"method"}
+
     clustering = kwargs.get("clustering", "tile")
-    if clustering not in valid_keys:
+
+    if isinstance(clustering, str):
+        clustering = {"method": clustering}
+
+    if not isinstance(clustering, dict):
+        raise ValueError("clustering must be a string or dict")
+
+    method = clustering.get("method", None)
+    if method not in valid_methods:
         raise ValueError(
-            f"Error: clustering type is not supported, supported types are {valid_keys}"
+            f"clustering method '{method}' not supported, must be one of {valid_methods}"
         )
+
+    valid_keys = valid_tile_keys if method == "tile" else valid_berger_keys
+    unknown = set(clustering.keys()) - valid_keys
+    if unknown:
+        raise ValueError(f"Unknown clustering options for '{method}': {unknown}")
+
+    if "tile_size" in clustering:
+        ndim = compute_dimension(kwargs["cells"])
+        ts = clustering["tile_size"]
+        if isinstance(ts, int):
+            clustering["tile_size"] = [ts] * ndim
+        if len(clustering["tile_size"]) != ndim:
+            raise ValueError(
+                f"tile_size length {len(clustering['tile_size'])} != ndim {ndim}"
+            )
+
+    if "allow_remote_tile_extent" in clustering:
+        if not isinstance(clustering["allow_remote_tile_extent"], bool):
+            raise ValueError("allow_remote_tile_extent must be a bool")
+
     return clustering
 
 
@@ -1019,7 +1050,7 @@ class Simulation(object):
 
         * **max_nbr_levels** (``int``), default=1, max number of levels in the hierarchy. Used if no `refinement_boxes` are set
         * **tag_buffer** (``int``), default=1, value representing the number of cells by which tagged cells are buffered before clustering into boxes. The larger `tag_buffer`, the wider refined regions will be around tagged cells.
-        * **clustering** (``str``), {"berger", "tile" (default)}, type of clustering to use for AMR. `tile` results in wider patches, less artifacts and better scalability
+        * **clustering** (``str`` or ``dict``), type of clustering to use for AMR. String form: ``"tile"`` (default) or ``"berger"``. Dict form: ``{"method": "tile", "tile_size": 16, "allow_remote_tile_extent": False}``. ``tile_size`` (int or per-dim list, default 8) controls the SAMRAI tile grid granularity — larger values reduce patch overlap risk and produce fewer, larger patches. ``allow_remote_tile_extent`` (bool, default ``True``) — set to ``False`` to disable cross-MPI-rank tile clustering, which eliminates overlap path 1 at the cost of smaller per-rank patches (useful as a diagnostic). ``tile`` results in wider patches, less artifacts and better scalability than ``berger``.
 
         **Expert parameters:**
 

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -754,6 +754,7 @@ def checker(func):
             "refinement",
             "tagging_threshold",
             "clustering",
+            "allow_patches_smaller_than_minimum_size_to_prevent_overlaps",
             "smallest_patch_size",
             "largest_patch_size",
             "diag_options",
@@ -797,6 +798,9 @@ def checker(func):
 
         kwargs["description"] = kwargs.get("description", None)
 
+        kwargs["allow_patches_smaller_than_minimum_size_to_prevent_overlaps"] = kwargs.get(
+            "allow_patches_smaller_than_minimum_size_to_prevent_overlaps", False
+        )
         kwargs["clustering"] = check_clustering(**kwargs)
 
         kwargs["restart_options"] = check_restart_options(**kwargs)

--- a/src/amr/wrappers/hierarchy.hpp
+++ b/src/amr/wrappers/hierarchy.hpp
@@ -402,6 +402,10 @@ auto patchHierarchyDatabase(PHARE::initializer::PHAREDict const& amr)
         largestPatchSize   = amr["largest_patch_size"].template to<std::vector<int>>();
     }
 
+    hierDB->putBool("allow_patches_smaller_than_minimum_size_to_prevent_overlaps",
+                    amr["allow_patches_smaller_than_minimum_size_to_prevent_overlaps"]
+                        .template to<bool>());
+
     auto addIntDimArray = [](auto& db, auto const& value, auto const& level) {
         int arr[dimension];
         std::fill_n(arr, dimension, value);

--- a/src/amr/wrappers/integrator.hpp
+++ b/src/amr/wrappers/integrator.hpp
@@ -189,8 +189,23 @@ Integrator<_dimension>::Integrator(
         }
 
         if (clustering_type == "tile")
+        {
+            auto tileDB = std::make_shared<SAMRAI::tbox::MemoryDatabase>("Tiledb");
+            if (dict["simulation"]["AMR"].contains("tile_size"))
+            {
+                auto ts = dict["simulation"]["AMR"]["tile_size"]
+                              .template to<std::vector<int>>();
+                tileDB->putIntegerVector("tile_size", ts);
+            }
+            if (dict["simulation"]["AMR"].contains("allow_remote_tile_extent"))
+            {
+                bool arte = dict["simulation"]["AMR"]["allow_remote_tile_extent"]
+                                .template to<bool>();
+                tileDB->putBool("allow_remote_tile_extent", arte);
+            }
             return std::make_shared<SAMRAI::mesh::TileClustering>(
-                SAMRAI::tbox::Dimension{dimension});
+                SAMRAI::tbox::Dimension{dimension}, tileDB);
+        }
 
         throw std::runtime_error(std::string{"Unknown clustering type "} + clustering_type);
     }();


### PR DESCRIPTION
Expose Tile clustering parameters to samrai from python. 
- tile_size (default: 8): tile_size used in initial clustering
- allow_remote_tile_extent (default: true): if false, does process local clustering.