### PR TITLE
run some tests serially as MPI is not required to validate

### DIFF
--- a/tests/amr/data/field/copy_pack/copy/CMakeLists.txt
+++ b/tests/amr/data/field/copy_pack/copy/CMakeLists.txt
@@ -23,6 +23,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   )
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/data/field/copy_pack/copy_overlap/CMakeLists.txt
+++ b/tests/amr/data/field/copy_pack/copy_overlap/CMakeLists.txt
@@ -25,6 +25,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   )
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/data/field/geometry/CMakeLists.txt
+++ b/tests/amr/data/field/geometry/CMakeLists.txt
@@ -27,6 +27,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${SAMRAI_LIBRARIES})
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/data/particles/refine/CMakeLists.txt
+++ b/tests/amr/data/particles/refine/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/models/CMakeLists.txt
+++ b/tests/amr/models/CMakeLists.txt
@@ -23,6 +23,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/multiphysics_integrator/CMakeLists.txt
+++ b/tests/amr/multiphysics_integrator/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 )
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 
 

--- a/tests/amr/resources_manager/CMakeLists.txt
+++ b/tests/amr/resources_manager/CMakeLists.txt
@@ -29,6 +29,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/amr/tagging/CMakeLists.txt
+++ b/tests/amr/tagging/CMakeLists.txt
@@ -24,6 +24,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   ${GTEST_LIBS})
 
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/core/data/electrons/CMakeLists.txt
+++ b/tests/core/data/electrons/CMakeLists.txt
@@ -14,6 +14,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   phare_initializer
   ${GTEST_LIBS})
 
-add_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_phare_test(${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR})
 
 

--- a/tests/core/data/particles/CMakeLists.txt
+++ b/tests/core/data/particles/CMakeLists.txt
@@ -14,7 +14,7 @@ function(_particles_test src test_name)
     phare_initializer
     ${GTEST_LIBS})
 
-  add_phare_test(${test_name} ${CMAKE_CURRENT_BINARY_DIR})
+  add_no_mpi_phare_test(${test_name} ${CMAKE_CURRENT_BINARY_DIR})
 
 endfunction(_particles_test)
 


### PR DESCRIPTION
closes #358

C++ test MPI-parallel vs serial-only registration (add_phare_test vs
add_no_mpi_phare_test in CMakeLists.txt).

switched to serial-only (add_no_mpi_phare_test):

  tests/core/data/electrons
  tests/core/data/particles
  tests/amr/data/field/copy_pack/copy
  tests/amr/data/field/copy_pack/copy_overlap
  tests/amr/data/particles/refine
  tests/amr/data/field/geometry
  tests/amr/models
  tests/amr/resources_manager
  tests/amr/tagging
  tests/amr/multiphysics_integrator

  (plus tests already serial before this pass: tests/amr/data/field/variable,
  tests/amr/data/field/refine, tests/amr/data/field/coarsening,
  tests/amr/data/field/time_interpolate, tests/amr/data/field/overlap,
  tests/amr/data/particles/copy, tests/amr/data/particles/copy_overlap)

left parallel (add_phare_test) on purpose:

  tests/amr/data/field/copy_pack/stream_pack   - stream_pack tests stay parallel
  tests/amr/data/particles/stream_pack         - stream_pack tests stay parallel
  tests/diagnostic                             - collective HDF5 create does
                                                  a real cross-rank sync
                                                  (core::mpi::max(maxLocalLevel)
                                                  in h5writer.hpp), untested at N=1
  tests/amr/messengers                         - all TEST_F cases currently
                                                  commented out (moot either way)
