### PR TITLE
do not duplicate level ghost interpolation during pressure computation

### DIFF
--- a/src/diagnostic/detail/types/fluid.hpp
+++ b/src/diagnostic/detail/types/fluid.hpp
@@ -91,7 +91,7 @@ void FluidDiagnosticWriter<H5Writer>::compute(DiagnosticProperties& diagnostic)
     // at this time, levelGhostPartsNew is emptied and not yet filled
     // and the former levelGhostPartsNew has been moved to levelGhostPartsOld
 
-    auto const fill_schedules = [&](auto& lvl) {
+    auto const fill_all_schedules = [&](auto& lvl) {
         for (std::size_t i = 0; i < ions.size(); ++i)
             modelView.fillPopMomTensor(lvl, h5Writer.timestamp(), i);
     };
@@ -115,7 +115,7 @@ void FluidDiagnosticWriter<H5Writer>::compute(DiagnosticProperties& diagnostic)
             },
             minLvl, maxLvl);
 
-        modelView.onLevels(fill_schedules, minLvl, maxLvl);
+        modelView.onLevels(fill_all_schedules, minLvl, maxLvl);
 
         modelView.visitHierarchy(
             [&](auto& layout, auto&&...) {
@@ -126,8 +126,9 @@ void FluidDiagnosticWriter<H5Writer>::compute(DiagnosticProperties& diagnostic)
     }
     else // if not computing total momentum tensor, user may want to compute it for some pop
     {
-        for (auto& pop : ions)
+        for (std::size_t i = 0; i < ions.size(); i++)
         {
+            auto& pop = ions[i];
             std::string const tree{"/ions/pop/" + pop.name() + "/"};
 
             if (!isActiveDiag(diagnostic, tree, "momentum_tensor"))
@@ -136,7 +137,9 @@ void FluidDiagnosticWriter<H5Writer>::compute(DiagnosticProperties& diagnostic)
             modelView.visitHierarchy(
                 [&](auto& layout, auto&&...) { interpolate_domain(pop, layout); }, minLvl, maxLvl);
 
-            modelView.onLevels(fill_schedules, minLvl, maxLvl);
+            modelView.onLevels(
+                [&, i = i](auto& lvl) { modelView.fillPopMomTensor(lvl, h5Writer.timestamp(), i); },
+                minLvl, maxLvl);
 
             modelView.visitHierarchy(
                 [&](auto& layout, auto&&...) { interpolate_ghost(pop, layout); }, minLvl, maxLvl);

--- a/src/diagnostic/detail/types/fluid.hpp
+++ b/src/diagnostic/detail/types/fluid.hpp
@@ -6,6 +6,7 @@
 
 #include "diagnostic/detail/h5typewriter.hpp"
 
+#include <algorithm>
 #include <stdexcept>
 
 namespace PHARE::diagnostic::h5
@@ -95,25 +96,33 @@ void FluidDiagnosticWriter<H5Writer>::compute(DiagnosticProperties& diagnostic)
             modelView.fillPopMomTensor(lvl, h5Writer.timestamp(), i);
     };
 
-    auto const interpolate_pop = [&](auto& pop, auto& layout, auto&&...) {
+    auto const interpolate_domain = [&](auto& pop, auto& layout, auto&&...) {
         auto& pop_momentum_tensor = pop.momentumTensor();
         pop_momentum_tensor.zero();
         interpolator(pop.domainParticles(), pop_momentum_tensor, layout, pop.mass());
+    };
+
+    auto const interpolate_ghost = [&](auto& pop, auto& layout, auto&&...) {
+        auto& pop_momentum_tensor = pop.momentumTensor();
         interpolator(pop.levelGhostParticlesOld(), pop_momentum_tensor, layout, pop.mass());
     };
 
     if (isActiveDiag(diagnostic, "/ions/", "momentum_tensor"))
     {
-        auto const interpolate = [&](auto& layout, auto&&...) {
-            for (auto& pop : ions)
-                interpolate_pop(pop, layout);
-        };
-        modelView.visitHierarchy(interpolate, minLvl, maxLvl);
+        modelView.visitHierarchy(
+            [&](auto& layout, auto&&...) {
+                std::ranges::for_each(ions, [&](auto& pop) { interpolate_domain(pop, layout); });
+            },
+            minLvl, maxLvl);
 
         modelView.onLevels(fill_schedules, minLvl, maxLvl);
 
-        modelView.visitHierarchy( //
-            [&](auto&&...) { ions.computeFullMomentumTensor(); }, minLvl, maxLvl);
+        modelView.visitHierarchy(
+            [&](auto& layout, auto&&...) {
+                std::ranges::for_each(ions, [&](auto& pop) { interpolate_ghost(pop, layout); });
+                ions.computeFullMomentumTensor();
+            },
+            minLvl, maxLvl);
     }
     else // if not computing total momentum tensor, user may want to compute it for some pop
     {
@@ -124,11 +133,13 @@ void FluidDiagnosticWriter<H5Writer>::compute(DiagnosticProperties& diagnostic)
             if (!isActiveDiag(diagnostic, tree, "momentum_tensor"))
                 continue;
 
-            auto const interpolate = [&](auto& layout, auto&&...) { interpolate_pop(pop, layout); };
-
-            modelView.visitHierarchy(interpolate, minLvl, maxLvl);
+            modelView.visitHierarchy(
+                [&](auto& layout, auto&&...) { interpolate_domain(pop, layout); }, minLvl, maxLvl);
 
             modelView.onLevels(fill_schedules, minLvl, maxLvl);
+
+            modelView.visitHierarchy(
+                [&](auto& layout, auto&&...) { interpolate_ghost(pop, layout); }, minLvl, maxLvl);
         }
     }
 }


### PR DESCRIPTION
since PGL level ghost are potentially included twice during pressure tensor interp/computation

another solution could be [just not having duplicate levelghosts ](https://github.com/PHAREHUB/PHARE/pull/1199)