### PR TITLE
particle splitting superclass type string correction

### DIFF
--- a/src/amr/data/particles/refine/split_1d.hpp
+++ b/src/amr/data/particles/refine/split_1d.hpp
@@ -132,7 +132,7 @@ struct Splitter<DimConst<1>, InterpConst<3>, RefinedParticlesConst<2>>
       SplitPattern_1_3_2_Dispatcher
 {
     constexpr Splitter()
-        : SplitPattern_1_2_2_Dispatcher{{weight[0], delta[0]}}
+        : SplitPattern_1_3_2_Dispatcher{{weight[0], delta[0]}}
     {
     }
 


### PR DESCRIPTION
the types were both referencing the same thing underneath, but it was misleading

closes #1106