### PR TITLE
fix mhd dispersion timestamps - allow functional test dry run on PR

### DIFF
--- a/res/ci/jobs/pull_request/dry_run_functional_tests.sh
+++ b/res/ci/jobs/pull_request/dry_run_functional_tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+(
+  set -ex
+
+  # prevent openmpi complaining about root user on CI
+  export OMPI_ALLOW_RUN_AS_ROOT=1
+  export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+  cd build
+  cmake .. -DPHARE_EXEC_LEVEL_MIN=11 -DPHARE_EXEC_LEVEL_MAX=100
+  export PHARE_DRY_RUN=1
+  ctest --output-on-failure
+)

--- a/res/cmake/def.cmake
+++ b/res/cmake/def.cmake
@@ -139,6 +139,11 @@ endif(ubsan)
 
 # public test functions
 #
+# add_phare_test/add_python3_test/add_no_mpi_phare_test/add_no_mpi_python3_test/
+# add_mpi_python3_test take no explicit level (unlike phare_exec/phare_python3_exec)
+# and are implicitly registered at PHARE_UNLEVELED_TEST_LEVEL (10): they are skipped
+# when PHARE_EXEC_LEVEL_MIN >= 1 or PHARE_EXEC_LEVEL_MAX < 11.
+#
 #   add_phare_test($binary $directory)
 #    execute binary in target directory, with mpirun when -DtestMPI=ON
 #
@@ -166,6 +171,12 @@ endif(ubsan)
 
 if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
+  # add_phare_test/add_python3_test/add_no_mpi_*/add_mpi_python3_test do not
+  # take an explicit level (unlike phare_exec/phare_python3_exec), so they are
+  # implicitly treated as this level - set PHARE_EXEC_LEVEL_MIN > this value
+  # (or PHARE_EXEC_LEVEL_MAX < this value) to skip them all.
+  set(PHARE_UNLEVELED_TEST_LEVEL 1)
+
   if (NOT DEFINED PHARE_MPI_PROCS)
     set(PHARE_MPI_PROCS 1)
     if(testMPI)
@@ -180,8 +191,20 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
     set_property(TEST ${binary} APPEND PROPERTY ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
   endfunction(set_exe_paths_)
 
-  function(add_phare_test_ binary directory)
+  # prevents building a target even when added via "add_executable"
+  function(skip_building binary)
+    set_target_properties(${binary} PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+  endfunction(skip_building)
+
+  # applies unconditionally to any binary that will actually be built - must
+  # never be skipped by the PHARE_UNLEVELED_TEST_LEVEL check below, else the
+  # binary silently builds with default (non-Werror, missing -DPHARE_HAS_HIGHFIVE) flags.
+  function(add_phare_test_build_flags_ binary)
     target_compile_options(${binary} PRIVATE ${PHARE_WERROR_FLAGS} -DPHARE_HAS_HIGHFIVE=${PHARE_HAS_HIGHFIVE})
+  endfunction(add_phare_test_build_flags_)
+
+  # ctest-registration decoration only - assumes add_test() was already called
+  function(add_phare_test_ binary directory)
     set_exe_paths_(${binary})
     set_property(TEST ${binary} APPEND PROPERTY ENVIRONMENT GMON_OUT_PREFIX=gprof.${binary})
     set_property(TEST ${binary} APPEND PROPERTY ENVIRONMENT PHARE_MPI_PROCS=${PHARE_MPI_PROCS})
@@ -196,16 +219,25 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
   endfunction(add_phare_test_)
 
   function(add_no_mpi_phare_test binary directory)
+    if(${PHARE_EXEC_LEVEL_MIN} GREATER ${PHARE_UNLEVELED_TEST_LEVEL})
+      # test inactive at this level - don't waste time building it either,
+      # rather than building it and silently skipping its compile flags
+      skip_building(${binary})
+      return()
+    endif()
     if(NOT testMPI OR (testMPI AND forceSerialTests))
+      add_phare_test_build_flags_(${binary})
       add_test(NAME ${binary} COMMAND ./${binary} WORKING_DIRECTORY ${directory})
       add_phare_test_(${binary} ${directory})
     else()
-      # this prevents building targets even when added via "add_executable"
-      set_target_properties(${binary} PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+      skip_building(${binary})
     endif()
   endfunction(add_no_mpi_phare_test)
 
   function(add_no_mpi_python3_test name file directory)
+    if(${PHARE_EXEC_LEVEL_MIN} GREATER ${PHARE_UNLEVELED_TEST_LEVEL})
+      return()
+    endif()
     if(NOT testMPI OR (testMPI AND forceSerialTests))
       add_test(NAME py3_${name} COMMAND ${Python_EXECUTABLE} -u ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name})
@@ -214,16 +246,29 @@ if (test AND ${PHARE_EXEC_LEVEL_MIN} GREATER 0) # 0 = no tests
 
   if(testMPI)
     function(add_phare_test binary directory)
+      if(${PHARE_EXEC_LEVEL_MIN} GREATER ${PHARE_UNLEVELED_TEST_LEVEL})
+        # test inactive at this level - don't waste time building it either,
+        # rather than building it and silently skipping its compile flags
+        skip_building(${binary})
+        return()
+      endif()
+      add_phare_test_build_flags_(${binary})
       add_test(NAME ${binary} COMMAND mpirun -n ${PHARE_MPI_PROCS} ${PHARE_MPIRUN_POSTFIX} ./${binary} WORKING_DIRECTORY ${directory})
       add_phare_test_(${binary} ${directory})
     endfunction(add_phare_test)
 
     function(add_python3_test name file directory)
+      if(${PHARE_EXEC_LEVEL_MIN} GREATER ${PHARE_UNLEVELED_TEST_LEVEL})
+        return()
+      endif()
       add_test(NAME py3_${name} COMMAND mpirun -n ${PHARE_MPI_PROCS} ${PHARE_MPIRUN_POSTFIX} python3 -u ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name})
     endfunction(add_python3_test)
 
     function(add_mpi_python3_test N name file directory)
+      if(${PHARE_EXEC_LEVEL_MIN} GREATER ${PHARE_UNLEVELED_TEST_LEVEL})
+        return()
+      endif()
       add_test(NAME py3_${name}_mpi_n_${N} COMMAND mpirun -n ${N} ${PHARE_MPIRUN_POSTFIX} python3 ${file} WORKING_DIRECTORY ${directory})
       set_exe_paths_(py3_${name}_mpi_n_${N})
     endfunction(add_mpi_python3_test)

--- a/res/cmake/def.cmake
+++ b/res/cmake/def.cmake
@@ -141,8 +141,8 @@ endif(ubsan)
 #
 # add_phare_test/add_python3_test/add_no_mpi_phare_test/add_no_mpi_python3_test/
 # add_mpi_python3_test take no explicit level (unlike phare_exec/phare_python3_exec)
-# and are implicitly registered at PHARE_UNLEVELED_TEST_LEVEL (10): they are skipped
-# when PHARE_EXEC_LEVEL_MIN >= 1 or PHARE_EXEC_LEVEL_MAX < 11.
+# and are implicitly registered at PHARE_UNLEVELED_TEST_LEVEL (1): they are skipped
+# when PHARE_EXEC_LEVEL_MIN > 1.
 #
 #   add_phare_test($binary $directory)
 #    execute binary in target directory, with mpirun when -DtestMPI=ON

--- a/tests/functional/alfven_wave/alfven_wave1d.py
+++ b/tests/functional/alfven_wave/alfven_wave1d.py
@@ -135,7 +135,11 @@ def phase_speed(run_path, ampl, xmax):
 def main():
     from pyphare import cpp
 
-    Simulator(config()).run()
+    sim = config()
+    Simulator(sim).run()
+
+    if sim.dry_run:
+        return
 
     if cpp.mpi_rank() == 0:
         vphi, t, phi, a, k = phase_speed(".", 0.01, 1000)

--- a/tests/functional/conservation/conserv.py
+++ b/tests/functional/conservation/conserv.py
@@ -190,10 +190,15 @@ def main():
     nbrcells = [100, 200]
     nbrdts = [25000, 100000]
 
+    sim = None
     for vth in cases:
         for dl, nbrcell, nbrdt in zip(dls, nbrcells, nbrdts):
-            Simulator(uniform(vth, dl, nbrcell, nbrdt)).run()
+            sim = uniform(vth, dl, nbrcell, nbrdt)
+            Simulator(sim).run()
             ph.global_vars.sim = None
+
+    if sim.dry_run:
+        return
 
     paths = glob("*vth*")
     runs_vth = {}

--- a/tests/functional/harris/harris_2d.py
+++ b/tests/functional/harris/harris_2d.py
@@ -216,8 +216,9 @@ class HarrisTest(SimulatorTest):
 
     def test_run(self):
         self.register_diag_dir_for_cleanup(diag_dir)
-        Simulator(config()).run().reset()
-        if cpp.mpi_rank() == 0:
+        sim = config()
+        Simulator(sim).run().reset()
+        if not sim.dry_run and cpp.mpi_rank() == 0:
             plot_dir = Path(f"{diag_dir}_plots") / str(cpp.mpi_size())
             plot_dir.mkdir(parents=True, exist_ok=True)
             plot(diag_dir, plot_dir)

--- a/tests/functional/ionIonBeam/ion_ion_beam1d.py
+++ b/tests/functional/ionIonBeam/ion_ion_beam1d.py
@@ -173,7 +173,11 @@ def main():
     # until the time at which the B value gets the greater... but is rather before with an offset
     # given by time_offset : the exponential fit is performed on [0, times[imax] - time_offset]
 
-    Simulator(config()).run()
+    sim = config()
+    Simulator(sim).run()
+
+    if sim.dry_run:
+        return
 
     if cpp.mpi_rank() == 0:
         times, first_mode, ampl, gamma, damped_mode, omega = growth_b_right_hand(

--- a/tests/functional/mhd_alfven2d/alfven2d.py
+++ b/tests/functional/mhd_alfven2d/alfven2d.py
@@ -143,8 +143,9 @@ class AlfvenTest(SimulatorTest):
 
     def test_run(self):
         self.register_diag_dir_for_cleanup(diag_dir)
-        Simulator(config()).run().reset()
-        if cpp.mpi_rank() == 0:
+        sim = config()
+        Simulator(sim).run().reset()
+        if not sim.dry_run and cpp.mpi_rank() == 0:
             plot_dir = Path(f"{diag_dir}_plots") / str(cpp.mpi_size())
             plot_dir.mkdir(parents=True, exist_ok=True)
             plot(diag_dir, plot_dir)

--- a/tests/functional/mhd_convergence/convergence.py
+++ b/tests/functional/mhd_convergence/convergence.py
@@ -128,7 +128,10 @@ def run_convergence(reconstruction, limiter):
 
     while Dx > Dx0 / 32.0 and Nx < 1600:
         ph.global_vars.sim = None
-        Simulator(config(Nx, Dx, reconstruction, limiter)).run().reset()
+        sim = config(Nx, Dx, reconstruction, limiter)
+        Simulator(sim).run().reset()
+        if sim.dry_run:
+            return
         run = Run(diag_dir)
         error = compute_error(run, final_time, Nx, Dx, ghosts)
         dx_values.append(Dx)

--- a/tests/functional/mhd_dispersion/whistler1d.py
+++ b/tests/functional/mhd_dispersion/whistler1d.py
@@ -35,7 +35,10 @@ def create_settings(cells, dl, m, nbr_periods, timestep, diag_dir):
     settings["final_time"] = (2 * np.pi / settings["w"]) * settings["nbr_periods"]
     # np.arrange() looked like it had some precision issues
     settings["nsteps"] = int(np.round(settings["final_time"] / settings["timestep"]))
-    settings["timestamps"] = np.linspace(0, settings["final_time"], settings["nsteps"])
+    # timestamps must be exact multiples of timestep (dt is kept bit-exact by
+    # Simulation), not a linspace over final_time whose spacing generally
+    # differs from timestep.
+    settings["timestamps"] = settings["timestep"] * np.arange(settings["nsteps"] + 1)
     return settings
 
 

--- a/tests/functional/mhd_harris/harris.py
+++ b/tests/functional/mhd_harris/harris.py
@@ -181,8 +181,9 @@ class HarrisTest(SimulatorTest):
 
     def test_run(self):
         self.register_diag_dir_for_cleanup(diag_dir)
-        Simulator(config()).run().reset()
-        if cpp.mpi_rank() == 0:
+        sim = config()
+        Simulator(sim).run().reset()
+        if not sim.dry_run and cpp.mpi_rank() == 0:
             plot_dir = Path(f"{diag_dir}_plots") / str(cpp.mpi_size())
             plot_dir.mkdir(parents=True, exist_ok=True)
             plot(diag_dir, plot_dir)

--- a/tests/functional/mhd_orszagtang/orszag_tang.py
+++ b/tests/functional/mhd_orszagtang/orszag_tang.py
@@ -151,8 +151,9 @@ class OrszagTangTest(SimulatorTest):
 
     def test_run(self):
         self.register_diag_dir_for_cleanup(diag_dir)
-        Simulator(config()).run().reset()
-        if cpp.mpi_rank() == 0:
+        sim = config()
+        Simulator(sim).run().reset()
+        if not sim.dry_run and cpp.mpi_rank() == 0:
             plot_dir = Path(f"{diag_dir}_plots") / str(cpp.mpi_size())
             plot_dir.mkdir(parents=True, exist_ok=True)
             plot(diag_dir, plot_dir)

--- a/tests/functional/mhd_rotor/rotor.py
+++ b/tests/functional/mhd_rotor/rotor.py
@@ -172,8 +172,9 @@ class RotorTest(SimulatorTest):
 
     def test_run(self):
         self.register_diag_dir_for_cleanup(diag_dir)
-        Simulator(config()).run().reset()
-        if cpp.mpi_rank() == 0:
+        sim = config()
+        Simulator(sim).run().reset()
+        if not sim.dry_run and cpp.mpi_rank() == 0:
             plot_dir = Path(f"{diag_dir}_plots") / str(cpp.mpi_size())
             plot_dir.mkdir(parents=True, exist_ok=True)
             plot(diag_dir, plot_dir)

--- a/tests/functional/mhd_shock/mhd_shock.py
+++ b/tests/functional/mhd_shock/mhd_shock.py
@@ -130,8 +130,9 @@ class ShockTest(SimulatorTest):
 
     def test_run(self):
         self.register_diag_dir_for_cleanup(diag_dir)
-        Simulator(config()).run().reset()
-        if cpp.mpi_rank() == 0:
+        sim = config()
+        Simulator(sim).run().reset()
+        if not sim.dry_run and cpp.mpi_rank() == 0:
             plot_dir = Path(f"{diag_dir}_plots") / str(cpp.mpi_size())
             plot_dir.mkdir(parents=True, exist_ok=True)
             plot(diag_dir, plot_dir)

--- a/tests/functional/shock/shock.py
+++ b/tests/functional/shock/shock.py
@@ -117,11 +117,13 @@ def main():
     import subprocess
     import matplotlib.pyplot as plt
 
+    dry_run = False
     for interp_order in (1, 2, 3):
         sim = config(interp_order)
         Simulator(sim).run()
+        dry_run = sim.dry_run
 
-        if cpp.mpi_rank() == 0:
+        if not dry_run and cpp.mpi_rank() == 0:
             dt = 10 * sim.time_step
             nt = sim.final_time / dt + 1
             times = dt * np.arange(nt)
@@ -150,6 +152,10 @@ def main():
             subprocess.call(cmd)
 
         ph.global_vars.sim = None
+
+    if dry_run:
+        return
+
     pngs = glob.glob("shock*/*.png")
     for png in pngs:
         os.remove(png)

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -262,7 +262,8 @@ def post_advance(new_time):
 
 
 def main():
-    Simulator(noRefinement(diagdir="noRefinement")).run().reset()
+    sim = noRefinement(diagdir="noRefinement")
+    Simulator(sim).run().reset()
     ph.global_vars.sim = None
 
     Simulator(
@@ -270,7 +271,7 @@ def main():
     ).run().reset()
     ph.global_vars.sim = None
 
-    if cpp.mpi_rank() == 0:
+    if not sim.dry_run and cpp.mpi_rank() == 0:
         make_figure()
 
 

--- a/tests/simulator/test_diagnostic_timestamps.py
+++ b/tests/simulator/test_diagnostic_timestamps.py
@@ -122,6 +122,9 @@ class DiagnosticsTest(unittest.TestCase):
 
         Simulator(simulation).run()
 
+        if sim.dry_run:
+            return
+
         def make_time(stamp):
             return "{:.10f}".format(stamp)
 
@@ -165,6 +168,9 @@ class DiagnosticsTest(unittest.TestCase):
                     )
 
                 Simulator(simulation).run()
+
+                if simulation.dry_run:
+                    return
 
                 for diagname, diagInfo in simulation.diagnostics.items():
                     h5_filename = os.path.join(diag_outputs, h5_filename_from(diagInfo))


### PR DESCRIPTION
allow skipping normal tests to only run functional tests

[build](https://hephaistos.lpp.polytechnique.fr/teamcity/buildConfiguration/Phare_Phare_BuildGithubPrGccSs) should trigger the new dry run script if found