### PR TITLE
Functional tests: add a load balancer

### DIFF
--- a/tests/functional/alfven_wave/alfven_wave1d.py
+++ b/tests/functional/alfven_wave/alfven_wave1d.py
@@ -96,6 +96,8 @@ def config():
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 

--- a/tests/functional/conservation/conserv.py
+++ b/tests/functional/conservation/conserv.py
@@ -91,6 +91,8 @@ def uniform(vth, dl, cells, nbr_steps):
             population_name="protons",
         )
 
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 

--- a/tests/functional/dispersion/dispersion.py
+++ b/tests/functional/dispersion/dispersion.py
@@ -87,6 +87,8 @@ def fromNoise():
     for quantity in ["E", "B"]:
         ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 
@@ -175,6 +177,8 @@ def prescribedModes():
         ph.FluidDiagnostics(
             quantity=quantity, write_timestamps=timestamps, flush_every=0
         )
+
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/ionIonBeam/ion_ion_beam1d.py
+++ b/tests/functional/ionIonBeam/ion_ion_beam1d.py
@@ -100,6 +100,9 @@ def config():
         ph.ParticleDiagnostics(
             quantity="domain", population_name=pop_name, write_timestamps=timestamps
         )
+
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 

--- a/tests/functional/shock/shock.py
+++ b/tests/functional/shock/shock.py
@@ -107,6 +107,8 @@ def config(interp_order):
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 

--- a/tests/functional/td/td1d.py
+++ b/tests/functional/td/td1d.py
@@ -101,6 +101,9 @@ def config():
             quantity=quantity,
             write_timestamps=timestamps,
         )
+
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -129,6 +129,8 @@ def config(**options):
                 population_name=pop,
             )
 
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 

--- a/tests/functional/translation/translat1d.py
+++ b/tests/functional/translation/translat1d.py
@@ -86,6 +86,8 @@ def config_uni(**kwargs):
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+
     return sim
 
 
@@ -180,6 +182,8 @@ def config_td(**kwargs):
 
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
+
+    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
 
     return sim
 


### PR DESCRIPTION
Some functional tests have no load balancer declared.

I have seen the time per timestep double across the dispersion run with 4 cores, so maybe this should help