### PR TITLE
CT-based magnetic energy flux

### DIFF
--- a/src/amr/solvers/solver_mhd_field_evolvers.hpp
+++ b/src/amr/solvers/solver_mhd_field_evolvers.hpp
@@ -91,8 +91,6 @@ ToPrimitiveTransformer(typename Model::amr_types::level_t&, Model&)
 
 
 
-
-
 template<typename Model, typename FVMethod>
 class FVMethodTransformer
 {
@@ -101,8 +99,8 @@ class FVMethodTransformer
     using core_type  = FVMethod;
 
 public:
-    using info_type    = core_type::Info_t;
-    using Equations_t  = core_type::Equations_t;
+    using info_type   = core_type::Info_t;
+    using Equations_t = core_type::Equations_t;
 
     template<typename T>
     using Rec = core_type::template Rec<T>;
@@ -119,16 +117,16 @@ public:
     }
 
 
-    void operator()(auto& fvm_state, auto& ct_state, auto& state, auto& fluxes, double const newTime)
+    void operator()(auto& ct_state, auto& state, auto& fluxes, double const newTime)
     {
         TimeSetter setTime{level, model, newTime};
 
         auto& rm = *model.resourcesManager;
-        for (auto& patch : rm.enumerate(level, fvm_state, ct_state, state, fluxes))
+        for (auto& patch : rm.enumerate(level, ct_state, state, fluxes))
         {
             auto const layout = amr::layoutFromPatch<GridLayout>(*patch);
             core_type finite_volume_method{info, layout};
-            finite_volume_method(fvm_state, ct_state, state, fluxes);
+            finite_volume_method(ct_state, state, fluxes);
         }
 
         setTime(state.rho, state.V, state.P, state.J);
@@ -219,6 +217,42 @@ public:
 
 
 
+// Applies the CT-based magnetic energy (Poynting) correction to the energy flux. Must run
+// AFTER the ConstrainedTransport step so state.E and the CT edge-B buffers (in ct_state) are
+// available and temporally consistent. Reuses the FVMethod (Godunov) core, which carries
+// apply_poynting_correction.
+template<typename Model, typename FVMethod>
+class PoyntingCorrectionTransformer
+{
+    using GridLayout = Model::gridlayout_type;
+    using level_t    = Model::amr_types::level_t;
+    using core_type  = FVMethod;
+
+public:
+    using info_type = core_type::Info_t;
+
+    explicit PoyntingCorrectionTransformer(level_t& level, auto& model, info_type const& info)
+        : level{level}
+        , model{model}
+        , info{info}
+    {
+    }
+
+    void operator()(auto& ct_state, auto& state, auto& fluxes)
+    {
+        auto& rm = *model.resourcesManager;
+        for (auto& patch : rm.enumerate(level, ct_state, state, fluxes))
+        {
+            auto const layout = amr::layoutFromPatch<GridLayout>(*patch);
+            core_type finite_volume_method{info, layout};
+            finite_volume_method.apply_poynting_correction(ct_state, state, fluxes);
+        }
+    }
+
+    level_t& level;
+    Model& model;
+    info_type const& info;
+};
 
 
 
@@ -263,6 +297,9 @@ struct Dispatchers : FieldEvolverDispatchers<Model>
 
     template<typename FVMethodStrategy>
     using FVMethod_t = FVMethodTransformer<Model, FVMethodStrategy>;
+
+    template<typename FVMethodStrategy>
+    using PoyntingCorrection_t = PoyntingCorrectionTransformer<Model, FVMethodStrategy>;
 
     using FiniteVolumeEuler_t = FiniteVolumeEulerTransformer<Model>;
 

--- a/src/amr/solvers/time_integrator/compute_fluxes.hpp
+++ b/src/amr/solvers/time_integrator/compute_fluxes.hpp
@@ -22,6 +22,8 @@ class ComputeFluxes
     using FVMethod_t     = Dispatchers_t::template FVMethod_t<FVMethodStrategy>;
     using FVMethodInfo_t = FVMethod_t::info_type;
 
+    using PoyntingCorrection_t = Dispatchers_t::template PoyntingCorrection_t<FVMethodStrategy>;
+
     constexpr static auto Hall             = FVMethod_t::Hall;
     constexpr static auto Resistivity      = FVMethod_t::Resistivity;
     constexpr static auto HyperResistivity = FVMethod_t::HyperResistivity;
@@ -36,8 +38,7 @@ class ComputeFluxes
     using ToPrimitiveConverter_t    = Dispatchers_t::ToPrimitiveConverter_t;
     using ToConservativeConverter_t = Dispatchers_t::ToConservativeConverter_t;
 
-    using VecField    = MHDModel::vecfield_type;
-    using Equations_t = FVMethod_t::Equations_t;
+    using VecField = MHDModel::vecfield_type;
 
 
 public:
@@ -60,23 +61,22 @@ public:
             TimeSetter{level, model, newTime}(state.B, state.J);
         }
 
-        FVMethod_t{level, model, fVMethodInfo_}(fvm_, ct_, state, fluxes, newTime);
+        FVMethod_t{level, model, fVMethodInfo_}(ct_, state, fluxes, newTime);
 
         // unecessary if we decide to store both primitive and conservative variables
         ToConservativeConverter_t{level, model}(state, to_conservative_gamma_, newTime);
 
         ConstrainedTransport_t{level, model, constrainedTransportInfo_}(ct_, state);
+
+        // CT-based magnetic energy flux: correct F_Etot with the Poynting flux E×B using
+        // the edge-B buffers CT just stored in ct_ (must follow the CT step).
+        PoyntingCorrection_t{level, model, fVMethodInfo_}(ct_, state, fluxes);
     }
 
-    void registerResources(MHDModel& model)
-    {
-        model.resourcesManager->registerResources(fvm_);
-        model.resourcesManager->registerResources(ct_);
-    }
+    void registerResources(MHDModel& model) { model.resourcesManager->registerResources(ct_); }
 
     void allocate(MHDModel& model, auto& patch, double const allocateTime) const
     {
-        model.resourcesManager->allocate(fvm_, patch, allocateTime);
         model.resourcesManager->allocate(ct_, patch, allocateTime);
     }
 
@@ -85,7 +85,6 @@ private:
     ConstrainedTransportInfo_t constrainedTransportInfo_;
 
     // Ampere_t ampere_;
-    core::GodunovState<VecField, Equations_t> fvm_{};
     core::UpwindConstrainedTransportState<VecField, Hall, Resistivity> ct_{};
     // ToPrimitiveConverter_t to_primitive_;
     // ToConservativeConverter_t to_conservative_;

--- a/src/core/numerics/MHD_equations/MHD_equations.hpp
+++ b/src/core/numerics/MHD_equations/MHD_equations.hpp
@@ -31,7 +31,12 @@ public:
         auto const P   = u.P;
 
         auto const GeneralisedPressure = P + 0.5 * (B.x * B.x + B.y * B.y + B.z * B.z);
-        auto const TotalEnergy         = eosPToEtot(gamma_, rho, V.x, V.y, V.z, B.x, B.y, B.z, P);
+
+        // HD-only energy: kinetic + thermal. No magnetic terms.
+        // All magnetic energy transport (B²V - (V·B)B = E×B in ideal MHD) is
+        // provided by the CT Poynting correction in apply_poynting_correction().
+        // Including B² here would double-count with the Poynting flux.
+        auto const Ehd = 0.5 * rho * (V.x * V.x + V.y * V.y + V.z * V.z) + P / (gamma_ - 1.0);
 
         if constexpr (direction == Direction::X)
         {
@@ -42,8 +47,7 @@ public:
             auto F_Bx    = 0.0;
             auto F_By    = B.y * V.x - V.y * B.x;
             auto F_Bz    = B.z * V.x - V.z * B.x;
-            auto F_Etot  = (TotalEnergy + GeneralisedPressure) * V.x
-                          - B.x * (V.x * B.x + V.y * B.y + V.z * B.z);
+            auto F_Etot  = (Ehd + P) * V.x;
 
             return PerIndex{F_rho, {F_rhoVx, F_rhoVy, F_rhoVz}, {F_Bx, F_By, F_Bz}, F_Etot};
         }
@@ -56,8 +60,7 @@ public:
             auto F_Bx    = B.x * V.y - V.x * B.y;
             auto F_By    = 0.0;
             auto F_Bz    = B.z * V.y - V.z * B.y;
-            auto F_Etot  = (TotalEnergy + GeneralisedPressure) * V.y
-                          - B.y * (V.x * B.x + V.y * B.y + V.z * B.z);
+            auto F_Etot  = (Ehd + P) * V.y;
 
             return PerIndex{F_rho, {F_rhoVx, F_rhoVy, F_rhoVz}, {F_Bx, F_By, F_Bz}, F_Etot};
         }
@@ -70,8 +73,7 @@ public:
             auto F_Bx    = B.x * V.z - V.x * B.z;
             auto F_By    = B.y * V.z - V.y * B.z;
             auto F_Bz    = 0.0;
-            auto F_Etot  = (TotalEnergy + GeneralisedPressure) * V.z
-                          - B.z * (V.x * B.x + V.y * B.y + V.z * B.z);
+            auto F_Etot  = (Ehd + P) * V.z;
 
             return PerIndex{F_rho, {F_rhoVx, F_rhoVy, F_rhoVz}, {F_Bx, F_By, F_Bz}, F_Etot};
         }
@@ -147,26 +149,23 @@ private:
         auto const JxB_y = J.z * B.x - J.x * B.z;
         auto const JxB_z = J.x * B.y - J.y * B.x;
 
-        auto const BdotJ = B.x * J.x + B.y * J.y + B.z * J.z;
-        auto const BdotB = B.x * B.x + B.y * B.y + B.z * B.z;
-
+        // Hall energy flux ((BdotJ*B - BdotB*J)/rho) is already captured by the CT
+        // Poynting correction via E×B, where E includes the Hall term (J×B)/rho.
+        // Adding it here would double-count with apply_poynting_correction().
         if constexpr (direction == Direction::X)
         {
             F_B.y += -JxB_z * invRho;
             F_B.z += JxB_y * invRho;
-            F_Etot += (BdotJ * B.x - BdotB * J.x) * invRho;
         }
         if constexpr (direction == Direction::Y)
         {
             F_B.x += JxB_z * invRho;
             F_B.z += -JxB_x * invRho;
-            F_Etot += (BdotJ * B.y - BdotB * J.y) * invRho;
         }
         if constexpr (direction == Direction::Z)
         {
             F_B.x += -JxB_y * invRho;
             F_B.y += JxB_x * invRho;
-            F_Etot += (BdotJ * B.z - BdotB * J.z) * invRho;
         }
     }
 };

--- a/src/core/numerics/constrained_transport/upwind_constrained_transport.hpp
+++ b/src/core/numerics/constrained_transport/upwind_constrained_transport.hpp
@@ -95,6 +95,9 @@ private:
             Ex(idx) = -(ct_state.aL_y(idx) * FL + ct_state.aR_y(idx) * FR)
                       + (ct_state.dR_y(idx) * BzR - ct_state.dL_y(idx) * BzL);
 
+            // Store upwind-averaged Bz at Ex location (y-face in 2D) for Poynting correction
+            ct_state.Bt_z_at_Ex(idx) = ct_state.aL_y(idx) * BzL + ct_state.aR_y(idx) * BzR;
+
             if constexpr (Hall)
             {
                 auto invRho  = 1.0 / ct_state.rhot_y(idx);
@@ -151,6 +154,10 @@ private:
             Ex(idx) = (aB * vzB * ByB + aT * vzT * ByT) - (aS * vyS * BzS + aN * vyN * BzN)
                       - (dT * ByT - dB * ByB) + (dN * BzN - dS * BzS);
 
+            // Store edge-B at Ex location for Poynting energy correction (3D)
+            ct_state.Bt_y_at_Ex(idx) = aB * ByB + aT * ByT;
+            ct_state.Bt_z_at_Ex(idx) = aS * BzS + aN * BzN;
+
             if constexpr (Hall)
             {
                 auto [jyS, jyN] = Reconstruction_t::template reconstruct<Direction::Y>(
@@ -183,6 +190,10 @@ private:
 
             Ey(idx) = (ct_state.aL_x(idx) * FL + ct_state.aR_x(idx) * FR)
                       - (ct_state.dR_x(idx) * BzR - ct_state.dL_x(idx) * BzL);
+
+            // Store upwind-averaged Bz at Ey location (x-face in 2D; also used in 1D) for
+            // the Poynting correction
+            ct_state.Bt_z_at_Ey(idx) = ct_state.aL_x(idx) * BzL + ct_state.aR_x(idx) * BzR;
 
             if constexpr (Hall)
             {
@@ -239,6 +250,10 @@ private:
             Ey(idx) = (aW * vxW * BzW + aE * vxE * BzE) - (aB * vzB * BxB + aT * vzT * BxT)
                       - (dE * BzE - dW * BzW) + (dT * BxT - dB * BxB);
 
+            // Store edge-B at Ey location for Poynting energy correction (3D)
+            ct_state.Bt_x_at_Ey(idx) = aB * BxB + aT * BxT;
+            ct_state.Bt_z_at_Ey(idx) = aW * BzW + aE * BzE;
+
             if constexpr (Hall)
             {
                 auto [jxW, jxE] = Reconstruction_t::template reconstruct<Direction::X>(
@@ -269,6 +284,9 @@ private:
 
             Ez(idx) = -(ct_state.aL_x(idx) * FL + ct_state.aR_x(idx) * FR)
                       + (ct_state.dR_x(idx) * ByR - ct_state.dL_x(idx) * ByL);
+
+            // Store upwind-averaged By at Ez location (1D) for the Poynting correction
+            ct_state.Bt_y_at_Ez(idx) = ct_state.aL_x(idx) * ByL + ct_state.aR_x(idx) * ByR;
 
             if constexpr (Hall)
             {
@@ -325,6 +343,10 @@ private:
 
             Ez(idx) = -(aW * vxW * ByW + aE * vxE * ByE) + (aS * vyS * BxS + aN * vyN * BxN)
                       + (dE * ByE - dW * ByW) - (dN * BxN - dS * BxS);
+
+            // Store edge-B at Ez location for Poynting energy correction (2D+)
+            ct_state.Bt_x_at_Ez(idx) = aS * BxS + aN * BxN;
+            ct_state.Bt_y_at_Ez(idx) = aW * ByW + aE * ByE;
 
             if constexpr (Hall)
             {

--- a/src/core/numerics/constrained_transport/upwind_constrained_transport_utils.hpp
+++ b/src/core/numerics/constrained_transport/upwind_constrained_transport_utils.hpp
@@ -19,33 +19,41 @@ class UpwindConstrainedTransportState
 public:
     UpwindConstrainedTransportState() = default;
 
+    // Edge-B buffers (Bt_*_at_E*) carry upwind-averaged transverse B at E-field edge
+    // locations for the CT Poynting energy correction. Bt_z_at_Ey / Bt_y_at_Ez are needed
+    // in all dimensions; Bt_x_at_Ez / Bt_z_at_Ex in 2D+; Bt_x_at_Ey / Bt_y_at_Ex in 3D.
     NO_DISCARD auto getCompileTimeResourcesViewList()
     {
         if constexpr (dimension == 1)
         {
             if constexpr (Hall || Resistivity)
-                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x);
+                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, Bt_z_at_Ey,
+                                             Bt_y_at_Ez);
             else
-                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x);
+                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, Bt_z_at_Ey, Bt_y_at_Ez);
         }
         else if constexpr (dimension == 2)
         {
             if constexpr (Hall || Resistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
-                                             aR_y, dL_y, dR_y, jt_y, rhot_y);
+                                             aR_y, dL_y, dR_y, jt_y, rhot_y, Bt_z_at_Ey, Bt_y_at_Ez,
+                                             Bt_x_at_Ez, Bt_z_at_Ex);
             else
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, vt_y, aL_y, aR_y, dL_y,
-                                             dR_y);
+                                             dR_y, Bt_z_at_Ey, Bt_y_at_Ez, Bt_x_at_Ez, Bt_z_at_Ex);
         }
         else if constexpr (dimension == 3)
         {
             if constexpr (Hall || Resistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
                                              aR_y, dL_y, dR_y, jt_y, rhot_y, vt_z, aL_z, aR_z, dL_z,
-                                             dR_z, jt_z, rhot_z);
+                                             dR_z, jt_z, rhot_z, Bt_z_at_Ey, Bt_y_at_Ez, Bt_x_at_Ez,
+                                             Bt_z_at_Ex, Bt_x_at_Ey, Bt_y_at_Ex);
             else
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, vt_y, aL_y, aR_y, dL_y,
-                                             dR_y, vt_z, aL_z, aR_z, dL_z, dR_z);
+                                             dR_y, vt_z, aL_z, aR_z, dL_z, dR_z, Bt_z_at_Ey,
+                                             Bt_y_at_Ez, Bt_x_at_Ez, Bt_z_at_Ex, Bt_x_at_Ey,
+                                             Bt_y_at_Ex);
         }
         else
             throw std::runtime_error(
@@ -57,33 +65,46 @@ public:
         if constexpr (dimension == 1)
         {
             if constexpr (Hall || Resistivity)
-                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x);
+                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, Bt_z_at_Ey,
+                                             Bt_y_at_Ez);
             else
-                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x);
+                return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, Bt_z_at_Ey, Bt_y_at_Ez);
         }
         else if constexpr (dimension == 2)
         {
             if constexpr (Hall || Resistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
-                                             aR_y, dL_y, dR_y, jt_y, rhot_y);
+                                             aR_y, dL_y, dR_y, jt_y, rhot_y, Bt_z_at_Ey, Bt_y_at_Ez,
+                                             Bt_x_at_Ez, Bt_z_at_Ex);
             else
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, vt_y, aL_y, aR_y, dL_y,
-                                             dR_y);
+                                             dR_y, Bt_z_at_Ey, Bt_y_at_Ez, Bt_x_at_Ez, Bt_z_at_Ex);
         }
         else if constexpr (dimension == 3)
         {
             if constexpr (Hall || Resistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
                                              aR_y, dL_y, dR_y, jt_y, rhot_y, vt_z, aL_z, aR_z, dL_z,
-                                             dR_z, jt_z, rhot_z);
+                                             dR_z, jt_z, rhot_z, Bt_z_at_Ey, Bt_y_at_Ez, Bt_x_at_Ez,
+                                             Bt_z_at_Ex, Bt_x_at_Ey, Bt_y_at_Ex);
             else
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, vt_y, aL_y, aR_y, dL_y,
-                                             dR_y, vt_z, aL_z, aR_z, dL_z, dR_z);
+                                             dR_y, vt_z, aL_z, aR_z, dL_z, dR_z, Bt_z_at_Ey,
+                                             Bt_y_at_Ez, Bt_x_at_Ez, Bt_z_at_Ex, Bt_x_at_Ey,
+                                             Bt_y_at_Ex);
         }
         else
             throw std::runtime_error(
                 "Error - UpwindConstrainedTransportState - dimension not supported");
     }
+
+    // Getters for edge-centered B fields (CT Poynting energy correction).
+    auto const& getBx_at_Ez() const { return Bt_x_at_Ez; }
+    auto const& getBy_at_Ez() const { return Bt_y_at_Ez; }
+    auto const& getBz_at_Ey() const { return Bt_z_at_Ey; }
+    auto const& getBx_at_Ey() const { return Bt_x_at_Ey; }
+    auto const& getBz_at_Ex() const { return Bt_z_at_Ex; }
+    auto const& getBy_at_Ex() const { return Bt_y_at_Ex; }
 
     template<auto direction>
     auto& getJt()
@@ -185,6 +206,15 @@ public:
         aR_z{"aR_z", MHDQuantity::Scalar::ScalarFlux_z},
         dL_z{"dL_z", MHDQuantity::Scalar::ScalarFlux_z},
         dR_z{"dR_z", MHDQuantity::Scalar::ScalarFlux_z};
+
+    // Edge-centered B fields for the Poynting energy correction, stored at the E-field
+    // edge locations where they are computed during CT.
+    Field Bt_x_at_Ez{"Bx1ez", MHDQuantity::Scalar::Ez}; // Bx at z-edge
+    Field Bt_y_at_Ez{"Bx2ez", MHDQuantity::Scalar::Ez}; // By at z-edge
+    Field Bt_z_at_Ey{"Bx3ey", MHDQuantity::Scalar::Ey}; // Bz at y-edge (x-face in 2D)
+    Field Bt_z_at_Ex{"Bx3ex", MHDQuantity::Scalar::Ex}; // Bz at x-edge (y-face in 2D)
+    Field Bt_x_at_Ey{"Bx1ey", MHDQuantity::Scalar::Ey}; // Bx at y-edge (3D only)
+    Field Bt_y_at_Ex{"Bx2ex", MHDQuantity::Scalar::Ex}; // By at x-edge (3D only)
 };
 
 } // namespace PHARE::core

--- a/src/core/numerics/godunov_fluxes/godunov_fluxes.hpp
+++ b/src/core/numerics/godunov_fluxes/godunov_fluxes.hpp
@@ -3,6 +3,7 @@
 
 #include "core/numerics/ohm/ohm.hpp"
 #include "core/utilities/types.hpp"
+#include "core/utilities/constants.hpp"
 #include "core/utilities/index/index.hpp"
 #include "core/utilities/point/point.hpp"
 #include "core/data/grid/gridlayoutdefs.hpp"
@@ -96,8 +97,8 @@ public:
     {
     }
 
-    template<typename GState, typename State, typename Fluxes>
-    void operator()(GState& fvm_state, auto& ct_state, State& state, Fluxes& fluxes)
+    template<typename State, typename Fluxes>
+    void operator()(auto& ct_state, State& state, Fluxes& fluxes)
     {
         constexpr auto directions = getDirections<dimension>();
 
@@ -134,11 +135,6 @@ public:
 
                         ct_state.template save<direction>(riemann_.vt, riemann_.jt, riemann_.rhot,
                                                           riemann_.uct_coefs, {indices...});
-
-                        // for energy ExB term
-                        if constexpr (Resistivity || HyperResistivity)
-                            save_tranverse_magnetic_field_<direction>(fvm_state, uL, uR,
-                                                                      {indices...});
                     }
                     else // Ideal
                     {
@@ -156,160 +152,124 @@ public:
 
                         ct_state.template save<direction>(riemann_.vt, riemann_.uct_coefs,
                                                           {indices...});
-
-                        // for energy ExB term
-                        if constexpr (Resistivity)
-                            save_tranverse_magnetic_field_<direction>(fvm_state, uL, uR,
-                                                                      {indices...});
                     }
                 });
 
-            // adding resistive contributions to energy taking advantage of the already computed jt
-            // fluxes for the laplacian computation. This probably doesn't need the grow as the
-            // required quantities for ct are already saved.
-            if constexpr (Resistivity || HyperResistivity)
-            {
-                layout_.evalOnBox(
-                    fluxes.template expose_centering<direction>(), [&](auto&... indices) {
-                        auto& Jt     = ct_state.template getJt<direction>();
-                        auto& Bt     = getBt_<direction>(fvm_state);
-                        auto F       = fluxes.template get_dir<direction>({indices...});
-                        auto& F_B    = F.B;
-                        auto& F_Etot = F.Etot();
+            // Note: resistive contributions to F_B and F_Etot are now handled via CT:
+            // - B is updated by Faraday using E (which includes ηJ from CT)
+            // - Etot gets the resistive Poynting flux via E×B where E = E_ideal + ηJ
+            // The old resistive_contributions code was dead (F_B is never consumed by the
+            // finite-volume update) and would double-count η(J×B) in F_Etot once combined
+            // with the Poynting correction.
+        });
+    }
 
-                        auto const& Btidx = toPerIndexVector(Bt, {indices...});
+    template<typename CTState, typename State, typename Fluxes>
+    void apply_poynting_correction(CTState const& ct_state, State const& state, Fluxes& fluxes)
+    {
+        // Apply Poynting flux correction to energy: ∂E/∂t -= ∇·(E×B)
+        // Must be called AFTER CT has computed both E and the edge-B fields, so the
+        // edge-centered B from CT is temporally consistent with E. Because E from CT
+        // includes resistive (ηJ) and hyper-resistive terms, E×B automatically captures
+        // the resistive Poynting flux.
+        constexpr auto directions     = getDirections<dimension>();
+        constexpr auto num_directions = std::tuple_size_v<std::decay_t<decltype(directions)>>;
 
-                        if constexpr (Resistivity)
-                        {
-                            // transverse B field components (probably a riemann operation).
-                            auto const& Jtidx = toPerIndexVector(Jt, {indices...});
-                            equations_.template resistive_contributions<direction>(
-                                eta, Btidx, Jtidx, F_B, F_Etot);
-                        }
-                        if constexpr (HyperResistivity)
-                        {
-                            auto const vecLaplJ
-                                = transverse_laplacian_<direction>(Jt, {indices...});
+        for_N<num_directions>([&](auto i) {
+            constexpr Direction direction = std::get<i>(directions);
 
-                            if (hyper_mode == HyperMode::constant)
-                                return constant_hyperresistive_<direction>(Btidx, vecLaplJ, F_B,
-                                                                           F_Etot);
-                            else if (hyper_mode == HyperMode::spatial)
-                            {
-                                auto const& Bn = toPerIndexVector(state.B, {indices...});
-                                auto const& rhot
-                                    = ct_state.template getRhot<direction>()(indices...);
-
-                                return spatial_hyperresistive_<direction>(Btidx, Bn, vecLaplJ, rhot,
-                                                                          F_B, F_Etot);
-                            }
-                            else
-                                throw std::runtime_error("Error - Ohm - unknown hyper_mode");
-                        }
-                    });
-            }
+            layout_.evalOnBox(fluxes.template expose_centering<direction>(), [&](auto&... indices) {
+                auto& F_Etot = fluxes.template get_dir<direction>({indices...}).Etot();
+                poynting_energy_flux_<direction>(ct_state, state.E,
+                                                 MeshIndex<dimension>{indices...}, F_Etot);
+            });
         });
     }
 
 private:
     template<auto direction>
-    auto save_tranverse_magnetic_field_(auto& fvm_state, auto const& uL, auto const& uR,
-                                        MeshIndex<dimension> idx)
+    void poynting_energy_flux_(auto const& ct_state, auto const& E,
+                               MeshIndex<dimension> const& index, auto& F_Etot) const
     {
-        auto Bidx = riemann_.vector_riemann_averaging(uL.B, uR.B);
+        // Magnetic energy flux through the face: S.n = (E x B).n. Since S_i = eps_ijk E_j B_k,
+        // a face never needs its own E component, which leaves exactly two products per face.
+        // E and the CT edge-B buffers are point values living on edges; each product is formed
+        // on the edge it lives on, then projected onto the flux face across the single axis
+        // separating the two locations (primal -> dual in every case).
+        //
+        // directionalInterp returns the identity stencil for an axis the simulation does not
+        // have, which is what collapses the lower dimensional cases: in 2D Ey already sits on
+        // the x-face, and in 1D both products already sit on the x-face.
+        using InterpDir = typename GridLayout::implT::InterpDir;
 
-        auto& Bt = getBt_<direction>(fvm_state);
+        // Same as GridLayout::project, but for an expression rather than a stored field: the
+        // integrand is a product of two fields, and since both are point values the product
+        // must be formed on the edge before being projected onto the face. Projecting the
+        // factors separately and multiplying on the face would be a different (and, beyond
+        // order 2, wrong) discretisation.
+        auto project_on_face = [&](auto const& stencil, auto&& integrand) {
+            std::decay_t<decltype(integrand(index))> result = 0.;
 
-        Bt(Component::X)(idx) = Bidx.x;
-        Bt(Component::Y)(idx) = Bidx.y;
-        Bt(Component::Z)(idx) = Bidx.z;
-    }
+            for (auto const& wp : stencil)
+                result += wp.coef * integrand(index + wp.indexes);
 
-    template<auto direction>
-    auto& getBt_(auto& fvm_state) const
-    {
-        if constexpr (direction == Direction::X)
-            return fvm_state.bt_x;
-        else if constexpr (direction == Direction::Y)
-            return fvm_state.bt_y;
-        else if constexpr (direction == Direction::Z)
-            return fvm_state.bt_z;
-    }
-
-    template<auto direction>
-    void constant_hyperresistive_(auto const& Bt, auto const& vecLaplJ, auto& F_B,
-                                  auto& F_Etot) const
-    {
-        equations_.template resistive_contributions<direction>(-nu, Bt, vecLaplJ, F_B, F_Etot);
-    }
-
-    template<auto direction>
-    void spatial_hyperresistive_(auto const& Bt, auto const& B, auto const& vecLaplJ,
-                                 auto const& rhot, auto& F_B, auto& F_Etot) const
-    {
-        auto minMeshSize = [&]() {
-            auto const meshSize = layout_.meshSize();
-            if constexpr (dimension == 1)
-                return meshSize[0];
-            else if constexpr (dimension == 2)
-                return std::min({meshSize[0], meshSize[1]});
-            else
-                return std::min({meshSize[0], meshSize[1], meshSize[2]});
-        }();
-
-
-        auto computeHR = [&](auto Bx, auto By, auto Bz) {
-            auto b          = std::sqrt(Bx * Bx + By * By + Bz * Bz);
-            auto const coef = -nu * minMeshSize * minMeshSize * (b / rhot + 1);
-            equations_.template resistive_contributions<direction>(coef, Bt, vecLaplJ, F_B, F_Etot);
+            return result;
         };
 
+        auto const& Ex = E(Component::X);
+        auto const& Ey = E(Component::Y);
+        auto const& Ez = E(Component::Z);
+
         if constexpr (direction == Direction::X)
         {
-            auto const Bx = B.x; // normal component
-            auto const By = Bt.y;
-            auto const Bz = Bt.z;
+            constexpr auto zEdgeToXFace
+                = GridLayout::implT::template directionalInterp<dirY, InterpDir::PrimalToDual>();
+            constexpr auto yEdgeToXFace
+                = GridLayout::implT::template directionalInterp<dirZ, InterpDir::PrimalToDual>();
 
-            computeHR(Bx, By, Bz);
+            auto const& By_at_Ez = ct_state.getBy_at_Ez();
+            auto const& Bz_at_Ey = ct_state.getBz_at_Ey();
+
+            auto const EzBy
+                = project_on_face(zEdgeToXFace, [&](auto const& i) { return Ez(i) * By_at_Ez(i); });
+            auto const EyBz
+                = project_on_face(yEdgeToXFace, [&](auto const& i) { return Ey(i) * Bz_at_Ey(i); });
+
+            F_Etot += EyBz - EzBy;
         }
         else if constexpr (direction == Direction::Y)
         {
-            auto const Bx = Bt.x;
-            auto const By = B.y; // normal component
-            auto const Bz = Bt.z;
+            constexpr auto zEdgeToYFace
+                = GridLayout::implT::template directionalInterp<dirX, InterpDir::PrimalToDual>();
+            constexpr auto xEdgeToYFace
+                = GridLayout::implT::template directionalInterp<dirZ, InterpDir::PrimalToDual>();
 
-            computeHR(Bx, By, Bz);
+            auto const& Bx_at_Ez = ct_state.getBx_at_Ez();
+            auto const& Bz_at_Ex = ct_state.getBz_at_Ex();
+
+            auto const EzBx
+                = project_on_face(zEdgeToYFace, [&](auto const& i) { return Ez(i) * Bx_at_Ez(i); });
+            auto const ExBz
+                = project_on_face(xEdgeToYFace, [&](auto const& i) { return Ex(i) * Bz_at_Ex(i); });
+
+            F_Etot += EzBx - ExBz;
         }
         else if constexpr (direction == Direction::Z)
         {
-            auto const Bx = Bt.x;
-            auto const By = Bt.y;
-            auto const Bz = B.z; // normal component
+            constexpr auto xEdgeToZFace
+                = GridLayout::implT::template directionalInterp<dirY, InterpDir::PrimalToDual>();
+            constexpr auto yEdgeToZFace
+                = GridLayout::implT::template directionalInterp<dirX, InterpDir::PrimalToDual>();
 
-            computeHR(Bx, By, Bz);
-        }
-    }
+            auto const& By_at_Ex = ct_state.getBy_at_Ex();
+            auto const& Bx_at_Ey = ct_state.getBx_at_Ey();
 
-    template<auto direction>
-    auto transverse_laplacian_(auto const& Jt, MeshIndex<dimension> index) const
-    {
-        if constexpr (direction == Direction::X)
-        {
-            auto const JyLapl = layout_.laplacian(Jt(Component::Y), index);
-            auto const JzLapl = layout_.laplacian(Jt(Component::Z), index);
-            return PerIndexVector<double>{std::nan(""), JyLapl, JzLapl};
-        }
-        else if constexpr (direction == Direction::Y)
-        {
-            auto const JxLapl = layout_.laplacian(Jt(Component::X), index);
-            auto const JzLapl = layout_.laplacian(Jt(Component::Z), index);
-            return PerIndexVector<double>{JxLapl, std::nan(""), JzLapl};
-        }
-        else if constexpr (direction == Direction::Z)
-        {
-            auto const JxLapl = layout_.laplacian(Jt(Component::X), index);
-            auto const JyLapl = layout_.laplacian(Jt(Component::Y), index);
-            return PerIndexVector<double>{JxLapl, JyLapl, std::nan("")};
+            auto const ExBy
+                = project_on_face(xEdgeToZFace, [&](auto const& i) { return Ex(i) * By_at_Ex(i); });
+            auto const EyBx
+                = project_on_face(yEdgeToZFace, [&](auto const& i) { return Ey(i) * Bx_at_Ey(i); });
+
+            F_Etot += ExBy - EyBx;
         }
     }
 

--- a/src/core/numerics/godunov_fluxes/godunov_utils.hpp
+++ b/src/core/numerics/godunov_fluxes/godunov_utils.hpp
@@ -321,53 +321,6 @@ struct AllFluxesNames
 };
 
 
-template<typename VecField, typename Equations>
-class GodunovState
-{
-    using Field                            = VecField::field_type;
-    constexpr static auto dimension        = VecField::dimension;
-    constexpr static auto Resistivity      = Equations::resistivity;
-    constexpr static auto HyperResistivity = Equations::hyperResistivity;
-
-public:
-    GodunovState() = default;
-
-    NO_DISCARD auto getCompileTimeResourcesViewList()
-    {
-        if constexpr (Resistivity || HyperResistivity)
-        {
-            if constexpr (dimension == 1)
-                return std::forward_as_tuple(bt_x);
-            else if constexpr (dimension == 2)
-                return std::forward_as_tuple(bt_x, bt_y);
-            else if constexpr (dimension == 3)
-                return std::forward_as_tuple(bt_x, bt_y, bt_z);
-        }
-        else
-            return std::forward_as_tuple();
-    }
-
-    NO_DISCARD auto getCompileTimeResourcesViewList() const
-    {
-        if constexpr (Resistivity || HyperResistivity)
-        {
-            if constexpr (dimension == 1)
-                return std::forward_as_tuple(bt_x);
-            else if constexpr (dimension == 2)
-                return std::forward_as_tuple(bt_x, bt_y);
-            else if constexpr (dimension == 3)
-                return std::forward_as_tuple(bt_x, bt_y, bt_z);
-        }
-        else
-            return std::forward_as_tuple();
-    }
-
-    VecField bt_x{"b_t_x", MHDQuantity::Vector::VecFlux_x};
-    VecField bt_y{"b_t_y", MHDQuantity::Vector::VecFlux_y};
-    VecField bt_z{"b_t_z", MHDQuantity::Vector::VecFlux_z};
-};
-
-
 template<template<typename> typename Op, typename Field, typename VecField>
 void operate(AllFluxes<Field, VecField>& dst, AllFluxes<Field, VecField> const& src, auto&&... args)
 {


### PR DESCRIPTION


<!--
Title should be a clear, one-line "take-home message": why this PR exists,
not just what it touches (e.g. "Fix particle split crash at level boundary",
not "Update SplitOp.hpp").
-->

## Issue

Relates to #1269 

## What this implements

Magnetic energy transport is removed from the per-cell flux (F_Etot becomes HD-only: kinetic + thermal) and carried entirely by a post-CT Poynting correction d(Etot)/dt -= div(E x B), using edge-centered B stored during the EMF computation.

## Design

<!-- Only needed if this PR touches several files or is "long".
Explain the design choices. Diagrams (e.g. Mermaid sequence/class diagrams)
are welcome for new classes/concepts. -->

## Tests

<!-- What unit or functional tests cover this change?
If none were added, explain why. -->
