### PR TITLE
Feature/mhd edge native dissipative flux (reduce ghost number constraint).

### DIFF
--- a/pyphare/pyphare/core/gridlayout.py
+++ b/pyphare/pyphare/core/gridlayout.py
@@ -252,8 +252,8 @@ def mhdGhostNbrFromReconstruction(reconstruction):
         "constant": 2,
         "linear": 4,
         "weno3": 4,
-        "wenoz": 6,
-        "mp5": 6,
+        "wenoz": 4,
+        "mp5": 4,
     }.get(reconstruction)
 
 

--- a/src/amr/solvers/solver_mhd_field_evolvers.hpp
+++ b/src/amr/solvers/solver_mhd_field_evolvers.hpp
@@ -91,8 +91,6 @@ ToPrimitiveTransformer(typename Model::amr_types::level_t&, Model&)
 
 
 
-
-
 template<typename Model, typename FVMethod>
 class FVMethodTransformer
 {
@@ -101,8 +99,8 @@ class FVMethodTransformer
     using core_type  = FVMethod;
 
 public:
-    using info_type    = core_type::Info_t;
-    using Equations_t  = core_type::Equations_t;
+    using info_type   = core_type::Info_t;
+    using Equations_t = core_type::Equations_t;
 
     template<typename T>
     using Rec = core_type::template Rec<T>;
@@ -119,16 +117,16 @@ public:
     }
 
 
-    void operator()(auto& fvm_state, auto& ct_state, auto& state, auto& fluxes, double const newTime)
+    void operator()(auto& ct_state, auto& state, auto& fluxes, double const newTime)
     {
         TimeSetter setTime{level, model, newTime};
 
         auto& rm = *model.resourcesManager;
-        for (auto& patch : rm.enumerate(level, fvm_state, ct_state, state, fluxes))
+        for (auto& patch : rm.enumerate(level, ct_state, state, fluxes))
         {
             auto const layout = amr::layoutFromPatch<GridLayout>(*patch);
             core_type finite_volume_method{info, layout};
-            finite_volume_method(fvm_state, ct_state, state, fluxes);
+            finite_volume_method(ct_state, state, fluxes);
         }
 
         setTime(state.rho, state.V, state.P, state.J);
@@ -215,10 +213,6 @@ public:
     Model& model;
     info_type const info;
 };
-
-
-
-
 
 
 

--- a/src/amr/solvers/time_integrator/compute_fluxes.hpp
+++ b/src/amr/solvers/time_integrator/compute_fluxes.hpp
@@ -60,7 +60,7 @@ public:
             TimeSetter{level, model, newTime}(state.B, state.J);
         }
 
-        FVMethod_t{level, model, fVMethodInfo_}(fvm_, ct_, state, fluxes, newTime);
+        FVMethod_t{level, model, fVMethodInfo_}(ct_, state, fluxes, newTime);
 
         // unecessary if we decide to store both primitive and conservative variables
         ToConservativeConverter_t{level, model}(state, to_conservative_gamma_, newTime);
@@ -68,15 +68,10 @@ public:
         ConstrainedTransport_t{level, model, constrainedTransportInfo_}(ct_, state);
     }
 
-    void registerResources(MHDModel& model)
-    {
-        model.resourcesManager->registerResources(fvm_);
-        model.resourcesManager->registerResources(ct_);
-    }
+    void registerResources(MHDModel& model) { model.resourcesManager->registerResources(ct_); }
 
     void allocate(MHDModel& model, auto& patch, double const allocateTime) const
     {
-        model.resourcesManager->allocate(fvm_, patch, allocateTime);
         model.resourcesManager->allocate(ct_, patch, allocateTime);
     }
 
@@ -84,9 +79,7 @@ private:
     FVMethodInfo_t fVMethodInfo_;
     ConstrainedTransportInfo_t constrainedTransportInfo_;
 
-    // Ampere_t ampere_;
-    core::GodunovState<VecField, Equations_t> fvm_{};
-    core::UpwindConstrainedTransportState<VecField, Hall, Resistivity> ct_{};
+    core::UpwindConstrainedTransportState<VecField, Hall, Resistivity, HyperResistivity> ct_{};
     // ToPrimitiveConverter_t to_primitive_;
     // ToConservativeConverter_t to_conservative_;
     double to_primitive_gamma_;

--- a/src/core/data/grid/impl/yee/gridlayout_mhd_yee.hpp
+++ b/src/core/data/grid/impl/yee/gridlayout_mhd_yee.hpp
@@ -36,8 +36,8 @@ public:
     struct GridData;
     static constexpr std::size_t dimension = dim;
     static constexpr std::string_view type = "yee";
-    // The MHD layout reserves ghosts based on the reconstruction stencil width,
-    // plus extra layers for J Laplacian and hyper-resistivity corrections.
+    // The MHD layout reserves ghosts based on the reconstruction stencil width, plus the one
+    // layer ampere loses by computing J on the shrinked ghost box.
     // static constexpr std::uint32_t reconstruction_nghosts = reconstruction_nghosts_;
     // Ghost width computed directly based on reconstruction stencil
     // static constexpr std::uint32_t ghost_width

--- a/src/core/data/grid/impl/yee/gridlayout_mhd_yee.hpp
+++ b/src/core/data/grid/impl/yee/gridlayout_mhd_yee.hpp
@@ -836,6 +836,77 @@ public:
         return directionalInterp<dirZ, InterpDir::PrimalToDual>();
     }
 
+    // Edge->face projections. Like the B*ToE* family above these are all single-axis moves (edge
+    // centerings differ from face centerings in exactly one axis, always primal->dual); used to
+    // move the non-ideal (resistive/hyper-resistive) flux contributions from J's native edge
+    // location to the face, and to project the transverse B onto the opposite edge so their
+    // product can be formed pointwise before projection.
+    NO_DISCARD auto static constexpr edgeYToFaceX()
+    {
+        // edge-Y is primal dual primal
+        // face-X is primal dual dual
+        // operation is thus pdP to pdD, shift only in Z
+
+        using PHARE::core::dirZ;
+
+        return directionalInterp<dirZ, InterpDir::PrimalToDual>();
+    }
+
+    NO_DISCARD auto static constexpr edgeZToFaceX()
+    {
+        // edge-Z is primal primal dual
+        // face-X is primal dual dual
+        // operation is thus pPd to pDd, shift only in Y
+
+        using PHARE::core::dirY;
+
+        return directionalInterp<dirY, InterpDir::PrimalToDual>();
+    }
+
+    NO_DISCARD auto static constexpr edgeXToFaceY()
+    {
+        // edge-X is dual primal primal
+        // face-Y is dual primal dual
+        // operation is thus dpP to dpD, shift only in Z
+
+        using PHARE::core::dirZ;
+
+        return directionalInterp<dirZ, InterpDir::PrimalToDual>();
+    }
+
+    NO_DISCARD auto static constexpr edgeZToFaceY()
+    {
+        // edge-Z is primal primal dual
+        // face-Y is dual primal dual
+        // operation is thus Ppd to Dpd, shift only in X
+
+        using PHARE::core::dirX;
+
+        return directionalInterp<dirX, InterpDir::PrimalToDual>();
+    }
+
+    NO_DISCARD auto static constexpr edgeXToFaceZ()
+    {
+        // edge-X is dual primal primal
+        // face-Z is dual dual primal
+        // operation is thus dPp to dDp, shift only in Y
+
+        using PHARE::core::dirY;
+
+        return directionalInterp<dirY, InterpDir::PrimalToDual>();
+    }
+
+    NO_DISCARD auto static constexpr edgeYToFaceZ()
+    {
+        // edge-Y is primal dual primal
+        // face-Z is dual dual primal
+        // operation is thus Pdp to Ddp, shift only in X
+
+        using PHARE::core::dirX;
+
+        return directionalInterp<dirX, InterpDir::PrimalToDual>();
+    }
+
     NO_DISCARD auto static constexpr edgeXToCellCenter()
     {
         // The X edge is dPP

--- a/src/core/numerics/MHD_equations/MHD_equations.hpp
+++ b/src/core/numerics/MHD_equations/MHD_equations.hpp
@@ -90,21 +90,6 @@ public:
         return f;
     }
 
-    // template<auto direction>
-    // auto compute(auto const& u, auto const& J, auto const& LaplJ) const
-    // {
-    //     PerIndex f = compute<direction>(u);
-    //
-    //     if constexpr (Hall)
-    //         hall_contribution_<direction>(u.rho, u.B, J, f.B, f.P);
-    //     if constexpr (Resistivity)
-    //         resistive_contributions_<direction>(eta_, u.B, J, f.B, f.P);
-    //
-    //     resistive_contributions_<direction>(nu_, u.B, -LaplJ, f.B, f.P);
-    //
-    //     return f;
-    // }
-
     template<auto direction>
     void resistive_contributions(auto const& coef, auto const& Bt, auto const& Jt, auto& F_B,
                                  auto& F_Etot) const
@@ -130,6 +115,37 @@ public:
             F_B.y += Jt.x * coef;
             F_Etot += (Jt.x * Bt.y - Jt.y * Bt.x) * coef;
         }
+    }
+
+    // Sibling of the above for the edge-native non-ideal (resistive + hyper-resistive) flux
+    // terms: projFirst/projSecond are the face-projected dissipative terms (eta*J - nu*lapl(J))
+    // formed on the two edges transverse to `direction` ("first"/"second", cyclic X->Y->Z->X);
+    // crossFirst/crossSecond are those same per-edge dissipative terms multiplied by the
+    // edge-projected transverse B *before* being projected to the face, since forming the
+    // E_diss x B product must happen at the edge (projection does not commute with
+    // multiplication). Takes pre-formed projected products rather than two separate factors
+    // (coef and whole Bt/Jt vectors) because that product can no longer be formed at the face.
+    template<auto direction>
+    void resistive_contributions(auto const& projFirst, auto const& projSecond,
+                                 auto const& crossFirst, auto const& crossSecond, auto& F_B,
+                                 auto& F_Etot) const
+    {
+        if constexpr (direction == Direction::X)
+        {
+            F_B.y += -projSecond;
+            F_B.z += projFirst;
+        }
+        if constexpr (direction == Direction::Y)
+        {
+            F_B.x += projFirst;
+            F_B.z += -projSecond;
+        }
+        if constexpr (direction == Direction::Z)
+        {
+            F_B.x += -projSecond;
+            F_B.y += projFirst;
+        }
+        F_Etot += crossFirst - crossSecond;
     }
 
 private:

--- a/src/core/numerics/constrained_transport/upwind_constrained_transport_utils.hpp
+++ b/src/core/numerics/constrained_transport/upwind_constrained_transport_utils.hpp
@@ -10,7 +10,7 @@
 namespace PHARE::core
 {
 
-template<typename VecField, bool Hall, bool Resistivity>
+template<typename VecField, bool Hall, bool Resistivity, bool HyperResistivity>
 class UpwindConstrainedTransportState
 {
     using Field                     = VecField::field_type;
@@ -23,14 +23,14 @@ public:
     {
         if constexpr (dimension == 1)
         {
-            if constexpr (Hall || Resistivity)
+            if constexpr (Hall || Resistivity || HyperResistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x);
             else
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x);
         }
         else if constexpr (dimension == 2)
         {
-            if constexpr (Hall || Resistivity)
+            if constexpr (Hall || Resistivity || HyperResistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
                                              aR_y, dL_y, dR_y, jt_y, rhot_y);
             else
@@ -39,7 +39,7 @@ public:
         }
         else if constexpr (dimension == 3)
         {
-            if constexpr (Hall || Resistivity)
+            if constexpr (Hall || Resistivity || HyperResistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
                                              aR_y, dL_y, dR_y, jt_y, rhot_y, vt_z, aL_z, aR_z, dL_z,
                                              dR_z, jt_z, rhot_z);
@@ -56,14 +56,14 @@ public:
     {
         if constexpr (dimension == 1)
         {
-            if constexpr (Hall || Resistivity)
+            if constexpr (Hall || Resistivity || HyperResistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x);
             else
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x);
         }
         else if constexpr (dimension == 2)
         {
-            if constexpr (Hall || Resistivity)
+            if constexpr (Hall || Resistivity || HyperResistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
                                              aR_y, dL_y, dR_y, jt_y, rhot_y);
             else
@@ -72,7 +72,7 @@ public:
         }
         else if constexpr (dimension == 3)
         {
-            if constexpr (Hall || Resistivity)
+            if constexpr (Hall || Resistivity || HyperResistivity)
                 return std::forward_as_tuple(vt_x, aL_x, aR_x, dL_x, dR_x, jt_x, rhot_x, vt_y, aL_y,
                                              aR_y, dL_y, dR_y, jt_y, rhot_y, vt_z, aL_z, aR_z, dL_z,
                                              dR_z, jt_z, rhot_z);

--- a/src/core/numerics/godunov_fluxes/godunov_fluxes.hpp
+++ b/src/core/numerics/godunov_fluxes/godunov_fluxes.hpp
@@ -47,12 +47,6 @@ auto getGrow(int const nghosts)
         if (i != dir)
             p[i] = nghosts;
 
-    // add one extra layer in the direction of the flux laplacian computation. Maybe some later
-    // optimisation would let us just compute for uct and have the extra layer only reconstructed
-    // for j
-    if constexpr (HyperResistivity)
-        p[dir] += 1;
-
     return p;
 }
 
@@ -96,8 +90,8 @@ public:
     {
     }
 
-    template<typename GState, typename State, typename Fluxes>
-    void operator()(GState& fvm_state, auto& ct_state, State& state, Fluxes& fluxes)
+    template<typename State, typename Fluxes>
+    void operator()(auto& ct_state, State& state, Fluxes& fluxes)
     {
         constexpr auto directions = getDirections<dimension>();
 
@@ -134,11 +128,6 @@ public:
 
                         ct_state.template save<direction>(riemann_.vt, riemann_.jt, riemann_.rhot,
                                                           riemann_.uct_coefs, {indices...});
-
-                        // for energy ExB term
-                        if constexpr (Resistivity || HyperResistivity)
-                            save_tranverse_magnetic_field_<direction>(fvm_state, uL, uR,
-                                                                      {indices...});
                     }
                     else // Ideal
                     {
@@ -156,163 +145,146 @@ public:
 
                         ct_state.template save<direction>(riemann_.vt, riemann_.uct_coefs,
                                                           {indices...});
-
-                        // for energy ExB term
-                        if constexpr (Resistivity)
-                            save_tranverse_magnetic_field_<direction>(fvm_state, uL, uR,
-                                                                      {indices...});
                     }
                 });
 
-            // adding resistive contributions to energy taking advantage of the already computed jt
-            // fluxes for the laplacian computation. This probably doesn't need the grow as the
-            // required quantities for ct are already saved.
+            // Non-ideal (resistive + hyper-resistive) flux contributions, taken from J at its
+            // native edge location: the E_diss x B product is formed on the edge and projected
+            // to the face. This keeps the Laplacian stencil confined to the edge-J reconstruction
+            // width, so it never needs J past the transverse-grow layer.
             if constexpr (Resistivity || HyperResistivity)
             {
                 layout_.evalOnBox(
                     fluxes.template expose_centering<direction>(), [&](auto&... indices) {
-                        auto& Jt     = ct_state.template getJt<direction>();
-                        auto& Bt     = getBt_<direction>(fvm_state);
+                        MeshIndex<dimension> idx{indices...};
                         auto F       = fluxes.template get_dir<direction>({indices...});
                         auto& F_B    = F.B;
                         auto& F_Etot = F.Etot();
 
-                        auto const& Btidx = toPerIndexVector(Bt, {indices...});
-
-                        if constexpr (Resistivity)
-                        {
-                            // transverse B field components (probably a riemann operation).
-                            auto const& Jtidx = toPerIndexVector(Jt, {indices...});
-                            equations_.template resistive_contributions<direction>(
-                                eta, Btidx, Jtidx, F_B, F_Etot);
-                        }
-                        if constexpr (HyperResistivity)
-                        {
-                            auto const vecLaplJ
-                                = transverse_laplacian_<direction>(Jt, {indices...});
-
-                            if (hyper_mode == HyperMode::constant)
-                                return constant_hyperresistive_<direction>(Btidx, vecLaplJ, F_B,
-                                                                           F_Etot);
-                            else if (hyper_mode == HyperMode::spatial)
-                            {
-                                auto const& Bn = toPerIndexVector(state.B, {indices...});
-                                auto const& rhot
-                                    = ct_state.template getRhot<direction>()(indices...);
-
-                                return spatial_hyperresistive_<direction>(Btidx, Bn, vecLaplJ, rhot,
-                                                                          F_B, F_Etot);
-                            }
-                            else
-                                throw std::runtime_error("Error - Ohm - unknown hyper_mode");
-                        }
+                        non_ideal_flux_contributions_<direction>(state, ct_state, idx, F_B, F_Etot);
                     });
             }
         });
     }
 
 private:
-    template<auto direction>
-    auto save_tranverse_magnetic_field_(auto& fvm_state, auto const& uL, auto const& uR,
-                                        MeshIndex<dimension> idx)
+    // Small local projector: sums a per-edge functor over the weight points of a compile-time
+    // edge<->face (or B->edge) stencil. Mirrors GridLayout::project, but takes a functor instead
+    // of a Field so it can project products (e.g. E_diss * B) formed at the edge before summing -
+    // GridLayout::project is intentionally not widened for this, per established convention.
+    template<auto Stencil>
+    auto proj_(MeshIndex<dimension> idx, auto&& at_edge) const
     {
-        auto Bidx = riemann_.vector_riemann_averaging(uL.B, uR.B);
-
-        auto& Bt = getBt_<direction>(fvm_state);
-
-        Bt(Component::X)(idx) = Bidx.x;
-        Bt(Component::Y)(idx) = Bidx.y;
-        Bt(Component::Z)(idx) = Bidx.z;
+        auto constexpr wps = Stencil();
+        double r           = 0.;
+        for (auto const& wp : wps)
+            r += wp.coef * at_edge(idx + wp.indexes);
+        return r;
     }
 
-    template<auto direction>
-    auto& getBt_(auto& fvm_state) const
+    auto minMeshSize_() const
     {
-        if constexpr (direction == Direction::X)
-            return fvm_state.bt_x;
-        else if constexpr (direction == Direction::Y)
-            return fvm_state.bt_y;
-        else if constexpr (direction == Direction::Z)
-            return fvm_state.bt_z;
+        auto const meshSize = layout_.meshSize();
+        if constexpr (dimension == 1)
+            return meshSize[0];
+        else if constexpr (dimension == 2)
+            return std::min({meshSize[0], meshSize[1]});
+        else
+            return std::min({meshSize[0], meshSize[1], meshSize[2]});
     }
 
-    template<auto direction>
-    void constant_hyperresistive_(auto const& Bt, auto const& vecLaplJ, auto& F_B,
-                                  auto& F_Etot) const
+    // direction's two transverse components ("first"/"second", in cyclic X->Y->Z->X order) each
+    // live on their own edge (edge-first, edge-second). EdgeFirstToFace/EdgeSecondToFace project
+    // those edges onto direction's face; BSecondToEFirst/BFirstToESecond project the *other*
+    // transverse B component onto the opposite edge, so the E_diss*B product can be formed
+    // pointwise on a single edge before being projected (projection does not commute with
+    // multiplication).
+    template<auto direction, auto EdgeFirstToFace, auto EdgeSecondToFace, auto BSecondToEFirst,
+             auto BFirstToESecond>
+    void non_ideal_face_contribution_(auto const& state, auto const& ct_state,
+                                      MeshIndex<dimension> idx, auto const& Jfirst,
+                                      auto const& Jsecond, auto const& Bfirst, auto const& Bsecond,
+                                      auto const& Bnormal, auto& F_B, auto& F_Etot) const
     {
-        equations_.template resistive_contributions<direction>(-nu, Bt, vecLaplJ, F_B, F_Etot);
-    }
-
-    template<auto direction>
-    void spatial_hyperresistive_(auto const& Bt, auto const& B, auto const& vecLaplJ,
-                                 auto const& rhot, auto& F_B, auto& F_Etot) const
-    {
-        auto minMeshSize = [&]() {
-            auto const meshSize = layout_.meshSize();
-            if constexpr (dimension == 1)
-                return meshSize[0];
-            else if constexpr (dimension == 2)
-                return std::min({meshSize[0], meshSize[1]});
-            else
-                return std::min({meshSize[0], meshSize[1], meshSize[2]});
-        }();
-
-
-        auto computeHR = [&](auto Bx, auto By, auto Bz) {
-            auto b          = std::sqrt(Bx * Bx + By * By + Bz * Bz);
-            auto const coef = -nu * minMeshSize * minMeshSize * (b / rhot + 1);
-            equations_.template resistive_contributions<direction>(coef, Bt, vecLaplJ, F_B, F_Etot);
+        auto Bfirst_e = [&](MeshIndex<dimension> e) {
+            return GridLayout::template project<BFirstToESecond>(Bfirst, e);
+        };
+        auto Bsecond_e = [&](MeshIndex<dimension> e) {
+            return GridLayout::template project<BSecondToEFirst>(Bsecond, e);
         };
 
-        if constexpr (direction == Direction::X)
+        double coef = 0.;
+        if constexpr (HyperResistivity)
         {
-            auto const Bx = B.x; // normal component
-            auto const By = Bt.y;
-            auto const Bz = Bt.z;
-
-            computeHR(Bx, By, Bz);
+            if (hyper_mode == HyperMode::constant)
+                coef = nu;
+            else if (hyper_mode == HyperMode::spatial)
+            {
+                auto const BnFace      = Bnormal(idx);
+                auto const BfirstFace  = proj_<EdgeSecondToFace>(idx, Bfirst_e);
+                auto const BsecondFace = proj_<EdgeFirstToFace>(idx, Bsecond_e);
+                auto const b           = std::sqrt(BnFace * BnFace + BfirstFace * BfirstFace
+                                                   + BsecondFace * BsecondFace);
+                auto const rhot        = ct_state.template getRhot<direction>()(idx);
+                auto const meshSize    = minMeshSize_();
+                coef                   = nu * meshSize * meshSize * (b / rhot + 1);
+            }
+            else
+                throw std::runtime_error("Error - Godunov - unknown hyper_mode");
         }
-        else if constexpr (direction == Direction::Y)
-        {
-            auto const Bx = Bt.x;
-            auto const By = B.y; // normal component
-            auto const Bz = Bt.z;
 
-            computeHR(Bx, By, Bz);
-        }
-        else if constexpr (direction == Direction::Z)
-        {
-            auto const Bx = Bt.x;
-            auto const By = Bt.y;
-            auto const Bz = B.z; // normal component
+        auto diss_first = [&](MeshIndex<dimension> e) {
+            double v = 0.;
+            if constexpr (Resistivity)
+                v += eta * Jfirst(e);
+            if constexpr (HyperResistivity)
+                v -= coef * layout_.laplacian(Jfirst, e);
+            return v;
+        };
+        auto diss_second = [&](MeshIndex<dimension> e) {
+            double v = 0.;
+            if constexpr (Resistivity)
+                v += eta * Jsecond(e);
+            if constexpr (HyperResistivity)
+                v -= coef * layout_.laplacian(Jsecond, e);
+            return v;
+        };
 
-            computeHR(Bx, By, Bz);
-        }
+        auto const projFirst  = proj_<EdgeFirstToFace>(idx, diss_first);
+        auto const projSecond = proj_<EdgeSecondToFace>(idx, diss_second);
+
+        auto const crossFirst = proj_<EdgeFirstToFace>(
+            idx, [&](MeshIndex<dimension> e) { return diss_first(e) * Bsecond_e(e); });
+        auto const crossSecond = proj_<EdgeSecondToFace>(
+            idx, [&](MeshIndex<dimension> e) { return diss_second(e) * Bfirst_e(e); });
+
+        equations_.template resistive_contributions<direction>(projFirst, projSecond, crossFirst,
+                                                               crossSecond, F_B, F_Etot);
     }
 
     template<auto direction>
-    auto transverse_laplacian_(auto const& Jt, MeshIndex<dimension> index) const
+    void non_ideal_flux_contributions_(auto const& state, auto const& ct_state,
+                                       MeshIndex<dimension> idx, auto& F_B, auto& F_Etot) const
     {
         if constexpr (direction == Direction::X)
-        {
-            auto const JyLapl = layout_.laplacian(Jt(Component::Y), index);
-            auto const JzLapl = layout_.laplacian(Jt(Component::Z), index);
-            return PerIndexVector<double>{std::nan(""), JyLapl, JzLapl};
-        }
+            non_ideal_face_contribution_<direction, GridLayout::implT::edgeYToFaceX,
+                                         GridLayout::implT::edgeZToFaceX, GridLayout::BzToEy,
+                                         GridLayout::ByToEz>(
+                state, ct_state, idx, state.J(Component::Y), state.J(Component::Z),
+                state.B(Component::Y), state.B(Component::Z), state.B(Component::X), F_B, F_Etot);
         else if constexpr (direction == Direction::Y)
-        {
-            auto const JxLapl = layout_.laplacian(Jt(Component::X), index);
-            auto const JzLapl = layout_.laplacian(Jt(Component::Z), index);
-            return PerIndexVector<double>{JxLapl, std::nan(""), JzLapl};
-        }
+            non_ideal_face_contribution_<direction, GridLayout::implT::edgeZToFaceY,
+                                         GridLayout::implT::edgeXToFaceY, GridLayout::BxToEz,
+                                         GridLayout::BzToEx>(
+                state, ct_state, idx, state.J(Component::Z), state.J(Component::X),
+                state.B(Component::Z), state.B(Component::X), state.B(Component::Y), F_B, F_Etot);
         else if constexpr (direction == Direction::Z)
-        {
-            auto const JxLapl = layout_.laplacian(Jt(Component::X), index);
-            auto const JyLapl = layout_.laplacian(Jt(Component::Y), index);
-            return PerIndexVector<double>{JxLapl, JyLapl, std::nan("")};
-        }
+            non_ideal_face_contribution_<direction, GridLayout::implT::edgeXToFaceZ,
+                                         GridLayout::implT::edgeYToFaceZ, GridLayout::ByToEx,
+                                         GridLayout::BxToEy>(
+                state, ct_state, idx, state.J(Component::X), state.J(Component::Y),
+                state.B(Component::X), state.B(Component::Y), state.B(Component::Z), F_B, F_Etot);
     }
-
 
     GridLayout layout_;
     Equations equations_;

--- a/src/core/numerics/godunov_fluxes/godunov_fluxes.hpp
+++ b/src/core/numerics/godunov_fluxes/godunov_fluxes.hpp
@@ -82,6 +82,12 @@ public:
     constexpr static auto Resistivity      = Equations::resistivity;
     constexpr static auto HyperResistivity = Equations::hyperResistivity;
 
+    // Zero margin by design: ampere computes J on the ghost box shrinked by one, so J is valid on
+    // ghost_width - 1 layers, and the reconstruction reads it out to nghosts on the transverse
+    // grow shell. Any consumer reaching further than that needs one more ghost layer.
+    static_assert(GridLayout::options.field_ghost_width >= Reconstruction_t::nghosts + 1,
+                  "MHD ghost width too small for the reconstruction stencil plus ampere's layer");
+
     explicit Godunov(GodunovInfo const& info, GridLayout const& layout)
         : Super{info}
         , layout_{layout}

--- a/src/core/numerics/godunov_fluxes/godunov_utils.hpp
+++ b/src/core/numerics/godunov_fluxes/godunov_utils.hpp
@@ -321,53 +321,6 @@ struct AllFluxesNames
 };
 
 
-template<typename VecField, typename Equations>
-class GodunovState
-{
-    using Field                            = VecField::field_type;
-    constexpr static auto dimension        = VecField::dimension;
-    constexpr static auto Resistivity      = Equations::resistivity;
-    constexpr static auto HyperResistivity = Equations::hyperResistivity;
-
-public:
-    GodunovState() = default;
-
-    NO_DISCARD auto getCompileTimeResourcesViewList()
-    {
-        if constexpr (Resistivity || HyperResistivity)
-        {
-            if constexpr (dimension == 1)
-                return std::forward_as_tuple(bt_x);
-            else if constexpr (dimension == 2)
-                return std::forward_as_tuple(bt_x, bt_y);
-            else if constexpr (dimension == 3)
-                return std::forward_as_tuple(bt_x, bt_y, bt_z);
-        }
-        else
-            return std::forward_as_tuple();
-    }
-
-    NO_DISCARD auto getCompileTimeResourcesViewList() const
-    {
-        if constexpr (Resistivity || HyperResistivity)
-        {
-            if constexpr (dimension == 1)
-                return std::forward_as_tuple(bt_x);
-            else if constexpr (dimension == 2)
-                return std::forward_as_tuple(bt_x, bt_y);
-            else if constexpr (dimension == 3)
-                return std::forward_as_tuple(bt_x, bt_y, bt_z);
-        }
-        else
-            return std::forward_as_tuple();
-    }
-
-    VecField bt_x{"b_t_x", MHDQuantity::Vector::VecFlux_x};
-    VecField bt_y{"b_t_y", MHDQuantity::Vector::VecFlux_y};
-    VecField bt_z{"b_t_z", MHDQuantity::Vector::VecFlux_z};
-};
-
-
 template<template<typename> typename Op, typename Field, typename VecField>
 void operate(AllFluxes<Field, VecField>& dst, AllFluxes<Field, VecField> const& src, auto&&... args)
 {

--- a/src/core/utilities/ghost_width_calculator.hpp
+++ b/src/core/utilities/ghost_width_calculator.hpp
@@ -47,14 +47,18 @@ constexpr std::uint32_t nbrGhostsFromInterpOrder()
  *
  * Ghost cells are needed for:
  * - Reconstruction stencil width
- * - One layer for J computation on the full ghost box
- * - One more layer for J Laplacian used by hyper-resistivity
+ * - One layer because ampere computes J on the ghost box shrinked by one, so J is only valid on
+ *   ghost_width - 1 layers while the reconstruction reads it out to the stencil width
  * - Rounded to even for Toth & Roe (2002) magnetic refinement formulas
+ *
+ * There is no hyper-resistivity layer: the non-ideal flux contributions take their Laplacian on
+ * J at its native edge location and project the result to the face, so they stay within the
+ * reconstruction reach. See Godunov::non_ideal_face_contribution_.
  */
 template<std::uint32_t reconstruction_nghosts>
 constexpr std::uint32_t nbrGhostsFromReconstruction()
 {
-    return roundUpToEven(reconstruction_nghosts + 2);
+    return roundUpToEven(reconstruction_nghosts + 1);
 }
 
 

--- a/tests/core/utilities/ghost_width_calculator/test_ghost_width_calculator.cpp
+++ b/tests/core/utilities/ghost_width_calculator/test_ghost_width_calculator.cpp
@@ -28,20 +28,20 @@ TEST(GhostWidthCalculator, HybridOrder3)
 
 TEST(GhostWidthCalculator, MHDConstantReconstruction)
 {
-    // stencil=1, (1+2)=3 -> rounded to 4
-    EXPECT_EQ(nbrGhostsFromReconstruction<1>(), 4);
+    // stencil=1, (1+1)=2 -> 2
+    EXPECT_EQ(nbrGhostsFromReconstruction<1>(), 2);
 }
 
 TEST(GhostWidthCalculator, MHDLinearReconstruction)
 {
-    // stencil=2, (2+2)=4 -> 4
+    // stencil=2, (2+1)=3 -> rounded to 4
     EXPECT_EQ(nbrGhostsFromReconstruction<2>(), 4);
 }
 
 TEST(GhostWidthCalculator, MHDWENOZReconstruction)
 {
-    // stencil=3, (3+2)=5 -> rounded to 6
-    EXPECT_EQ(nbrGhostsFromReconstruction<3>(), 6);
+    // stencil=3, (3+1)=4 -> 4
+    EXPECT_EQ(nbrGhostsFromReconstruction<3>(), 4);
 }
 
 TEST(GhostWidthCalculator, ParticleGhosts)

--- a/tests/core/utilities/ghost_width_calculator/test_gridlayout_integration.cpp
+++ b/tests/core/utilities/ghost_width_calculator/test_gridlayout_integration.cpp
@@ -51,8 +51,8 @@ TEST(GridLayoutIntegration, MHDConstantReconstruction)
     static constexpr auto opts = mhdOpts(MHDOpts::ReconstructionType::Constant);
     using Layout               = PHARE_Types<opts>::MHD::GridLayout_t;
 
-    // Constant: nghosts=1, field_ghost_width = roundUpToEven(1+2) = 4
-    EXPECT_EQ(Layout::options.field_ghost_width, 4u);
+    // Constant: nghosts=1, field_ghost_width = roundUpToEven(1+1) = 2
+    EXPECT_EQ(Layout::options.field_ghost_width, 2u);
 }
 
 TEST(GridLayoutIntegration, MHDLinearReconstruction)
@@ -60,7 +60,7 @@ TEST(GridLayoutIntegration, MHDLinearReconstruction)
     static constexpr auto opts = mhdOpts(MHDOpts::ReconstructionType::Linear);
     using Layout               = PHARE_Types<opts>::MHD::GridLayout_t;
 
-    // Linear: nghosts=2, field_ghost_width = roundUpToEven(2+2) = 4
+    // Linear: nghosts=2, field_ghost_width = roundUpToEven(2+1) = 4
     EXPECT_EQ(Layout::options.field_ghost_width, 4u);
 }
 
@@ -69,8 +69,8 @@ TEST(GridLayoutIntegration, MHDWENOZReconstruction)
     static constexpr auto opts = mhdOpts(MHDOpts::ReconstructionType::WENOZ);
     using Layout               = PHARE_Types<opts>::MHD::GridLayout_t;
 
-    // WENOZ: nghosts=3, field_ghost_width = roundUpToEven(3+2) = 6
-    EXPECT_EQ(Layout::options.field_ghost_width, 6u);
+    // WENOZ: nghosts=3, field_ghost_width = roundUpToEven(3+1) = 4
+    EXPECT_EQ(Layout::options.field_ghost_width, 4u);
 }
 
 TEST(GridLayoutIntegration, BackwardCompatibilityOrder1)


### PR DESCRIPTION
## Issue
#1283

## What this implements

`nbrGhostsFromReconstruction<R>()` was `roundUpToEven(R + 2)`, so WENOZ/MP5 MHD builds reserve **6** field ghost layers. The extra layer was bought by one thing: with hyper-resistivity on, laplJ was computed from reconstructed values, which required +1 cell in each directions.

The non-ideal (resistive **and** hyper-resistive) flux contributions now come from J at its native **edge** location, so the Laplacian never reaches past layer 2, the `+1` shell is gone, and the constant becomes `roundUpToEven(R + 1)`: WENOZ/MP5 **6 → 4**, Linear/WENO3/Constant unchanged (rounding absorbs it).

## Design

`E_diss = eta*J - coef*laplacian(J)` is formed on the edge, multiplied **there** by the edge-projected transverse B — projection does not commute with multiplication, so the product must be formed before projecting — and the product is projected to the face. The flux's non-ideal terms are then the face projection of the *same* edge quantities the CT already uses to advance B, where before the two used different discretisations of ∇²J times different B's.

## Tests

Harris bitwise identical in ideal. Differences in the order of O(1e-5) with spatial hyper resistivity on harris at 0.4 dx. Expected since different numerics, lowering at O(dx^2) (hyper constant) or O(dx^4) (hyper spatial). Expected as second order representation of the laplacian (multiplied by dx^2 in spatial case). 