### PR TITLE
Add CONTRIBUTING.md, issue templates, and PR template

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,21 @@ knowledge_base:
     project_keys: []
   linear:
     team_keys: []
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - '**/.cursorrules'
+      - .github/copilot-instructions.md
+      - '**/CLAUDE.md'
+      - '**/GEMINI.md'
+      - '**/.cursor/rules/*'
+      - '**/.windsurfrules'
+      - '**/.clinerules/*'
+      - '**/.rules/*'
+      - '**/AGENT.md'
+      - '**/AGENTS.md'
+      - '**/REVIEW.md'
+      - CONTRIBUTING.md
 chat:
   auto_reply: true
 reviews:
@@ -21,6 +36,7 @@ reviews:
   poem: false
   review_status: true
   collapse_walkthrough: true
+  sequence_diagrams: true
   path_filters: []
   path_instructions:
     - path: '**/*.hpp'
@@ -50,6 +66,10 @@ reviews:
     biome:
       enabled: true
     hadolint:
+      enabled: true
+    clang:
+      enabled: true
+    cppcheck:
       enabled: true
   auto_review:
     enabled: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Something in PHARE isn't working as expected
+labels: ["bug 🔥", "triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What's wrong
+      description: Describe the bug and what you expected to happen instead.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Is it reproducible?
+      options:
+        - "Yes, reliably"
+        - "Yes, intermittently"
+        - "No / unknown"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: If reproducible, give the minimal steps, config, or script needed. If not reproducible, explain what you observed and any conditions that seemed related.
+      placeholder: |
+        1. Simulation config / script used (attach or paste)
+        2. Command run
+        3. What happens
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Commit/branch, build config (cmake flags, compiler), machine (laptop/HPC), dimension/interp order, MPI ranks, anything relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional details
+      description: Logs, stack traces, output files, related issues/PRs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature / change request
+description: Propose a new feature or a change to existing code
+labels: ["feature", "triage"]
+body:
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: What problem does this solve, or what capability is missing? This is the most important part — the how can come later.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What would change, at a high level (new capability, behavior change, API, etc.)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: Ideas on how (optional)
+      description: Any thoughts, hints, or constraints on implementation. Not required — this can be worked out later, in this issue or in the PR.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, or reasons to not do this, if any.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Related issues/PRs, discussions, references.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+Title should be a clear, one-line "take-home message": why this PR exists,
+not just what it touches (e.g. "Fix particle split crash at level boundary",
+not "Update SplitOp.hpp").
+-->
+
+## Issue
+
+<!-- Fixes #... / Relates to #...
+Every PR should reference an issue, unless this is a small, urgent,
+self-evident fix (in which case say so explicitly and explain why an
+issue isn't needed). -->
+
+## What this implements
+
+<!-- Is the issue fully or partially implemented by this PR?
+What assumptions did you make? -->
+
+## Design
+
+<!-- Only needed if this PR touches several files or is "long".
+Explain the design choices. Diagrams (e.g. Mermaid sequence/class diagrams)
+are welcome for new classes/concepts. -->
+
+## Tests
+
+<!-- What unit or functional tests cover this change?
+If none were added, explain why. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to PHARE
+
+## Issues
+
+Every idea for changing the code — a bug fix or a new feature — starts as an
+issue, before any code is written.
+
+- **Bug reports** should make clear whether the bug is reproducible, and if
+  so, how (steps, config, environment). If it isn't reproducible, describe
+  what was observed and any conditions that seemed related.
+- **Feature / change requests** should lead with the *why*: what problem this
+  solves or what capability is missing. The *how* is secondary and can be
+  worked out later, either in the issue itself or in the implementing PR.
+
+Use the [bug report](.github/ISSUE_TEMPLATE/bug_report.yml) or
+[feature request](.github/ISSUE_TEMPLATE/feature_request.yml) template when
+opening an issue.
+
+## Pull Requests
+
+- **A PR should reference an issue.** PRs without an issue must be small,
+  self-evident, and urgent — straightforward enough that why/priority/timing
+  don't need discussion.
+- **One issue per PR.** A PR should exist for a single reason to change the
+  code. Bundling unrelated changes together slows down review — small,
+  focused PRs merge faster.
+- **Keep PRs small.** PRs of more than ~500 lines or more than ~10 files
+  should be rare; split the work if possible.
+- **PR description** should include:
+  - A title that states the take-home message — why this PR, not just what
+    it touches.
+  - A link to the issue it implements, and an explanation of *how*: is the
+    issue fully or partially implemented? What assumptions were made?
+  - If the PR touches several files or is long, an explanation of the
+    *design*. Diagrams (e.g. Mermaid sequence/class diagrams) are welcome
+    for new classes or concepts.
+- **Tests.** Bring unit or functional tests with the code as much as
+  possible. If tests aren't included, explain why in the PR description.
+
+Use the [PR template](.github/pull_request_template.md) — it mirrors this
+checklist.


### PR DESCRIPTION
We currently do not have "rules" for how the code base should change.
This leads to possibly hectic PRs difficult to review about some undiscussed and undocumented features.
These files try to prevent this situation with a more formal approach.
The key is that small-single-issue-a priori-discussed-PRs are less likely to pile up as opposed to current ones.
Let's consider this PR as the last not having a prior issue :D