### PR TITLE
cast interpOrder to int to prevent list access with float

### DIFF
--- a/pyphare/pyphare/pharesee/hierarchy/fromh5.py
+++ b/pyphare/pyphare/pharesee/hierarchy/fromh5.py
@@ -183,7 +183,7 @@ def patch_levels_from_h5(h5f, time, selection_box=None):
     """
 
     root_cell_width = h5f.attrs["cell_width"]
-    interp_order = h5f.attrs["interpOrder"] if "interpOrder" in h5f.attrs else 0
+    interp_order = int(h5f.attrs["interpOrder"]) if "interpOrder" in h5f.attrs else 0
     basename = os.path.basename(h5f.filename)
 
     patch_levels = {}


### PR DESCRIPTION
weirdly we only see this on the caliper functional tests build


```
21:54:48   Traceback (most recent call last):
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/build/tests/functional/conservation/conserv.py", line 275, in <module>
21:54:48       main()
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/build/tests/functional/conservation/conserv.py", line 222, in main
21:54:48       runs_vth[path], Bnrj_vth[path], K_vth[path], times_vth[path] = energies(path)
21:54:48                                                                      ^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/build/tests/functional/conservation/conserv.py", line 172, in energies
21:54:48       protons = r.GetParticles(t, "protons")
21:54:48                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/run/run.py", line 335, in GetParticles
21:54:48       return self._get_hierarchy(time, filename(pop_name), hier=hier, **kwargs)
21:54:48              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/run/run.py", line 65, in _get_hierarchy
21:54:48       return _get_hier(hier)
21:54:48              ^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/run/run.py", line 58, in _get_hier
21:54:48       return hierarchy_from(
21:54:48              ^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/hierarchy/__init__.py", line 38, in hierarchy_from
21:54:48       return hierarchy_fromh5(h5_filename, times, hier, **kwargs)
21:54:48              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/hierarchy/fromh5.py", line 331, in hierarchy_fromh5
21:54:48       return new_from_h5(h5_filename, time, **kwargs)
21:54:48              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/hierarchy/fromh5.py", line 302, in new_from_h5
21:54:48       patch_levels = patch_levels_from_h5(h5f, time, selection_box=selection_box[it])
21:54:48                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/hierarchy/fromh5.py", line 222, in patch_levels_from_h5
21:54:48       add_to_patchdata(
21:54:48     File "/opt/buildagent/work/3bd323ee5a73a841/pyphare/pyphare/pharesee/hierarchy/fromh5.py", line 80, in add_to_patchdata
21:54:48       particle_ghosts = [1, 2, 2][interp_order - 1]
```