### PR TITLE
load balancing cleanup

### DIFF
--- a/pyphare/pyphare/pharein/initialize/general.py
+++ b/pyphare/pyphare/pharein/initialize/general.py
@@ -3,9 +3,8 @@ import os
 import numpy as np
 import pybindlibs.dictator as pp
 from pyphare.core.phare_utilities import is_scalar
-from pyphare.pharein.load_balancer import LoadBalancer
-from pyphare.pharein.simulation import deserialize as deserialize_sim
 from pyphare.pharein.simulation import serialize as serialize_sim
+from pyphare.pharein.simulation import deserialize as deserialize_sim
 
 
 def _patch_data_ids(restart_file_dir):
@@ -159,24 +158,23 @@ def populateDict(sim):
         )  # integrator.h might want some looking at
 
     # load balancer block start
-    lb = sim.load_balancer or LoadBalancer(active=False, _register=False)
     base = "simulation/AMR/loadbalancing"
-    add_bool(f"{base}/active", lb.active)
-    add_string(f"{base}/mode", lb.mode)
-    add_double(f"{base}/tolerance", lb.tol)
+    lb = sim.load_balancer
+    add_bool(f"{base}/active", True if lb else False)
+    if lb:
+        add_string(f"{base}/mode", lb.mode)
+        add_double(f"{base}/tolerance", lb.tol)
+        add_bool(f"{base}/auto", lb.auto)
+        add_size_t(f"{base}/next_rebalance", lb.next_rebalance)
+        add_size_t(f"{base}/max_next_rebalance", lb.max_next_rebalance)
+        add_size_t(
+            f"{base}/next_rebalance_backoff_multiplier",
+            lb.next_rebalance_backoff_multiplier,
+        )
 
-    # if mode==nppc, imbalance allowed
-    add_bool(f"{base}/auto", lb.auto)
-    add_size_t(f"{base}/next_rebalance", lb.next_rebalance)
-    add_size_t(f"{base}/max_next_rebalance", lb.max_next_rebalance)
-    add_size_t(
-        f"{base}/next_rebalance_backoff_multiplier",
-        lb.next_rebalance_backoff_multiplier,
-    )
-
-    # cadence based values
-    add_size_t(f"{base}/every", lb.every)
-    add_bool(f"{base}/on_init", lb.on_init)
+        # cadence based values
+        add_size_t(f"{base}/every", lb.every)
+        add_bool(f"{base}/on_init", lb.on_init)
     # load balancer block end
 
     serialized_sim = serialize_sim(sim)

--- a/pyphare/pyphare/pharein/load_balancer.py
+++ b/pyphare/pyphare/pharein/load_balancer.py
@@ -2,22 +2,28 @@
 #
 
 from dataclasses import dataclass, field
-from . import global_vars as gv
 
 
 @dataclass
 class LoadBalancer:
-    # whether or not load balancing is performed
-    active: bool = field(default_factory=lambda: True)
+    # Levels other than L0 are never explicitly rebalanced by this class - they get
+    # rebalanced as a side effect of regridding, whenever that naturally happens.
+    # Only L0 is rebalanced "on demand" by the logic these options configure.
 
-    # which way load is assessed
+    # which way load is assessed - applies to every level, not just L0
     mode: str = field(default_factory=lambda: "nppc")
 
-    # acceptable imbalance essentially
+    # acceptable imbalance essentially - used both for L0's explicit rebalance
+    # decision and as the threshold applied to every other level when it is
+    # regridded. currently a single value shared by all levels; there is no
+    # per-level override
     tol: float = field(default_factory=lambda: 0.05)
 
-    # whether to rebalance/check imbalance on init
+    # L0 only: whether to force a rebalance check of L0 at the very first step
     on_init: bool = field(default_factory=lambda: True)
+
+    # L0 only: everything below this line governs *when* L0's explicit rebalance
+    # check runs - none of it affects other levels
 
     # if auto, other values are not used if active
     auto: bool = field(default_factory=lambda: False)
@@ -48,6 +54,8 @@ class LoadBalancer:
             raise RuntimeError(f"LoadBalancer mode '{self.mode}' is not valid")
 
         if self._register:
+            from . import global_vars as gv
+
             if not gv.sim:
                 raise RuntimeError(
                     "LoadBalancer cannot be registered as no simulation exists"

--- a/src/amr/load_balancing/load_balancer_details.hpp
+++ b/src/amr/load_balancing/load_balancer_details.hpp
@@ -2,9 +2,8 @@
 #define PHARE_AMR_LOAD_BALANCER_LOAD_BALANCER_DETAILS_HPP
 
 #include <string>
-#include <cstdint>
+#include <cstddef>
 
-#include "core/logger.hpp"
 #include "initializer/data_provider.hpp"
 
 namespace PHARE::amr

--- a/src/simulator/simulator.hpp
+++ b/src/simulator/simulator.hpp
@@ -218,6 +218,7 @@ private:
     void diagnostics_init(initializer::PHAREDict const&, auto&);
     void hybrid_init(initializer::PHAREDict const&);
     void mhd_init(initializer::PHAREDict const&);
+    void finalize_init(PHARE::initializer::PHAREDict const& dict);
 
     void handle_dictionary_exception(core::DictionaryException const& ex);
 };
@@ -277,6 +278,49 @@ void Simulator<opts>::diagnostics_init(initializer::PHAREDict const& dict, auto&
     this->allowEmergencyDumps = cppdict::get_value(dict, "allow_emergency_dumps", false);
 }
 
+template<auto opts>
+void Simulator<opts>::finalize_init(initializer::PHAREDict const& dict)
+{
+    auto const lb_info = amr::LoadBalancerDetails::FROM(dict["simulation"]["AMR"]["loadbalancing"]);
+    auto lbm_          = std::make_unique<amr::LoadBalancerManager<opts.dimension>>(dict);
+    auto loadBalancer_db = std::make_shared<SAMRAI::tbox::MemoryDatabase>("LoadBalancerDB");
+    loadBalancer_db->putDouble("flexible_load_tolerance", lb_info.tolerance);
+    auto loadBalancer = std::make_shared<SAMRAI::mesh::CascadePartitioner>(
+        SAMRAI::tbox::Dimension{dimension}, "LoadBalancer", loadBalancer_db);
+
+    if (lb_info.active and dict["simulation"]["AMR"]["refinement"].contains("tagging"))
+    {
+        // Load balancers break with refinement boxes - only tagging supported
+        /*
+          P=0000000:Program abort called in file ``/.../SAMRAI/xfer/RefineSchedule.cpp'' at line
+          369 P=0000000:ERROR MESSAGE: P=0000000:RefineSchedule:RefineSchedule error: We are not
+          currently P=0000000:supporting RefineSchedules with the source level finer
+          P=0000000:than the destination level
+        */
+
+        if (find_model("HybridModel"))
+        {
+            auto lbe_ = std::make_shared<amr::LoadBalancerEstimatorHybrid<PHARETypes>>(
+                lb_info.mode, lbm_->getId());
+            lbm_->addLoadBalancerEstimator(maxMHDLevel_, maxLevelNumber_ - 1, std::move(lbe_));
+        }
+        if (find_model("MHDModel"))
+        {
+            auto lbe_ = std::make_shared<amr::LoadBalancerEstimatorMHD<PHARETypes>>(lbm_->getId());
+            lbm_->addLoadBalancerEstimator(0, maxMHDLevel_ - 1, std::move(lbe_));
+        }
+        lbm_->setLoadBalancer(loadBalancer);
+    }
+    auto const lbm_id = lbm_->getId(); // moved on next line
+    multiphysInteg_->setLoadBalancerManager(std::move(lbm_));
+
+    startTime_ = restart_time(dict);
+    integrator_
+        = std::make_unique<Integrator>(dict, hierarchy_, multiphysInteg_, multiphysInteg_,
+                                       loadBalancer, startTime_, finalTime_, lb_info, lbm_id);
+    timeStamper = core::TimeStamperFactory::create(dict["simulation"]);
+}
+
 
 template<auto opts>
 void Simulator<opts>::hybrid_init(initializer::PHAREDict const& dict)
@@ -305,42 +349,6 @@ void Simulator<opts>::hybrid_init(initializer::PHAREDict const& dict)
                                             std::move(hybridTagger_));
         }
     }
-
-    amr::LoadBalancerDetails lb_info
-        = amr::LoadBalancerDetails::FROM(dict["simulation"]["AMR"]["loadbalancing"]);
-
-    auto lbm_ = std::make_unique<amr::LoadBalancerManager<opts.dimension>>(dict);
-    auto lbe_ = std::make_shared<amr::LoadBalancerEstimatorHybrid<PHARETypes>>(lb_info.mode,
-                                                                               lbm_->getId());
-
-    auto loadBalancer_db = std::make_shared<SAMRAI::tbox::MemoryDatabase>("LoadBalancerDB");
-    loadBalancer_db->putDouble("flexible_load_tolerance", lb_info.tolerance);
-    auto loadBalancer = std::make_shared<SAMRAI::mesh::CascadePartitioner>(
-        SAMRAI::tbox::Dimension{dimension}, "LoadBalancer", loadBalancer_db);
-
-    if (dict["simulation"]["AMR"]["refinement"].contains("tagging"))
-    { // Load balancers break with refinement boxes - only tagging supported
-        /*
-          P=0000000:Program abort called in file ``/.../SAMRAI/xfer/RefineSchedule.cpp'' at line 369
-          P=0000000:ERROR MESSAGE:
-          P=0000000:RefineSchedule:RefineSchedule error: We are not currently
-          P=0000000:supporting RefineSchedules with the source level finer
-          P=0000000:than the destination level
-        */
-        lbm_->addLoadBalancerEstimator(maxMHDLevel_, maxLevelNumber_ - 1, std::move(lbe_));
-        lbm_->setLoadBalancer(loadBalancer);
-    }
-
-    auto lbm_id = lbm_->getId(); // moved on next line
-    multiphysInteg_->setLoadBalancerManager(std::move(lbm_));
-
-    startTime_ = restart_time(dict);
-
-    integrator_
-        = std::make_unique<Integrator>(dict, hierarchy_, multiphysInteg_, multiphysInteg_,
-                                       loadBalancer, startTime_, finalTime_, lb_info, lbm_id);
-
-    timeStamper = core::TimeStamperFactory::create(dict["simulation"]);
 
     if (dict["simulation"].contains("diagnostics"))
         diagnostics_init(dict["simulation"]["diagnostics"], *hybridModel_);
@@ -372,41 +380,6 @@ void Simulator<opts>::mhd_init(initializer::PHAREDict const& dict)
             multiphysInteg_->registerTagger(0, maxMHDLevel_ - 1, std::move(mhdTagger_));
         }
     }
-
-    amr::LoadBalancerDetails lb_info
-        = amr::LoadBalancerDetails::FROM(dict["simulation"]["AMR"]["loadbalancing"]);
-
-    auto lbm_ = std::make_unique<amr::LoadBalancerManager<opts.dimension>>(dict);
-    auto lbe_ = std::make_shared<amr::LoadBalancerEstimatorMHD<PHARETypes>>(lbm_->getId());
-
-    auto loadBalancer_db = std::make_shared<SAMRAI::tbox::MemoryDatabase>("LoadBalancerDB");
-    loadBalancer_db->putDouble("flexible_load_tolerance", lb_info.tolerance);
-    auto loadBalancer = std::make_shared<SAMRAI::mesh::CascadePartitioner>(
-        SAMRAI::tbox::Dimension{dimension}, "LoadBalancer", loadBalancer_db);
-
-    if (dict["simulation"]["AMR"]["refinement"].contains("tagging"))
-    { // Load balancers break with refinement boxes - only tagging supported
-        /*
-          P=0000000:Program abort called in file ``/.../SAMRAI/xfer/RefineSchedule.cpp'' at line 369
-          P=0000000:ERROR MESSAGE:
-          P=0000000:RefineSchedule:RefineSchedule error: We are not currently
-          P=0000000:supporting RefineSchedules with the source level finer
-          P=0000000:than the destination level
-        */
-        lbm_->addLoadBalancerEstimator(0, maxMHDLevel_ - 1, std::move(lbe_));
-        lbm_->setLoadBalancer(loadBalancer);
-    }
-
-    auto lbm_id = lbm_->getId(); // moved on next line
-    multiphysInteg_->setLoadBalancerManager(std::move(lbm_));
-
-    startTime_ = restart_time(dict);
-
-    integrator_
-        = std::make_unique<Integrator>(dict, hierarchy_, multiphysInteg_, multiphysInteg_,
-                                       loadBalancer, startTime_, finalTime_, lb_info, lbm_id);
-
-    timeStamper = core::TimeStamperFactory::create(dict["simulation"]);
 
     if (dict["simulation"].contains("diagnostics"))
         diagnostics_init(dict["simulation"]["diagnostics"], *mhdModel_);
@@ -460,6 +433,8 @@ Simulator<opts>::Simulator(PHARE::initializer::PHAREDict const& dict,
 
     if (!hyb_resman_ptr and !mhd_resman_ptr)
         throw std::runtime_error("unsupported model");
+
+    finalize_init(dict);
 
     amr::ResourcesManagerGlobals::registerForRestarts();
 }

--- a/tests/functional/alfven_wave/alfven_wave1d.py
+++ b/tests/functional/alfven_wave/alfven_wave1d.py
@@ -96,7 +96,7 @@ def config():
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/conservation/conserv.py
+++ b/tests/functional/conservation/conserv.py
@@ -91,7 +91,7 @@ def uniform(vth, dl, cells, nbr_steps):
             population_name="protons",
         )
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/dispersion/dispersion.py
+++ b/tests/functional/dispersion/dispersion.py
@@ -87,7 +87,7 @@ def fromNoise():
     for quantity in ["E", "B"]:
         ph.ElectromagDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 
@@ -178,7 +178,7 @@ def prescribedModes():
             quantity=quantity, write_timestamps=timestamps, flush_every=0
         )
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/harris/harris_2d.py
+++ b/tests/functional/harris/harris_2d.py
@@ -148,7 +148,7 @@ def config():
 
     ph.InfoDiagnostics(quantity="particle_count")
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/harris/harris_3d.py
+++ b/tests/functional/harris/harris_3d.py
@@ -148,7 +148,7 @@ def config():
     )
 
     ph.ElectronModel(closure="isothermal", Te=0.0)
-    ph.LoadBalancer(active=True, mode="nppc", tol=0.05, every=1000)
+    ph.LoadBalancer(mode="nppc", tol=0.05, every=1000)
 
     pop = "protons"
     ph.FluidDiagnostics(quantity="bulkVelocity", write_timestamps=timestamps)

--- a/tests/functional/ionIonBeam/ion_ion_beam1d.py
+++ b/tests/functional/ionIonBeam/ion_ion_beam1d.py
@@ -101,7 +101,7 @@ def config():
             quantity="domain", population_name=pop_name, write_timestamps=timestamps
         )
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/shock/shock.py
+++ b/tests/functional/shock/shock.py
@@ -107,7 +107,7 @@ def config(interp_order):
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/td/td1d.py
+++ b/tests/functional/td/td1d.py
@@ -102,7 +102,7 @@ def config():
             write_timestamps=timestamps,
         )
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/tdtagged/td1dtagged.py
+++ b/tests/functional/tdtagged/td1dtagged.py
@@ -129,7 +129,7 @@ def config(**options):
                 population_name=pop,
             )
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/functional/translation/translat1d.py
+++ b/tests/functional/translation/translat1d.py
@@ -86,7 +86,7 @@ def config_uni(**kwargs):
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 
@@ -183,7 +183,7 @@ def config_td(**kwargs):
     for quantity in ["charge_density", "bulkVelocity"]:
         ph.FluidDiagnostics(quantity=quantity, write_timestamps=timestamps)
 
-    ph.LoadBalancer(active=True, auto=True, mode="nppc", tol=0.05)
+    ph.LoadBalancer(auto=True, mode="nppc", tol=0.05)
 
     return sim
 

--- a/tests/simulator/test_load_balancing.py
+++ b/tests/simulator/test_load_balancing.py
@@ -206,9 +206,7 @@ class LoadBalancingTest(SimulatorTest):
             return
 
         with self.assertRaises(RuntimeError):
-            self.run_sim(
-                dict(active=True, mode="nppc", tol=0.01, **lbkwargs),
-            )
+            self.run_sim(dict(mode="nppc", tol=0.01, **lbkwargs))
             # does not get here
 
     @unittest.skip("should change with moments")
@@ -224,9 +222,7 @@ class LoadBalancingTest(SimulatorTest):
         if cpp.mpi_size() == 1:  # doesn't make sense
             return
 
-        diag_dir = self.run_sim(
-            dict(active=True, mode="nppc", tol=0.01, **lbkwargs),
-        )
+        diag_dir = self.run_sim(dict(mode="nppc", tol=0.01, **lbkwargs))
 
         if cpp.mpi_rank() == 0:
             t0_sdev = np.std(list(time_info(diag_dir).values()))
@@ -257,9 +253,7 @@ class LoadBalancingTest(SimulatorTest):
             check_time,
         )
         is_hier = get_particles(
-            self.run_sim(
-                dict(active=True, auto=True, mode="nppc", tol=0.05),
-            ),
+            self.run_sim(dict(auto=True, mode="nppc", tol=0.05)),
             check_time,
         )
 


### PR DESCRIPTION
given to close #1286

drop load_balancer.active from python API, assume declaration is registration of active
do not register C++ load balancers if not active to prevent regridding side effects
clarify load balancer python class attributes

at most there could be two tolerances configurable by users, one for L0 and one for all other levels which are tagged/regrid