### PR TITLE
allow init dump for 0 total time

### DIFF
--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -75,9 +75,15 @@ def validate_timestamps(clazz, key, **kwargs):
         )
     if not np.all(np.diff(timestamps) >= 0):
         raise RuntimeError(f"Error: {clazz}.{key} not in ascending order)")
-    if not np.all(
-        np.abs(timestamps / sim.time_step - np.rint(timestamps / sim.time_step) < 1e-9)
-    ):
+    def is_inconsistent():
+        if sim.final_time - init_time > 0:
+            return not np.all(
+                np.abs(
+                    timestamps / sim.time_step - np.rint(timestamps / sim.time_step) < 1e-9
+                )
+            )
+
+    if is_inconsistent():
         raise RuntimeError(
             f"Error: {clazz}.{key} is inconsistent with simulation.time_step"
         )


### PR DESCRIPTION
Skip time_step alignment check when total_time is zero (avoids 0/0 division).

closes #1191
