### PR TITLE
timestamper comparisons

### DIFF
--- a/res/cmake/bench.cmake
+++ b/res/cmake/bench.cmake
@@ -48,6 +48,7 @@ if (bench)
 
   add_subdirectory(tools/bench/core/data/particles)
   add_subdirectory(tools/bench/core/numerics/pusher)
+  add_subdirectory(tools/bench/core/utilities)
 
   add_subdirectory(tools/bench/amr/data/particles)
   add_subdirectory(tools/bench/core/numerics/ion_updater)

--- a/src/core/utilities/timestamps.hpp
+++ b/src/core/utilities/timestamps.hpp
@@ -1,13 +1,13 @@
 #ifndef PHARE_CORE_UTILITIES_TIMESTAMPS_HPP
 #define PHARE_CORE_UTILITIES_TIMESTAMPS_HPP
 
+#include "core/def.hpp"
+#include "core/logger.hpp"
+#include "initializer/data_provider.hpp"
+
 #include <string>
 #include <cassert>
 #include <cstdint>
-
-#include "core/logger.hpp"
-#include "initializer/data_provider.hpp"
-#include "core/def.hpp"
 
 namespace PHARE::core
 {
@@ -39,16 +39,135 @@ private:
     std::size_t idx_ = 0;
 };
 
+// No error compensation: reduces to plain incremental addition whenever dt
+// actually changes step to step, and is therefore subject to the same
+// accumulated rounding drift as naive floating-point summation.
+class NaiveTimeStamper : public ITimeStamper
+{
+public:
+    NaiveTimeStamper(double const& dt, double const& init_time = 0)
+        : dt_{dt}
+        , last_change_{init_time}
+        , last_time_(init_time)
+    {
+    }
+
+    double operator+=(double const& new_dt) noexcept override
+    {
+        assert(new_dt > 0);
+
+        if (new_dt != dt_) // not sure if safe, possibly
+        {
+            dt_          = new_dt;
+            last_change_ = last_time_;
+            n_same_      = 0;
+        }
+        return (last_time_ = last_change_ + (dt_ * ++n_same_));
+    }
+
+private:
+    std::size_t n_same_ = 0;
+    double dt_          = 0;
+    double last_change_ = 0;
+    double last_time_   = 0;
+};
+
+class KahanTimeStamper : public ITimeStamper
+{
+public:
+    KahanTimeStamper(double const& dt, double const& init_time = 0)
+        : dt_{dt}
+        , last_time_(init_time)
+        , error_compensation_(0.0)
+    {
+    }
+
+    double operator+=(double const& new_dt) noexcept override
+    {
+        assert(new_dt > 0);
+        dt_ = new_dt;
+
+        // Kahan Summation Algorithm
+        // 1. Subtract the accumulated floating-point error from the new increment
+        double y = dt_ - error_compensation_;
+
+        // 2. Add the corrected increment to the running total.
+        // High-order bits are updated; low-order bits of 'y' may be lost here.
+        double temp = last_time_ + y;
+
+        // 3. Recover the exact low-order bits that were dropped in the addition
+        error_compensation_ = (temp - last_time_) - y;
+
+        // 4. Update the state
+        return (last_time_ = temp);
+    }
+
+private:
+    double dt_                 = 0;
+    double last_time_          = 0;
+    double error_compensation_ = 0; // Tracks the lost bits
+};
+
+// Same compensated-summation idea as KahanTimeStamper, restructured around a
+// tail carried forward into the next increment rather than an error term
+// subtracted from it.
+class CascadedTimeStamper : public ITimeStamper
+{
+public:
+    CascadedTimeStamper(double const& dt, double const& init_time = 0)
+        : dt_{dt}
+        , time_head_(init_time)
+        , time_tail_(0.0)
+    {
+    }
+
+    double operator+=(double const& new_dt) noexcept override
+    {
+        assert(new_dt > 0);
+        dt_ = new_dt;
+
+        // Cascade the new timestep into the lower-precision tail first
+        double interim_tail = time_tail_ + dt_;
+
+        // Advance the head by the combined tail values
+        double next_head = time_head_ + interim_tail;
+
+        // Calculate what failed to transfer to the head, preserving it in the tail
+        time_tail_ = interim_tail - (next_head - time_head_);
+        time_head_ = next_head;
+
+        return time_head_ + time_tail_;
+    }
+
+private:
+    double dt_        = 0;
+    double time_head_ = 0; // Stores the macroscopic time
+    double time_tail_ = 0; // Stores the sub-CFL micro-fractions
+};
+
+
 struct TimeStamperFactory
 {
+    std::string constexpr static default_time_stamper = "constant";
+
     NO_DISCARD static std::unique_ptr<ITimeStamper> create(initializer::PHAREDict const& dict)
     {
         assert(dict.contains("time_step"));
-        auto time_step  = dict["time_step"].template to<double>();
-        std::size_t idx = 0;
+        auto time_step = dict["time_step"].template to<double>();
 
-        // only option for the moment https://github.com/PHAREHUB/PHARE/issues/475
-        return std::make_unique<ConstantTimeStamper>(time_step, idx);
+        auto type = cppdict::get_value(dict, "time_stamper", default_time_stamper);
+
+        if (type == "constant")
+            return std::make_unique<ConstantTimeStamper>(time_step);
+
+        if (type == "naive")
+            return std::make_unique<NaiveTimeStamper>(time_step);
+        if (type == "kahan")
+            return std::make_unique<KahanTimeStamper>(time_step);
+        if (type == "cascaded")
+            return std::make_unique<CascadedTimeStamper>(time_step);
+
+        throw std::runtime_error("No TimeStamper exists for key: " + type);
     }
 };
 

--- a/tools/bench/core/utilities/CMakeLists.txt
+++ b/tools/bench/core/utilities/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required (VERSION 3.20.1)
+
+project(phare_bench_utilities)
+
+add_phare_cpp_benchmark(10 ${PROJECT_NAME} timestamps ${CMAKE_CURRENT_BINARY_DIR})

--- a/tools/bench/core/utilities/timestamps.cpp
+++ b/tools/bench/core/utilities/timestamps.cpp
@@ -1,0 +1,130 @@
+
+#include "tools/bench/core/bench.hpp"
+#include "core/utilities/timestamps.hpp"
+
+#include "benchmark/benchmark.h"
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace PHARE::core::bench
+{
+template<typename T>
+std::string to_string_with_precision(T const& a_value, std::size_t const len)
+{
+    std::ostringstream out;
+    out.precision(len);
+    out << std::fixed << a_value;
+    return out.str();
+}
+
+// accuracy test adapted from increment_error.cpp: repeatedly increments a
+// TimeStamper by a fixed dt and reports the first step at which the
+// accumulated time acquires spurious low-order digits.
+template<typename Stamper>
+void check_accuracy_constant_dt(std::string const& name, double const time_step = .001,
+                                 std::size_t const time_step_nbr = 3000000)
+{
+    Stamper stamper{time_step};
+
+    for (std::size_t i = 0; i < time_step_nbr; i++)
+    {
+        double const t = (stamper += time_step);
+        auto const timeStamp = to_string_with_precision(t, 10);
+        if (timeStamp.back() != '0')
+        {
+            std::cout << name << " diverged at step " << i << " : " << timeStamp << std::endl;
+            return;
+        }
+    }
+    std::cout << name << " did not diverge after " << time_step_nbr << " steps" << std::endl;
+}
+
+// A "Variable" stamper only takes its incremental (as opposed to recomputed
+// from scratch) code path when new_dt actually differs from the previous dt.
+// Alternating dt by +-1e-16 forces that path on every step while keeping the
+// true accumulated value indistinguishable from time_step_nbr * time_step at
+// the precision checked below, so any divergence still reflects the
+// stamper's own floating-point handling rather than a genuinely different dt.
+template<typename Stamper>
+void check_accuracy_variable_dt(std::string const& name, double const time_step = .001,
+                                 std::size_t const time_step_nbr = 3000000)
+{
+    Stamper stamper{time_step};
+
+    for (std::size_t i = 0; i < time_step_nbr; i++)
+    {
+        double const dt = time_step + (i % 2 == 0 ? 1e-16 : -1e-16);
+        double const t  = (stamper += dt);
+        auto const timeStamp = to_string_with_precision(t, 10);
+        if (timeStamp.back() != '0')
+        {
+            std::cout << name << " (variable dt) diverged at step " << i << " : " << timeStamp
+                       << std::endl;
+            return;
+        }
+    }
+    std::cout << name << " (variable dt) did not diverge after " << time_step_nbr << " steps"
+               << std::endl;
+}
+
+void check_all_accuracy()
+{
+    // ConstantTimeStamper asserts new_dt == dt_, so it cannot take part in
+    // the variable-dt check below; it is only exercised with a fixed dt.
+    check_accuracy_constant_dt<ConstantTimeStamper>("ConstantTimeStamper");
+    check_accuracy_constant_dt<NaiveTimeStamper>("NaiveTimeStamper");
+    check_accuracy_constant_dt<KahanTimeStamper>("KahanTimeStamper");
+    check_accuracy_constant_dt<CascadedTimeStamper>("CascadedTimeStamper");
+
+    check_accuracy_variable_dt<NaiveTimeStamper>("NaiveTimeStamper");
+    check_accuracy_variable_dt<KahanTimeStamper>("KahanTimeStamper");
+    check_accuracy_variable_dt<CascadedTimeStamper>("CascadedTimeStamper");
+}
+
+
+// cost of incrementing the concrete stamper type directly (no virtual dispatch)
+template<typename Stamper>
+void step(benchmark::State& state)
+{
+    constexpr double time_step = .001;
+    Stamper stamper{time_step};
+
+    while (state.KeepRunning())
+        benchmark::DoNotOptimize(stamper += time_step);
+}
+
+// cost as used in practice, i.e. through the ITimeStamper interface returned
+// by TimeStamperFactory (see simulator.hpp: (*timeStamper) += dt)
+template<typename Stamper>
+void step_virtual(benchmark::State& state)
+{
+    constexpr double time_step = .001;
+    std::unique_ptr<ITimeStamper> stamper = std::make_unique<Stamper>(time_step);
+
+    while (state.KeepRunning())
+        benchmark::DoNotOptimize((*stamper) += time_step);
+}
+
+BENCHMARK_TEMPLATE(step, ConstantTimeStamper)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(step, NaiveTimeStamper)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(step, KahanTimeStamper)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(step, CascadedTimeStamper)->Unit(benchmark::kNanosecond);
+
+BENCHMARK_TEMPLATE(step_virtual, ConstantTimeStamper)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(step_virtual, NaiveTimeStamper)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(step_virtual, KahanTimeStamper)->Unit(benchmark::kNanosecond);
+BENCHMARK_TEMPLATE(step_virtual, CascadedTimeStamper)->Unit(benchmark::kNanosecond);
+
+} // namespace PHARE::core::bench
+
+
+int main(int argc, char** argv)
+{
+    PHARE::core::bench::check_all_accuracy();
+
+    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
compare direct calls and virtual calls
show divergence of naive timestamper

local results 

```
ConstantTimeStamper did not diverge after 3000000 steps
NaiveTimeStamper did not diverge after 3000000 steps
KahanTimeStamper did not diverge after 3000000 steps
CascadedTimeStamper did not diverge after 3000000 steps
NaiveTimeStamper (variable dt) diverged at step 60420 : 60.4209999999
KahanTimeStamper (variable dt) did not diverge after 3000000 steps
CascadedTimeStamper (variable dt) did not diverge after 3000000 steps
2026-07-16T13:39:22+02:00
Running ./build/tools/bench/core/utilities/phare_bench_utilities_timestamps
Run on (16 X 4691.16 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 98304 KiB (x1)
Load Average: 4.60, 5.57, 2.91
***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
step<ConstantTimeStamper>              0.261 ns        0.261 ns   2687470019
step<NaiveTimeStamper>                 0.260 ns        0.260 ns   2705208959
step<KahanTimeStamper>                  1.53 ns         1.53 ns    456830091
step<CascadedTimeStamper>               1.59 ns         1.59 ns    441397969
step_virtual<ConstantTimeStamper>       1.54 ns         1.54 ns    456223299
step_virtual<NaiveTimeStamper>          1.54 ns         1.54 ns    453880243
step_virtual<KahanTimeStamper>          3.45 ns         3.45 ns    203046288
step_virtual<CascadedTimeStamper>       3.45 ns         3.45 ns    202646984
```

divergence is consistent given previous work

https://github.com/PHARCHIVE/test_snippets/blob/main/numeric/double/increment_error.cpp