### PR TITLE
some clang-tidy cleanup

### DIFF
--- a/src/core/logger.hpp
+++ b/src/core/logger.hpp
@@ -20,7 +20,7 @@ constexpr static std::uint8_t LOG_LEVEL = PHARE_LOG_LEVEL;
 #include <sstream>  // IWYU pragma: keep
 #include <iostream> // IWYU pragma: keep
 #define PHARE_LOG_LINE_STR(str)                                                                    \
-    std::cout << __FILE__ << ":" << __LINE__ << " - " << str << std::endl
+    std::cout << __FILE__ << ":" << __LINE__ << " - " << (str) << std::endl
 #define PHARE_LOG_LINE_SS(s) PHARE_LOG_LINE_STR((std::stringstream{} << s).str())
 #else
 #define PHARE_LOG_LINE_STR(str)

--- a/src/core/utilities/types.hpp
+++ b/src/core/utilities/types.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cassert>
 #include <iomanip>
+#include <limits>
 #include <numeric>
 #include <sstream>
 #include <iostream>
@@ -149,6 +150,8 @@ namespace core
     template<typename Type, std::size_t size>
     NO_DISCARD constexpr std::array<Type, size> ConstArray(Type val = 0)
     {
+        static_assert(size <= std::numeric_limits<std::uint8_t>::max(),
+                      "ConstArray loop counter is std::uint8_t and would overflow for this size");
         std::array<Type, size> arr{};
         for (std::uint8_t i = 0; i < size; i++)
             arr[i] = val;

--- a/src/initializer/data_provider.hpp
+++ b/src/initializer/data_provider.hpp
@@ -62,7 +62,7 @@ namespace initializer
 
         void init() { phareDict = std::make_unique<PHAREDict>(); }
 
-        void stop() { phareDict.release(); }
+        void stop() { phareDict.reset(); }
 
         NO_DISCARD auto& dict()
         {

--- a/src/phare/phare.cpp
+++ b/src/phare/phare.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
     simulator->initialize();
 
     dictHandler.stop();
-    provider.release();
+    provider.reset();
 
     [[maybe_unused]] auto time = simulator->startTime();
 


### PR DESCRIPTION
biggest things from using clang-tidy

std::unique_ptr::release doesn't actually destruct.

```
src/initializer/data_provider.hpp:65:23: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors [bugprone-unused-return-value]
   65 |         void stop() { phareDict.release(); }
      |                       ^~~~~~~~~~~~~~~~~~~
```

```
src/core/utilities/types.hpp:153:34: warning: loop variable has narrower type 'std::uint8_t' than iteration's upper bound 'std::size_t' [bugprone-too-small-loop-variable]
  153 |         for (std::uint8_t i = 0; i < size; i++)
      |                                  ^

```

```
src/core/logger.hpp:23:58: warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
   23 |     std::cout << __FILE__ << ":" << __LINE__ << " - " << str << std::endl
      |
```
