### PR TITLE
don't fail if ffmpeg is not found in shock functional test

### DIFF
--- a/tests/functional/shock/shock.py
+++ b/tests/functional/shock/shock.py
@@ -149,7 +149,10 @@ def main():
                     interp_order, interp_order, interp_order
                 )
             )
-            subprocess.call(cmd)
+            try:
+                subprocess.call(cmd)
+            except FileNotFoundError:
+                print("ffmpeg not found, skipping video generation")
 
         ph.global_vars.sim = None
 


### PR DESCRIPTION
shock tests fails without ffmpeg

closes #839