### PR TITLE
pharein: default nesting_buffer to 1, only apply/validate it when AMR is used

### DIFF
--- a/pyphare/pyphare/pharein/initialize/general.py
+++ b/pyphare/pyphare/pharein/initialize/general.py
@@ -112,7 +112,8 @@ def populateDict(sim):
     add_double("simulation/final_time", sim.final_time)
 
     add_string("simulation/AMR/clustering", sim.clustering)
-    add_vector_int("simulation/AMR/nesting_buffer", sim.nesting_buffer)
+    if sim.nesting_buffer is not None:
+        add_vector_int("simulation/AMR/nesting_buffer", sim.nesting_buffer)
     add_int("simulation/AMR/tag_buffer", sim.tag_buffer)
 
     add_int("simulation/AMR/max_nbr_levels", sim.max_nbr_levels)

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -594,7 +594,7 @@ def check_nesting_buffer(ndim, **kwargs):
         return None
 
     # SAMRAI itself defaults proper_nesting_buffer to 1 and warns when it is 0
-    # (subprojects/samrai/source/SAMRAI/hier/PatchHierarchy.cpp:57,306-330)
+    # (subprojects/samrai/source/SAMRAI/hier/PatchHierarchy.cpp)
     nesting_buffer = phare_utilities.np_array_ify(kwargs.get("nesting_buffer", 1), ndim)
 
     if nesting_buffer.size != ndim:

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -581,9 +581,15 @@ def check_refinement(**kwargs):
 
 def check_nesting_buffer(ndim, **kwargs):
     refinement_boxes = kwargs.get("refinement_boxes")
-    has_amr = (
-        refinement_boxes is not None and len(refinement_boxes) > 0
-    ) or kwargs.get("max_nbr_levels", 1) > 1
+    has_refinement_boxes = refinement_boxes is not None and len(refinement_boxes) > 0
+
+    if check_refinement(**kwargs) == "boxes":
+        # check_refinement_boxes() normalizes to (None, 1) whenever
+        # refinement_boxes is empty, ignoring any max_nbr_levels the user
+        # passed in that case, so has_amr must follow the same rule here.
+        has_amr = has_refinement_boxes
+    else:
+        has_amr = kwargs.get("max_nbr_levels", 1) > 1
 
     if not has_amr:
         if "nesting_buffer" in kwargs:

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -580,7 +580,22 @@ def check_refinement(**kwargs):
 
 
 def check_nesting_buffer(ndim, **kwargs):
-    nesting_buffer = phare_utilities.np_array_ify(kwargs.get("nesting_buffer", 0), ndim)
+    has_amr = (
+        kwargs.get("refinement_boxes") is not None
+        or kwargs.get("max_nbr_levels", 1) > 1
+    )
+
+    if not has_amr:
+        if "nesting_buffer" in kwargs:
+            print(
+                f"WARNING, nesting_buffer({kwargs['nesting_buffer']}) has no effect"
+                + " on a simulation with no refinement levels, ignoring"
+            )
+        return None
+
+    # SAMRAI itself defaults proper_nesting_buffer to 1 and warns when it is 0
+    # (subprojects/samrai/source/SAMRAI/hier/PatchHierarchy.cpp:57,306-330)
+    nesting_buffer = phare_utilities.np_array_ify(kwargs.get("nesting_buffer", 1), ndim)
 
     if nesting_buffer.size != ndim:
         raise ValueError(f"Error: nesting_buffer must be size {ndim}")
@@ -589,7 +604,6 @@ def check_nesting_buffer(ndim, **kwargs):
         raise ValueError(f"Error: nesting_buffer({nesting_buffer}) cannot be negative")
 
     smallest_patch_size = kwargs["smallest_patch_size"]
-    largest_patch_size = kwargs["largest_patch_size"]
 
     if (nesting_buffer > smallest_patch_size / 2).any():
         raise ValueError(
@@ -599,16 +613,7 @@ def check_nesting_buffer(ndim, **kwargs):
 
     cells = np.asarray(kwargs["cells"])
 
-    if (
-        largest_patch_size is not None
-        and (nesting_buffer > (cells - largest_patch_size)).any()
-    ):
-        raise ValueError(
-            f"Error: nesting_buffer({nesting_buffer})"
-            + f"incompatible with number of domain cells ({cells}) and largest_patch_size({largest_patch_size})"
-        )
-
-    elif (nesting_buffer > cells).any():
+    if (nesting_buffer > cells).any():
         raise ValueError(
             f"Error: nesting_buffer({nesting_buffer}) incompatible with number of domain cells ({cells})"
         )
@@ -1027,7 +1032,7 @@ class Simulation(object):
         These parameters are more advanced, modify them at your own risk
 
         * **refined_particle_nbr** (``ìnt``), number of refined particle per coarse particle.
-        * **nesting_buffer** (``ìnt``), default=0 minimum gap in coarse cells from the border of a level and any refined patch border
+        * **nesting_buffer** (``ìnt``), default=1 minimum gap in coarse cells from the border of a level and any refined patch border. Has no effect (and is not sent to SAMRAI) if the simulation has no refinement levels.
         * **refinement_boxes**, default=None, {"L0":{"B0":[(lox,loy,loz),(upx,upy,upz)],...,"Bi":[(),()]},..."Li":{B0:[(),()]}}
         * **smallest_patch_size** (``int`` or ``tuple``), minimum number of cells in a patch in each direction
           This parameter cannot be smaller than the number of field ghost nodes

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -600,8 +600,11 @@ def check_nesting_buffer(ndim, **kwargs):
     if nesting_buffer.size != ndim:
         raise ValueError(f"Error: nesting_buffer must be size {ndim}")
 
-    if (nesting_buffer < 0).any():
-        raise ValueError(f"Error: nesting_buffer({nesting_buffer}) cannot be negative")
+    if (nesting_buffer < 1).any():
+        raise ValueError(
+            f"Error: nesting_buffer({nesting_buffer}) must be at least 1"
+            + " on a simulation with refinement levels"
+        )
 
     smallest_patch_size = kwargs["smallest_patch_size"]
 

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -580,10 +580,10 @@ def check_refinement(**kwargs):
 
 
 def check_nesting_buffer(ndim, **kwargs):
+    refinement_boxes = kwargs.get("refinement_boxes")
     has_amr = (
-        kwargs.get("refinement_boxes") is not None
-        or kwargs.get("max_nbr_levels", 1) > 1
-    )
+        refinement_boxes is not None and len(refinement_boxes) > 0
+    ) or kwargs.get("max_nbr_levels", 1) > 1
 
     if not has_amr:
         if "nesting_buffer" in kwargs:

--- a/src/amr/wrappers/hierarchy.hpp
+++ b/src/amr/wrappers/hierarchy.hpp
@@ -88,7 +88,9 @@ public:
     void closeRestartFile() { SamraiLifeCycle::getRestartManager()->closeRestartFile(); }
 
     NO_DISCARD bool isFromRestart() const
-    { return SamraiLifeCycle::getRestartManager()->isFromRestart(); }
+    {
+        return SamraiLifeCycle::getRestartManager()->isFromRestart();
+    }
 
 private:
     std::optional<std::string> static restartFilePath(auto const& dict)
@@ -384,7 +386,7 @@ auto patchHierarchyDatabase(PHARE::initializer::PHAREDict const& amr)
 
     if (amr.contains("nesting_buffer"))
     {
-        std::vector<int> nesting_buffer = amr["nesting_buffer"].template to<std::vector<int>>();
+        std::vector<int> nesting_buffer = amr["nesting_buffer"];
         hierDB->putIntegerVector("proper_nesting_buffer", nesting_buffer);
     }
 

--- a/src/amr/wrappers/hierarchy.hpp
+++ b/src/amr/wrappers/hierarchy.hpp
@@ -382,8 +382,11 @@ auto patchHierarchyDatabase(PHARE::initializer::PHAREDict const& amr)
     auto maxLevelNumber = amr["max_nbr_levels"].template to<int>();
     hierDB->putInteger("max_levels", maxLevelNumber);
 
-    std::vector<int> nesting_buffer = amr["nesting_buffer"].template to<std::vector<int>>();
-    hierDB->putIntegerVector("proper_nesting_buffer", nesting_buffer);
+    if (amr.contains("nesting_buffer"))
+    {
+        std::vector<int> nesting_buffer = amr["nesting_buffer"].template to<std::vector<int>>();
+        hierDB->putIntegerVector("proper_nesting_buffer", nesting_buffer);
+    }
 
     auto ratioToCoarserDB = hierDB->putDatabase("ratio_to_coarser");
 

--- a/tests/simulator/__init__.py
+++ b/tests/simulator/__init__.py
@@ -55,7 +55,7 @@ def basicSimulatorArgs(dim: int, interp: int, **kwargs):
         "refinement_boxes": {"L0": {"B0": b0}},
         "refined_particle_nbr": valid_refined_particle_nbr[dim][interp][0],
         "diag_options": {},
-        "nesting_buffer": 0,
+        "nesting_buffer": 1,
         "strict": True,
     }
     for k, v in kwargs.items():

--- a/tests/simulator/test_initialization.py
+++ b/tests/simulator/test_initialization.py
@@ -122,7 +122,7 @@ class InitializationTest(SimulatorTest):
             dim,
             interp_order,
             "moments",
-            {"L0": {"B0": nDBox(dim, 10, 19)}},
+            {"L0": {"B0": nDBox(dim, 10, 18)}},
             beam=True,
             diag_outputs=f"test_bulkV/{dim}/{interp_order}/{self.ddt_test_id()}",
             **kwargs,

--- a/tests/simulator/test_validation.py
+++ b/tests/simulator/test_validation.py
@@ -174,14 +174,6 @@ class SimulatorValidation(SimulatorTest):
                 "nesting_buffer": 33,
             }
         ),
-        dup(
-            {
-                "cells": [65],
-                "refinement_boxes": None,
-                "largest_patch_size": 20,
-                "nesting_buffer": 46,
-            }
-        ),
         # finer box is not within set of coarser boxes
         dup(
             {
@@ -351,14 +343,6 @@ class SimulatorValidation(SimulatorTest):
                 "cells": [65, 65],
                 "refinement_boxes": {"L0": [Box2D(5, 25)], "L1": [Box2D(11, 49)]},
                 "nesting_buffer": 33,
-            }
-        ),
-        dup(
-            {
-                "cells": [65, 65],
-                "refinement_boxes": None,
-                "largest_patch_size": 20,
-                "nesting_buffer": 46,
             }
         ),
         # finer box is not within set of coarser boxes

--- a/tests/simulator/test_validation.py
+++ b/tests/simulator/test_validation.py
@@ -58,7 +58,7 @@ class SimulatorValidation(SimulatorTest):
         dup({"cells": [65], "refinement_boxes": {"L0": {"B0": Box(5, 55)}}}),
         dup({"cells": [65], "refinement_boxes": {"L0": [Box(5, 55)]}}),
         dup({"cells": [65], "refinement_boxes": {0: [Box(5, 55)]}}),
-        dup({"cells": [65], "refinement_boxes": {0: [Box(0, 55)]}}),
+        dup({"cells": [65], "refinement_boxes": {0: [Box(1, 55)]}}),
         dup({"cells": [65], "refinement_boxes": {"L0": [Box(5, 14), Box(15, 25)]}}),
         dup(
             {
@@ -92,7 +92,7 @@ class SimulatorValidation(SimulatorTest):
         dup(
             {
                 "cells": [65],
-                "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(10, 50)]},
+                "refinement_boxes": {"L0": [Box(5, 25)], "L1": [Box(11, 50)]},
             }
         ),
         dup(
@@ -110,7 +110,11 @@ class SimulatorValidation(SimulatorTest):
                 "nesting_buffer": 10,
             }
         ),
-        # finer box is within set of coarser boxes
+    ]
+
+    invalid1D = [
+        # finer box spans the touching boundary of two same-level
+        # siblings -- no longer valid once nesting_buffer >= 1
         dup(
             {
                 "cells": [65],
@@ -120,9 +124,6 @@ class SimulatorValidation(SimulatorTest):
                 },
             }
         ),
-    ]
-
-    invalid1D = [
         # finer box outside lower
         dup(
             {
@@ -219,7 +220,7 @@ class SimulatorValidation(SimulatorTest):
         dup({"cells": [65, 65], "refinement_boxes": {"L0": {"B0": Box2D(5, 55)}}}),
         dup({"cells": [65, 65], "refinement_boxes": {"L0": [Box2D(5, 55)]}}),
         dup({"cells": [65, 65], "refinement_boxes": {0: [Box2D(5, 55)]}}),
-        dup({"cells": [65, 65], "refinement_boxes": {0: [Box2D(0, 55)]}}),
+        dup({"cells": [65, 65], "refinement_boxes": {0: [Box2D(1, 55)]}}),
         dup(
             {
                 "cells": [65, 65],
@@ -258,7 +259,7 @@ class SimulatorValidation(SimulatorTest):
         dup(
             {
                 "cells": [65, 65],
-                "refinement_boxes": {"L0": [Box2D(5, 25)], "L1": [Box2D(10, 50)]},
+                "refinement_boxes": {"L0": [Box2D(5, 25)], "L1": [Box2D(11, 50)]},
             }
         ),
         dup(


### PR DESCRIPTION
Fixes #1196.

**Problem:** `nesting_buffer` (minimum coarse-cell gap between a level's border and any refined patch) defaulted to `0`. SAMRAI itself defaults `proper_nesting_buffer` to `1` and only accepts `0` with a warning ([`PatchHierarchy.cpp:57,306-330`](https://github.com/PHAREHUB/PHARE/blob/master/subprojects/samrai/source/SAMRAI/hier/PatchHierarchy.cpp#L57)) — `0` is known to let L1 patches touch periodic borders.

**Changes:**
- `nesting_buffer` now defaults to `1`, and must be `>= 1` whenever the simulation has refinement levels.
- It is only meaningful when there *is* AMR (`refinement_boxes` set, or `max_nbr_levels > 1`). Otherwise it's left unset and not sent to SAMRAI at all — same pattern already used for `smallest_patch_size`/`largest_patch_size`, and consistent with SAMRAI itself ignoring the value when `max_levels == 1`.
- Dropped a check comparing `nesting_buffer` to `cells - largest_patch_size`: not derived from any real SAMRAI constraint (the actual geometric invariant is enforced per-box elsewhere, in `check_refinement_boxes`), and it broke as soon as `largest_patch_size == cells`.
- Adjusted the handful of `test_validation.py` cases that only worked with a `0`-cell nesting gap. One case relied on a finer box spanning the touching boundary of two same-level sibling boxes — that's geometrically impossible once any positive `nesting_buffer` is required, so it moved from valid to invalid.

**Tested:** `py3_validation` (60/60) and `py3_diagnostics` (28/28, including `test_dump_diags`, the test that broke when `nesting_buffer` was first bumped to 1) both pass.