### PR TITLE
mpi namespace leftovers from #1272

### DIFF
--- a/src/amr/level_initializer/hybrid_level_initializer.hpp
+++ b/src/amr/level_initializer/hybrid_level_initializer.hpp
@@ -93,7 +93,7 @@ namespace solver
             {
                 PHARE_LOG_ERROR(ex.what());
             }
-            if (core::mpi::any_errors())
+            if (mpi::any_errors())
                 throw core::DictionaryException{}("ID", "HybridLevelInitializer::initialize");
 
             // now all particles are here, we must compute moments.

--- a/src/amr/resources_manager/amr_utils.hpp
+++ b/src/amr/resources_manager/amr_utils.hpp
@@ -290,7 +290,7 @@ namespace amr
         auto const& mapping      = level.getProcessorMapping();
         auto const& global_boxes = level.getBoxes();
 
-        std::vector<std::vector<core::Box<int, dim>>> boxes_per_rank(core::mpi::size());
+        std::vector<std::vector<core::Box<int, dim>>> boxes_per_rank(mpi::size());
         assert(global_boxes.size() == level.getGlobalNumberOfPatches());
 
         auto gbox_iter = global_boxes.begin();

--- a/src/amr/samrai.cpp
+++ b/src/amr/samrai.cpp
@@ -24,7 +24,7 @@ SamraiLifeCycle::SamraiLifeCycle(int argc, char** argv)
     PHARE_WITH_PHLOP({
         if (auto e = core::get_env("PHARE_SCOPE_TIMING", "false"); e == "1" || e == "true")
             phlop::scope_timer()
-                .file_name(".phare/timings/rank." + std::to_string(core::mpi::rank()) + ".txt")
+                .file_name(".phare/timings/rank." + std::to_string(mpi::rank()) + ".txt")
                 .init();
     })
 }

--- a/src/amr/solvers/solver_mhd.hpp
+++ b/src/amr/solvers/solver_mhd.hpp
@@ -384,7 +384,7 @@ void SolverMHD<MHDModel, AMR_Types, TimeIntegratorStrategy, Messenger>::advanceL
         PHARE_LOG_ERROR(ex());
     }
 
-    if (core::mpi::any_errors())
+    if (mpi::any_errors())
         throw core::DictionaryException{}("ID", "SolverMHD::advanceLevel");
 }
 

--- a/src/amr/solvers/solver_ppc.hpp
+++ b/src/amr/solvers/solver_ppc.hpp
@@ -559,7 +559,7 @@ void SolverPPC<HybridModel, AMR_Types>::moveIons_(level_t& level, HybridModel& m
     {
         PHARE_LOG_ERROR(ex());
     }
-    if (core::mpi::any_errors())
+    if (mpi::any_errors())
         throw core::DictionaryException{}("ID", "Updater::updatePopulations");
 
     // this needs to be done before calling the messenger

--- a/src/amr/wrappers/hierarchy.hpp
+++ b/src/amr/wrappers/hierarchy.hpp
@@ -57,7 +57,7 @@ public:
                 pdrm->registerPatchDataForRestart(id);
 
             int timeStepIdx = 0; // forced to zero as we wrap in our own timestamp directories
-            restart_manager->openRestartFile(*_restartFilePath, timeStepIdx, core::mpi::size());
+            restart_manager->openRestartFile(*_restartFilePath, timeStepIdx, mpi::size());
         }
     }
 
@@ -79,16 +79,18 @@ public:
         // there's a PR for this next line, but until then the code below is the same
         // return SAMRAI::tbox::RestartManager::getManager()->getRestartFileFullPath(path, idx);
 
-        return path                                                                   //
-               + "/restore." + SAMRAI::tbox::Utilities::intToString(idx, 6)           //
-               + "/nodes." + SAMRAI::tbox::Utilities::nodeToString(core::mpi::size()) //
-               + "/proc." + SAMRAI::tbox::Utilities::processorToString(core::mpi::rank());
+        return path                                                             //
+               + "/restore." + SAMRAI::tbox::Utilities::intToString(idx, 6)     //
+               + "/nodes." + SAMRAI::tbox::Utilities::nodeToString(mpi::size()) //
+               + "/proc." + SAMRAI::tbox::Utilities::processorToString(mpi::rank());
     }
 
     void closeRestartFile() { SamraiLifeCycle::getRestartManager()->closeRestartFile(); }
 
     NO_DISCARD bool isFromRestart() const
-    { return SamraiLifeCycle::getRestartManager()->isFromRestart(); }
+    {
+        return SamraiLifeCycle::getRestartManager()->isFromRestart();
+    }
 
 private:
     std::optional<std::string> static restartFilePath(auto const& dict)

--- a/src/amr/wrappers/integrator.hpp
+++ b/src/amr/wrappers/integrator.hpp
@@ -107,7 +107,7 @@ private:
         {
             PHARE_LOG_SCOPE(1, "Integrator::_should_rebalance_now::automatic");
 
-            auto workLoads       = core::mpi::collect(computeNonUniformWorkLoadForLevel0());
+            auto workLoads       = mpi::collect(computeNonUniformWorkLoadForLevel0());
             auto const max_value = *std::max_element(workLoads.begin(), workLoads.end());
             for (auto& workload : workLoads)
                 workload /= max_value;

--- a/src/diagnostic/detail/h5typewriter.hpp
+++ b/src/diagnostic/detail/h5typewriter.hpp
@@ -32,20 +32,17 @@ public:
     virtual void createFiles(DiagnosticProperties& diagnostic) = 0;
 
     virtual void getDataSetInfo(DiagnosticProperties& diagnostic, std::size_t iLevel,
-                                std::string const& patchID, Attributes& patchAttributes)
-        = 0;
+                                std::string const& patchID, Attributes& patchAttributes) = 0;
 
     virtual void
     initDataSets(DiagnosticProperties& diagnostic,
                  std::unordered_map<std::size_t, std::vector<std::string>> const& patchIDs,
-                 Attributes& patchAttributes, std::size_t maxLevel)
-        = 0;
+                 Attributes& patchAttributes, std::size_t maxLevel) = 0;
 
     virtual void writeAttributes(
         DiagnosticProperties&, Attributes&,
         std::unordered_map<std::size_t, std::vector<std::pair<std::string, Attributes>>>&,
-        std::size_t maxLevel)
-        = 0;
+        std::size_t maxLevel) = 0;
     //------------------------------------------------------------------------
 
 
@@ -79,7 +76,7 @@ protected:
         {
             auto& lvlPatches       = patchIDs.at(lvl);
             std::size_t patchNbr   = lvlPatches.size();
-            std::size_t maxPatches = core::mpi::max(patchNbr);
+            std::size_t maxPatches = mpi::max(patchNbr);
             for (std::size_t i = 0; i < patchNbr; ++i)
                 initPatch(lvl, patchAttributes[std::to_string(lvl) + "_" + lvlPatches[i]],
                           lvlPatches[i]);
@@ -98,7 +95,7 @@ protected:
         {
             auto& lvlPatches       = patchAttributes.at(lvl);
             std::size_t patchNbr   = lvlPatches.size();
-            std::size_t maxPatches = core::mpi::max(patchNbr);
+            std::size_t maxPatches = mpi::max(patchNbr);
             for (auto const& [patch, attr] : lvlPatches)
                 h5Writer_.writeAttributeDict(file, attr,
                                              h5Writer_.getPatchPathAddTimestamp(lvl, patch));

--- a/src/diagnostic/detail/h5writer.hpp
+++ b/src/diagnostic/detail/h5writer.hpp
@@ -246,14 +246,14 @@ template<typename ModelView>
 void H5Writer<ModelView>::dump(std::vector<DiagnosticProperties*> const& diagnostics,
                                double timestamp)
 {
-    timestamp_                     = timestamp;
+    timestamp_                   = timestamp;
     fileAttributes_["dimension"] = dimension;
     if constexpr (solver::is_hybrid_model_v<Model_t>)
         fileAttributes_["interpOrder"] = GridLayout::options.interp_order;
-    fileAttributes_["layoutType"]  = modelView_.getLayoutTypeString();
-    fileAttributes_["domain_box"]  = modelView_.domainBox();
-    fileAttributes_["cell_width"]  = modelView_.cellWidth();
-    fileAttributes_["origin"]      = modelView_.origin();
+    fileAttributes_["layoutType"] = modelView_.getLayoutTypeString();
+    fileAttributes_["domain_box"] = modelView_.domainBox();
+    fileAttributes_["cell_width"] = modelView_.cellWidth();
+    fileAttributes_["origin"]     = modelView_.origin();
 
     fileAttributes_["boundary_conditions"] = modelView_.boundaryConditions();
 
@@ -318,7 +318,7 @@ void H5Writer<ModelView>::initializeDatasets_(std::vector<DiagnosticProperties*>
     modelView_.visitHierarchy(collectPatchAttributes, minLevel, maxLevel);
 
     // sets empty vectors in case current process lacks patch on a level
-    std::size_t maxMPILevel = core::mpi::max(maxLocalLevel);
+    std::size_t maxMPILevel = mpi::max(maxLocalLevel);
     for (std::size_t lvl = minLevel; lvl <= maxMPILevel; lvl++)
         if (!lvlPatchIDs.count(lvl))
             lvlPatchIDs.emplace(lvl, std::vector<std::string>());
@@ -352,7 +352,7 @@ void H5Writer<ModelView>::writeDatasets_(std::vector<DiagnosticProperties*> cons
 
     modelView_.visitHierarchy(writePatch, minLevel, maxLevel);
 
-    std::size_t maxMPILevel = core::mpi::max(maxLocalLevel);
+    std::size_t maxMPILevel = mpi::max(maxLocalLevel);
     // sets empty vectors in case current process lacks patch on a level
     for (std::size_t lvl = minLevel; lvl <= maxMPILevel; lvl++)
         if (!patchAttributes.count(lvl))

--- a/src/diagnostic/detail/vtkh5_type_writer.hpp
+++ b/src/diagnostic/detail/vtkh5_type_writer.hpp
@@ -66,11 +66,11 @@ struct HierarchyData
                 data.n_boxes_per_level[ilvl]    = 0;
                 data.level_boxes_per_rank[ilvl] = amr::boxesPerRankOn<dim>(level);
                 data.flattened_lcl_level_boxes[ilvl]
-                    = flatten_boxes(data.level_boxes_per_rank[ilvl][core::mpi::rank()]);
+                    = flatten_boxes(data.level_boxes_per_rank[ilvl][mpi::rank()]);
 
                 for (std::size_t i = 0; i < data.level_boxes_per_rank[ilvl].size(); ++i)
                 {
-                    data.level_rank_data_size[ilvl].resize(core::mpi::size());
+                    data.level_rank_data_size[ilvl].resize(mpi::size());
 
                     data.level_rank_data_size[ilvl][i] = 0;
                     for (auto box : data.level_boxes_per_rank[ilvl][i])
@@ -87,9 +87,9 @@ struct HierarchyData
                 data.level_data_size[ilvl]   = 0;
                 data.n_boxes_per_level[ilvl] = 0;
                 data.level_rank_data_size[ilvl].clear();
-                data.level_rank_data_size[ilvl].resize(core::mpi::size());
+                data.level_rank_data_size[ilvl].resize(mpi::size());
                 data.level_boxes_per_rank[ilvl].clear();
-                data.level_boxes_per_rank[ilvl].resize(core::mpi::size());
+                data.level_boxes_per_rank[ilvl].resize(mpi::size());
                 data.flattened_lcl_level_boxes[ilvl].clear();
             },
             h5Writer.minLevel, h5Writer.maxLevel);
@@ -291,7 +291,7 @@ public:
         //  next rank, or the next step, is indexed onto rows nobody wrote
         PHARE_DEBUG_DO(if (level > -1) {
             auto const& reserved = HierData::INSTANCE().level_rank_data_size[level];
-            assert(data_offset - start_offset == reserved[core::mpi::rank()]);
+            assert(data_offset - start_offset == reserved[mpi::rank()]);
         })
     }
 
@@ -475,7 +475,7 @@ void H5TypeWriter<Writer>::VTKFileInitializer::resize_data(int const ilvl)
     auto const new_size         = data_offset + level_data_size;
 
     point_data_ds.resize({new_size, N});
-    for (int i = 0; i < core::mpi::rank(); ++i)
+    for (int i = 0; i < mpi::rank(); ++i)
         data_offset += rank_data_sizes[i];
 }
 
@@ -505,12 +505,12 @@ void H5TypeWriter<Writer>::VTKFileInitializer::resize_boxes(int const ilvl)
 
     PHARE_LOG_SCOPE(3, "VTKFileInitializer::resize_boxes::2");
     amrbox_ds.resize({box_offset + total_boxes, boxValsIn3D});
-    for (int i = 0; i < core::mpi::rank(); ++i)
+    for (int i = 0; i < mpi::rank(); ++i)
         box_offset += rank_boxes[i].size();
 
 
     PHARE_LOG_SCOPE(3, "VTKFileInitializer::resize_boxes::3");
-    amrbox_ds.select({box_offset, 0}, {rank_boxes[core::mpi::rank()].size(), dimension * 2})
+    amrbox_ds.select({box_offset, 0}, {rank_boxes[mpi::rank()].size(), dimension * 2})
         .write(hier_data.flattened_lcl_level_boxes[ilvl]);
 }
 

--- a/src/diagnostic/detail/vtkh5_writer.hpp
+++ b/src/diagnostic/detail/vtkh5_writer.hpp
@@ -39,7 +39,7 @@ class H5Writer
         void setup(DiagnosticProperties& prop) {}
         void write(DiagnosticProperties& prop)
         {
-            if (core::mpi::rank() == 0)
+            if (mpi::rank() == 0)
             {
                 PHARE_LOG_LINE_SS( //
                     "No diagnostic writer found for " + prop.type + ":" + prop.quantity);
@@ -184,7 +184,7 @@ template<typename ModelView>
 void H5Writer<ModelView>::dump(std::vector<DiagnosticProperties*> const& diagnostics,
                                double timestamp)
 {
-    timestamp_                             = timestamp;
+    timestamp_                   = timestamp;
     fileAttributes_["dimension"] = dimension;
     if constexpr (solver::is_hybrid_model_v<Model_t>)
         fileAttributes_["interpOrder"] = GridLayout::options.interp_order;

--- a/src/diagnostic/diagnostic_manager.hpp
+++ b/src/diagnostic/diagnostic_manager.hpp
@@ -129,7 +129,7 @@ private:
 
     bool needsElapsedAction_(double const nextTime) const
     {
-        return core::mpi::unix_timestamp_now() > nextTime;
+        return mpi::unix_timestamp_now() > nextTime;
     }
 
 
@@ -171,7 +171,7 @@ private:
     std::map<std::string, std::size_t> nextWrite_;
     std::map<std::string, std::size_t> nextWriteElapsed_;
 
-    std::time_t const start_time_{core::mpi::unix_timestamp_now()};
+    std::time_t const start_time_{mpi::unix_timestamp_now()};
 };
 
 

--- a/src/diagnostic/diagnostic_model_view.hpp
+++ b/src/diagnostic/diagnostic_model_view.hpp
@@ -94,7 +94,7 @@ public:
         dict["nbrCells"] = core::Point<std::uint32_t, Model::dimension>{grid.nbrCells()}.toVector();
         dict["lower"]    = grid.AMRBox().lower.toVector();
         dict["upper"]    = grid.AMRBox().upper.toVector();
-        dict["mpi_rank"] = static_cast<std::size_t>(core::mpi::rank());
+        dict["mpi_rank"] = static_cast<std::size_t>(mpi::rank());
         return dict;
     }
 

--- a/src/hdf5/detail/h5/h5_file.hpp
+++ b/src/hdf5/detail/h5/h5_file.hpp
@@ -51,7 +51,7 @@ public:
             fapl.add(HighFive::MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
 #else
             std::cout << "WARNING: PARALLEL HDF5 not available" << std::endl;
-            if (core::mpi::size() > 1)
+            if (mpi::size() > 1)
             {
                 throw std::runtime_error("HDF5 NOT PARALLEL!");
             }
@@ -152,9 +152,9 @@ public:
     template<typename Type, typename Size>
     void create_data_set_per_mpi(std::string const& path, Size const& dataSetSize)
     {
-        auto const mpi_size = core::mpi::size();
-        auto const sizes    = core::mpi::collect(dataSetSize, mpi_size);
-        auto const paths    = core::mpi::collect(path, mpi_size);
+        auto const mpi_size = mpi::size();
+        auto const sizes    = mpi::collect(dataSetSize, mpi_size);
+        auto const paths    = mpi::collect(path, mpi_size);
         for (int i = 0; i < mpi_size; i++)
         { // in the case an mpi node lacks something to write
             if (is_zero(sizes[i]) || paths[i] == "")
@@ -174,7 +174,7 @@ public:
         // assumes all keyPaths and values are identical, and no null patches
         // clang-format off
         PHARE_DEBUG_DO(
-            auto const paths = core::mpi::collect(keyPath, core::mpi::size());
+            auto const paths = mpi::collect(keyPath, mpi::size());
             if (!core::all(paths, [&](auto const& path) { return path == paths[0]; }))
                 throw std::runtime_error("Function does not support different paths per mpi core");
         )
@@ -234,14 +234,14 @@ public:
                     .write(value);
         };
 
-        int const mpi_size = core::mpi::size();
+        int const mpi_size = mpi::size();
         auto const values  = [&]() {
             if constexpr (data_is_vector)
-                return core::mpi::collect_raw(data, mpi_size);
+                return mpi::collect_raw(data, mpi_size);
             else
-                return core::mpi::collect(data, mpi_size);
+                return mpi::collect(data, mpi_size);
         }();
-        auto const paths = core::mpi::collect(path, mpi_size);
+        auto const paths = mpi::collect(path, mpi_size);
 
         for (int i = 0; i < mpi_size; ++i)
         {

--- a/src/mpi/mpi_utils.cpp
+++ b/src/mpi/mpi_utils.cpp
@@ -10,7 +10,7 @@
 #define PHARE_ERRORS_USE_MPI_ABORT 1
 #endif
 
-namespace PHARE::core::mpi
+namespace PHARE::mpi
 {
 int size()
 {
@@ -87,4 +87,4 @@ std::int64_t unix_timestamp_now()
     return all_get_from_rank_0([]() { return static_cast<std::int64_t>(std::time(NULL)); });
 }
 
-} // namespace PHARE::core::mpi
+} // namespace PHARE::mpi

--- a/src/mpi/mpi_utils.hpp
+++ b/src/mpi/mpi_utils.hpp
@@ -14,10 +14,10 @@
 
 #if !defined(PHARE_LOG_ERROR)
 #define PHARE_LOG_ERROR(x)                                                                         \
-    PHARE::core::mpi::log_error(std::string{__FILE__} + ":" + std::to_string(__LINE__), x);
+    PHARE::mpi::log_error(std::string{__FILE__} + ":" + std::to_string(__LINE__), x);
 #endif
 
-namespace PHARE::core::mpi
+namespace PHARE::mpi
 {
 template<typename Data>
 NO_DISCARD std::vector<Data> collect(Data const& data, int mpi_size = 0);
@@ -177,12 +177,12 @@ NO_DISCARD std::vector<Vector> collectVector(Vector const& sendBuff, int mpi_siz
 }
 
 template<typename T, typename Vector>
-NO_DISCARD SpanSet<T, int> collectSpanSet(Vector const& sendBuff, int mpi_size = 0)
+NO_DISCARD core::SpanSet<T, int> collectSpanSet(Vector const& sendBuff, int mpi_size = 0)
 {
     if (mpi_size == 0)
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
-    SpanSet<T, int> rcvBuff{collect(static_cast<int>(sendBuff.size()), mpi_size)};
+    core::SpanSet<T, int> rcvBuff{collect(static_cast<int>(sendBuff.size()), mpi_size)};
     _collect_vector<T>(sendBuff, rcvBuff, rcvBuff.sizes, rcvBuff.displs, mpi_size);
 
     return rcvBuff;
@@ -212,7 +212,8 @@ NO_DISCARD auto collectArrays(std::array<T, size> const& arr, int mpi_size)
 
 
 template<typename Vector>
-NO_DISCARD SpanSet<typename Vector::value_type, int> collect_raw(Vector const& data, int mpi_size)
+NO_DISCARD core::SpanSet<typename Vector::value_type, int> collect_raw(Vector const& data,
+                                                                       int mpi_size)
 {
     if (mpi_size == 0)
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
@@ -238,7 +239,7 @@ NO_DISCARD std::vector<Data> collect(Data const& data, int mpi_size)
         return values;
     }
 }
-} // namespace PHARE::core::mpi
+} // namespace PHARE::mpi
 
 
 #endif /* PHARE_CORE_UTILITIES_MPI_H */

--- a/src/python3/cpp_etc.cpp
+++ b/src/python3/cpp_etc.cpp
@@ -80,10 +80,10 @@ PYBIND11_MODULE(cpp_etc, m)
     py::class_<PyArrayWrapper<double>, py::smart_holder, core::Span<double>>(m, "PyWrapper");
 
 
-    m.def("mpi_size", []() { return core::mpi::size(); });
-    m.def("mpi_rank", []() { return core::mpi::rank(); });
-    m.def("mpi_barrier", []() { core::mpi::barrier(); });
-    m.def("mpi_initialized", []() { return core::mpi::is_init(); });
+    m.def("mpi_size", []() { return mpi::size(); });
+    m.def("mpi_rank", []() { return mpi::rank(); });
+    m.def("mpi_barrier", []() { mpi::barrier(); });
+    m.def("mpi_initialized", []() { return mpi::is_init(); });
 
     py::class_<SamraiLifeCycle, std::shared_ptr<SamraiLifeCycle>>(m, "SamraiLifeCycle")
         .def(py::init<>())

--- a/src/python3/data_wrangler.hpp
+++ b/src/python3/data_wrangler.hpp
@@ -120,7 +120,7 @@ public:
 
     auto sync(std::vector<PatchData<std::vector<double>, dimension>> const& input)
     {
-        auto const mpi_size = core::mpi::size();
+        auto const mpi_size = mpi::size();
         std::vector<PatchData<std::vector<double>, dimension>> collected;
 
         auto const reinterpret_array = [&](auto& py_array) {
@@ -129,12 +129,12 @@ public:
         };
 
         auto const collect = [&](PatchData<std::vector<double>, dimension> const& patch_data) {
-            auto patchIDs = core::mpi::collect(patch_data.patchID, mpi_size);
-            auto origins  = core::mpi::collect(patch_data.origin, mpi_size);
-            auto lower    = core::mpi::collect_raw(makeSpan(patch_data.lower), mpi_size);
-            auto upper    = core::mpi::collect_raw(makeSpan(patch_data.upper), mpi_size);
-            auto ghosts   = core::mpi::collect(patch_data.nGhosts, mpi_size);
-            auto datas    = core::mpi::collect(patch_data.data, mpi_size);
+            auto patchIDs = mpi::collect(patch_data.patchID, mpi_size);
+            auto origins  = mpi::collect(patch_data.origin, mpi_size);
+            auto lower    = mpi::collect_raw(makeSpan(patch_data.lower), mpi_size);
+            auto upper    = mpi::collect_raw(makeSpan(patch_data.upper), mpi_size);
+            auto ghosts   = mpi::collect(patch_data.nGhosts, mpi_size);
+            auto datas    = mpi::collect(patch_data.data, mpi_size);
 
             for (int i = 0; i < mpi_size; i++)
             {
@@ -145,7 +145,7 @@ public:
             }
         };
 
-        auto const max = core::mpi::max(input.size());
+        auto const max = mpi::max(input.size());
 
         PatchData<std::vector<double>, dimension> empty;
 

--- a/src/restarts/detail/h5writer.hpp
+++ b/src/restarts/detail/h5writer.hpp
@@ -56,7 +56,7 @@ public:
             "/phare", "serialized_simulation",
             properties.fileAttributes["serialized_simulation"].template to<std::string>());
 
-        core::mpi::barrier();
+        mpi::barrier();
     }
 
 

--- a/src/restarts/restarts_manager.hpp
+++ b/src/restarts/restarts_manager.hpp
@@ -82,7 +82,7 @@ private:
 
     bool needsElapsedAction_(double const nextTime) const
     {
-        return core::mpi::unix_timestamp_now() > nextTime;
+        return mpi::unix_timestamp_now() > nextTime;
     }
 
 
@@ -109,7 +109,7 @@ private:
     std::size_t nextWriteSimUnit_ = 0;
     std::size_t nextWriteElapsed_ = 0;
 
-    std::time_t const start_time_{core::mpi::unix_timestamp_now()};
+    std::time_t const start_time_{mpi::unix_timestamp_now()};
 };
 
 

--- a/src/simulator/simulator.hpp
+++ b/src/simulator/simulator.hpp
@@ -146,15 +146,15 @@ private:
         if (auto log = core::get_env("PHARE_LOG"))
         {
             if (log == "RANK_FILES")
-                return std::make_unique<std::ofstream>(".log/" + std::to_string(core::mpi::rank())
+                return std::make_unique<std::ofstream>(".log/" + std::to_string(mpi::rank())
                                                        + ".out");
 
 
             if (log == "DATETIME_FILES")
             {
-                auto date_time = core::mpi::date_time();
-                auto rank      = std::to_string(core::mpi::rank());
-                auto size      = std::to_string(core::mpi::size());
+                auto date_time = mpi::date_time();
+                auto rank      = std::to_string(mpi::rank());
+                auto size      = std::to_string(mpi::size());
                 return std::make_unique<std::ofstream>(".log/" + date_time + "_" + rank + "_of_"
                                                        + size + ".out");
             }
@@ -517,7 +517,7 @@ void Simulator<opts>::initialize()
         PHARE_LOG_ERROR(*error);
     }
 
-    if (core::mpi::any_errors())
+    if (mpi::any_errors())
     {
         this->dMan.reset(); // closes/flushes hdf5 files
         if (error)
@@ -566,7 +566,7 @@ double Simulator<opts>::advance(double dt)
         PHARE_LOG_ERROR(*error);
     }
 
-    if (core::mpi::any_errors())
+    if (mpi::any_errors())
     {
         this->dMan.reset(); // closes/flushes hdf5 files
         if (error)

--- a/tests/diagnostic/test-diagnostics_1d.cpp
+++ b/tests/diagnostic/test-diagnostics_1d.cpp
@@ -31,6 +31,6 @@ int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     PHARE::SamraiLifeCycle samsam(argc, argv);
-    out_dir += std::to_string(core::mpi::size()) + "/"; // concurrent tests
+    out_dir += std::to_string(mpi::size()) + "/"; // concurrent tests
     return RUN_ALL_TESTS();
 }

--- a/tests/diagnostic/test-diagnostics_2d.cpp
+++ b/tests/diagnostic/test-diagnostics_2d.cpp
@@ -31,6 +31,6 @@ int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     PHARE::SamraiLifeCycle samsam(argc, argv);
-    out_dir += std::to_string(core::mpi::size()) + "/"; // concurrent tests
+    out_dir += std::to_string(mpi::size()) + "/"; // concurrent tests
     return RUN_ALL_TESTS();
 }

--- a/tests/diagnostic/test-diagnostics_3d.cpp
+++ b/tests/diagnostic/test-diagnostics_3d.cpp
@@ -31,6 +31,6 @@ int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     PHARE::SamraiLifeCycle samsam(argc, argv);
-    out_dir += std::to_string(core::mpi::size()) + "/"; // concurrent tests
+    out_dir += std::to_string(mpi::size()) + "/"; // concurrent tests
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
forgot to change the namespace from `PHARE::core::mpi` to `PHARE::mpi`