### PR TITLE
fix: emergency dump one full-hierarchy step, not per-level

### DIFF
--- a/src/diagnostic/diagnostic_manager.hpp
+++ b/src/diagnostic/diagnostic_manager.hpp
@@ -67,6 +67,10 @@ class IDiagnosticsManager
 public:
     virtual bool dump(double timeStamp, double timeStep)         = 0;
     virtual void dump_level(std::size_t level, double timeStamp) = 0;
+    // unconditional full-hierarchy dump (all levels, all diagnostics, in a single
+    // step). Used for emergency dumps so the VTKHDF step metadata stays consistent
+    // (one step = all levels), unlike a per-level dump_level loop.
+    virtual void dump_all(double timeStamp)                      = 0;
     inline virtual ~IDiagnosticsManager();
 };
 IDiagnosticsManager::~IDiagnosticsManager() {}
@@ -83,6 +87,8 @@ public:
 
 
     void dump_level(std::size_t level, double timeStamp) override;
+
+    void dump_all(double timeStamp) override;
 
 
     DiagnosticsManager(std::unique_ptr<Writer>&& writer_ptr)
@@ -219,6 +225,23 @@ void DiagnosticsManager<Writer>::dump_level(std::size_t level, double timeStamp)
         activeDiagnostics.emplace_back(&diag);
 
     writer_->dump_level(level, activeDiagnostics, timeStamp);
+}
+
+
+template<typename Writer>
+void DiagnosticsManager<Writer>::dump_all(double timeStamp)
+{
+    std::vector<DiagnosticProperties*> activeDiagnostics;
+    for (auto& diag : diagnostics_)
+    {
+        // recompute derived quantities (B=B1+B0, P, V, Etot) so the snapshot is
+        // consistent, then dump every diagnostic in one full-hierarchy step.
+        writer_->getDiagnosticWriterForType(diag.type)->compute(diag);
+        activeDiagnostics.emplace_back(&diag);
+    }
+
+    if (activeDiagnostics.size() > 0)
+        writer_->dump(activeDiagnostics, timeStamp);
 }
 
 

--- a/src/diagnostic/diagnostics.hpp
+++ b/src/diagnostic/diagnostics.hpp
@@ -42,6 +42,8 @@ struct NullOpDiagnosticsManager : public IDiagnosticsManager
     {
         throw std::runtime_error("NOOP");
     }
+
+    void dump_all(double /*timestamp*/) override { throw std::runtime_error("NOOP"); }
 };
 
 struct DiagnosticsManagerResolver

--- a/src/simulator/simulator.hpp
+++ b/src/simulator/simulator.hpp
@@ -588,8 +588,11 @@ void Simulator<opts>::handle_dictionary_exception(core::DictionaryException cons
     if (this->allowEmergencyDumps)
         for (auto const& exception_id : dump_exceptions)
             if (ex.id() == exception_id)
-                for (int ilvl = 0; ilvl < hierarchy_->getMaxNumberOfLevels(); ++ilvl)
-                    this->dMan->dump_level(ilvl, currentTime_);
+                // single full-hierarchy dump: one VTKHDF step holding all levels.
+                // A per-level dump_level loop appends one step per level, breaking
+                // the OverlappingAMR "one step = all levels" invariant (ParaView
+                // then shows nothing for the multi-level emergency snapshot).
+                this->dMan->dump_all(currentTime_);
 }
 
 template<auto opts>


### PR DESCRIPTION
Fix by claude for #1275. Here his explanation:

## Summary
- Emergency dumps (`handle_dictionary_exception`) looped `dump_level(ilvl)` per AMR level. Each `dump_level` call bumps VTKHDF's `/Steps/NSteps` and appends a `Values` entry once while writing only that level's data — VTKHDF `OverlappingAMR` requires one step to hold all levels, so a multi-level emergency dump produced split, partial steps that ParaView renders as blank. Single-level/no-AMR runs happened to survive since `dump_level(0)` is effectively a full snapshot in that case.
- `dump_level` also skipped `compute()`, leaving derived quantities ( `P`, `V`) stale in the emergency snapshot.
- Adds `IDiagnosticsManager::dump_all(timeStamp)`: runs `compute()` on every diagnostic, then a single full-hierarchy `dump()` — one consistent VTKHDF step with all levels. The emergency handler now calls `dump_all` instead of the per-level loop.

## Test plan
- [x] Existing emergency-dump exercising tests still build/pass (verified on the branch this fix was developed on)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)